### PR TITLE
Scopes Support

### DIFF
--- a/resources/schema.json
+++ b/resources/schema.json
@@ -10,51 +10,8 @@
     "appliesTo",
     "properties"
   ],
-  "properties": {
-    "name": {
-      "$id": "#/name",
-      "type": "string",
-      "title": "element template name",
-      "description": "The name of the element template"
-    },
-    "id": {
-      "$id": "#/id",
-      "type": "string",
-      "title": "element template id",
-      "description": "The identifier of the element template"
-    },
-    "description": {
-      "$id": "#/description",
-      "type": "string",
-      "title": "element template description",
-      "description": "The description of the element template"
-    },
-    "version": {
-      "$id": "#/version",
-      "type": "number",
-      "title": "element template version",
-      "description": "The version of the element template"
-    },
-    "isDefault": {
-      "$id": "#/isDefault",
-      "type": "boolean",
-      "title": "element template is default",
-      "description": "Indicates whether the element template is a default template"
-    },
-    "appliesTo": {
-      "$id": "#/appliesTo",
-      "type": "array",
-      "title": "element template applies to",
-      "description": "The definition for which element types the element template can be applied",
-      "default": [],
-      "items": {
-        "$id": "#/appliesTo/items",
-        "type": "string",
-        "pattern": "^(bpmn:)"
-      }
-    },
-    "properties": {
-      "$id": "#/properties",
+  "definitions": {
+    "properties":  {
       "type": "array",
       "title": "element template properties",
       "description": "The properties of the element template",
@@ -516,6 +473,54 @@
           }
         }
       }
+    }
+  },
+  "properties": {
+    "name": {
+      "$id": "#/name",
+      "type": "string",
+      "title": "element template name",
+      "description": "The name of the element template"
+    },
+    "id": {
+      "$id": "#/id",
+      "type": "string",
+      "title": "element template id",
+      "description": "The identifier of the element template"
+    },
+    "description": {
+      "$id": "#/description",
+      "type": "string",
+      "title": "element template description",
+      "description": "The description of the element template"
+    },
+    "version": {
+      "$id": "#/version",
+      "type": "number",
+      "title": "element template version",
+      "description": "The version of the element template"
+    },
+    "isDefault": {
+      "$id": "#/isDefault",
+      "type": "boolean",
+      "title": "element template is default",
+      "description": "Indicates whether the element template is a default template"
+    },
+    "appliesTo": {
+      "$id": "#/appliesTo",
+      "type": "array",
+      "title": "element template applies to",
+      "description": "The definition for which element types the element template can be applied",
+      "default": [],
+      "items": {
+        "$id": "#/appliesTo/items",
+        "type": "string",
+        "pattern": "^(bpmn:)"
+      }
+    },
+    "properties": {
+      "$ref": "#/definitions/properties",
+      "$id": "#/properties"
     },
     "metadata": {
       "$id": "#/metadata",

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -532,7 +532,23 @@
       "$id": "#/scopes",
       "type": "object",
       "title": "element template scope",
-      "description": "Special scoped bindings that allow you to configure nested elements"
+      "description": "Special scoped bindings that allow you to configure nested elements",
+      "additionalProperties": false,
+      "errorMessage": {
+        "additionalProperties": "scope must be defined as element type"
+      },
+      "patternProperties": {
+        "^(bpmn|camunda):": {
+          "type": "object",
+          "title": "element template scoped connector binding",
+          "description": "A scoped binding for a camunda connector inside the element",
+          "properties": {
+            "properties": {
+              "$ref": "#/definitions/properties"
+            }
+          }
+        }
+      }
     },
     "entriesVisible": {
       "$id": "#/entriesVisible",

--- a/test/fixtures/choices-missing-name.js
+++ b/test/fixtures/choices-missing-name.js
@@ -25,13 +25,13 @@ export const errors = [
   {
     'keyword': 'errorMessage',
     'dataPath': '/properties/0/choices/1',
-    'schemaPath': '#/properties/properties/items/properties/choices/items/errorMessage',
+    'schemaPath': '#/definitions/properties/items/properties/choices/items/errorMessage',
     'params': {
       'errors': [
         {
           'keyword': 'required',
           'dataPath': '/properties/0/choices/1',
-          'schemaPath': '#/properties/properties/items/properties/choices/items/required',
+          'schemaPath': '#/definitions/properties/items/properties/choices/items/required',
           'params': {
             'missingProperty': 'name'
           },

--- a/test/fixtures/choices-missing-value.js
+++ b/test/fixtures/choices-missing-value.js
@@ -25,13 +25,13 @@ export const errors = [
   {
     'keyword': 'errorMessage',
     'dataPath': '/properties/0/choices/1',
-    'schemaPath': '#/properties/properties/items/properties/choices/items/errorMessage',
+    'schemaPath': '#/definitions/properties/items/properties/choices/items/errorMessage',
     'params': {
       'errors': [
         {
           'keyword': 'required',
           'dataPath': '/properties/0/choices/1',
-          'schemaPath': '#/properties/properties/items/properties/choices/items/required',
+          'schemaPath': '#/definitions/properties/items/properties/choices/items/required',
           'params': {
             'missingProperty': 'value'
           },

--- a/test/fixtures/invalid-binding-type.js
+++ b/test/fixtures/invalid-binding-type.js
@@ -28,13 +28,13 @@ export const errors = [
   {
     'keyword': 'errorMessage',
     'dataPath': '/properties/1/binding/type',
-    'schemaPath': '#/properties/properties/items/properties/binding/properties/type/errorMessage',
+    'schemaPath': '#/definitions/properties/items/properties/binding/properties/type/errorMessage',
     'params': {
       'errors': [
         {
           'keyword': 'enum',
           'dataPath': '/properties/1/binding/type',
-          'schemaPath': '#/properties/properties/items/properties/binding/properties/type/enum',
+          'schemaPath': '#/definitions/properties/items/properties/binding/properties/type/enum',
           'params': {
             'allowedValues': [
               'property',

--- a/test/fixtures/invalid-camunda-in-business-key-type.js
+++ b/test/fixtures/invalid-camunda-in-business-key-type.js
@@ -19,13 +19,13 @@ export const errors = [
   {
     'keyword': 'errorMessage',
     'dataPath': '/properties/0/type',
-    'schemaPath': '#/properties/properties/items/allOf/3/then/properties/type/errorMessage',
+    'schemaPath': '#/definitions/properties/items/allOf/3/then/properties/type/errorMessage',
     'params': {
       'errors': [
         {
           'keyword': 'enum',
           'dataPath': '/properties/0/type',
-          'schemaPath': '#/properties/properties/items/allOf/3/then/properties/type/enum',
+          'schemaPath': '#/definitions/properties/items/allOf/3/then/properties/type/enum',
           'params': {
             'allowedValues': [
               'String',
@@ -42,7 +42,7 @@ export const errors = [
   {
     'keyword': 'if',
     'dataPath': '/properties/0',
-    'schemaPath': '#/properties/properties/items/allOf/3/if',
+    'schemaPath': '#/definitions/properties/items/allOf/3/if',
     'params': {
       'failingKeyword': 'then'
     },

--- a/test/fixtures/invalid-camunda-in-type.js
+++ b/test/fixtures/invalid-camunda-in-type.js
@@ -20,13 +20,13 @@ export const errors = [
   {
     'keyword': 'errorMessage',
     'dataPath': '/properties/0/type',
-    'schemaPath': '#/properties/properties/items/allOf/3/then/properties/type/errorMessage',
+    'schemaPath': '#/definitions/properties/items/allOf/3/then/properties/type/errorMessage',
     'params': {
       'errors': [
         {
           'keyword': 'enum',
           'dataPath': '/properties/0/type',
-          'schemaPath': '#/properties/properties/items/allOf/3/then/properties/type/enum',
+          'schemaPath': '#/definitions/properties/items/allOf/3/then/properties/type/enum',
           'params': {
             'allowedValues': [
               'String',
@@ -43,7 +43,7 @@ export const errors = [
   {
     'keyword': 'if',
     'dataPath': '/properties/0',
-    'schemaPath': '#/properties/properties/items/allOf/3/if',
+    'schemaPath': '#/definitions/properties/items/allOf/3/if',
     'params': {
       'failingKeyword': 'then'
     },

--- a/test/fixtures/invalid-camunda-out-type.js
+++ b/test/fixtures/invalid-camunda-out-type.js
@@ -20,13 +20,13 @@ export const errors = [
   {
     'keyword': 'errorMessage',
     'dataPath': '/properties/0/type',
-    'schemaPath': '#/properties/properties/items/allOf/3/then/properties/type/errorMessage',
+    'schemaPath': '#/definitions/properties/items/allOf/3/then/properties/type/errorMessage',
     'params': {
       'errors': [
         {
           'keyword': 'enum',
           'dataPath': '/properties/0/type',
-          'schemaPath': '#/properties/properties/items/allOf/3/then/properties/type/enum',
+          'schemaPath': '#/definitions/properties/items/allOf/3/then/properties/type/enum',
           'params': {
             'allowedValues': [
               'String',
@@ -43,7 +43,7 @@ export const errors = [
   {
     'keyword': 'if',
     'dataPath': '/properties/0',
-    'schemaPath': '#/properties/properties/items/allOf/3/if',
+    'schemaPath': '#/definitions/properties/items/allOf/3/if',
     'params': {
       'failingKeyword': 'then'
     },

--- a/test/fixtures/invalid-camunda-out.js
+++ b/test/fixtures/invalid-camunda-out.js
@@ -27,13 +27,13 @@ export const errors = [
   {
     'keyword': 'errorMessage',
     'dataPath': '/properties/1/binding',
-    'schemaPath': '#/properties/properties/items/properties/binding/allOf/3/then/errorMessage',
+    'schemaPath': '#/definitions/properties/items/properties/binding/allOf/3/then/errorMessage',
     'params': {
       'errors': [
         {
           'keyword': 'required',
           'dataPath': '/properties/1/binding',
-          'schemaPath': '#/properties/properties/items/properties/binding/allOf/3/then/oneOf/0/required',
+          'schemaPath': '#/definitions/properties/items/properties/binding/allOf/3/then/oneOf/0/required',
           'params': {
             'missingProperty': 'variables'
           },
@@ -42,7 +42,7 @@ export const errors = [
         {
           'keyword': 'required',
           'dataPath': '/properties/1/binding',
-          'schemaPath': '#/properties/properties/items/properties/binding/allOf/3/then/oneOf/1/required',
+          'schemaPath': '#/definitions/properties/items/properties/binding/allOf/3/then/oneOf/1/required',
           'params': {
             'missingProperty': 'source'
           },
@@ -51,7 +51,7 @@ export const errors = [
         {
           'keyword': 'required',
           'dataPath': '/properties/1/binding',
-          'schemaPath': '#/properties/properties/items/properties/binding/allOf/3/then/oneOf/2/required',
+          'schemaPath': '#/definitions/properties/items/properties/binding/allOf/3/then/oneOf/2/required',
           'params': {
             'missingProperty': 'sourceExpression'
           },
@@ -60,7 +60,7 @@ export const errors = [
         {
           'keyword': 'oneOf',
           'dataPath': '/properties/1/binding',
-          'schemaPath': '#/properties/properties/items/properties/binding/allOf/3/then/oneOf',
+          'schemaPath': '#/definitions/properties/items/properties/binding/allOf/3/then/oneOf',
           'params': {
             'passingSchemas': null
           },
@@ -73,7 +73,7 @@ export const errors = [
   {
     'keyword': 'if',
     'dataPath': '/properties/1/binding',
-    'schemaPath': '#/properties/properties/items/properties/binding/allOf/3/if',
+    'schemaPath': '#/definitions/properties/items/properties/binding/allOf/3/if',
     'params': {
       'failingKeyword': 'then'
     },

--- a/test/fixtures/invalid-camunda-property-type.js
+++ b/test/fixtures/invalid-camunda-property-type.js
@@ -28,13 +28,13 @@ export const errors = [
   {
     'keyword': 'errorMessage',
     'dataPath': '/properties/0/type',
-    'schemaPath': '#/properties/properties/items/allOf/3/then/properties/type/errorMessage',
+    'schemaPath': '#/definitions/properties/items/allOf/3/then/properties/type/errorMessage',
     'params': {
       'errors': [
         {
           'keyword': 'enum',
           'dataPath': '/properties/0/type',
-          'schemaPath': '#/properties/properties/items/allOf/3/then/properties/type/enum',
+          'schemaPath': '#/definitions/properties/items/allOf/3/then/properties/type/enum',
           'params': {
             'allowedValues': [
               'String',
@@ -51,7 +51,7 @@ export const errors = [
   {
     'keyword': 'if',
     'dataPath': '/properties/0',
-    'schemaPath': '#/properties/properties/items/allOf/3/if',
+    'schemaPath': '#/definitions/properties/items/allOf/3/if',
     'params': {
       'failingKeyword': 'then'
     },

--- a/test/fixtures/invalid-execution-listener-type.js
+++ b/test/fixtures/invalid-execution-listener-type.js
@@ -32,13 +32,13 @@ export const errors = [
   {
     'keyword': 'errorMessage',
     'dataPath': '/properties/2/type',
-    'schemaPath': '#/properties/properties/items/allOf/2/then/properties/type/errorMessage',
+    'schemaPath': '#/definitions/properties/items/allOf/2/then/properties/type/errorMessage',
     'params': {
       'errors': [
         {
           'keyword': 'enum',
           'dataPath': '/properties/2/type',
-          'schemaPath': '#/properties/properties/items/allOf/2/then/properties/type/enum',
+          'schemaPath': '#/definitions/properties/items/allOf/2/then/properties/type/enum',
           'params': {
             'allowedValues': [
               'Hidden'
@@ -53,7 +53,7 @@ export const errors = [
   {
     'keyword': 'if',
     'dataPath': '/properties/2',
-    'schemaPath': '#/properties/properties/items/allOf/2/if',
+    'schemaPath': '#/definitions/properties/items/allOf/2/if',
     'params': {
       'failingKeyword': 'then'
     },

--- a/test/fixtures/invalid-field-type.js
+++ b/test/fixtures/invalid-field-type.js
@@ -28,13 +28,13 @@ export const errors = [
   {
     'keyword': 'errorMessage',
     'dataPath': '/properties/1/type',
-    'schemaPath': '#/properties/properties/items/allOf/4/then/properties/type/errorMessage',
+    'schemaPath': '#/definitions/properties/items/allOf/4/then/properties/type/errorMessage',
     'params': {
       'errors': [
         {
           'keyword': 'enum',
           'dataPath': '/properties/1/type',
-          'schemaPath': '#/properties/properties/items/allOf/4/then/properties/type/enum',
+          'schemaPath': '#/definitions/properties/items/allOf/4/then/properties/type/enum',
           'params': {
             'allowedValues': [
               'String',
@@ -52,7 +52,7 @@ export const errors = [
   {
     'keyword': 'if',
     'dataPath': '/properties/1',
-    'schemaPath': '#/properties/properties/items/allOf/4/if',
+    'schemaPath': '#/definitions/properties/items/allOf/4/if',
     'params': {
       'failingKeyword': 'then'
     },

--- a/test/fixtures/invalid-input-parameter-type.js
+++ b/test/fixtures/invalid-input-parameter-type.js
@@ -20,13 +20,13 @@ export const errors = [
   {
     'keyword': 'errorMessage',
     'dataPath': '/properties/0/type',
-    'schemaPath': '#/properties/properties/items/allOf/4/then/properties/type/errorMessage',
+    'schemaPath': '#/definitions/properties/items/allOf/4/then/properties/type/errorMessage',
     'params': {
       'errors': [
         {
           'keyword': 'enum',
           'dataPath': '/properties/0/type',
-          'schemaPath': '#/properties/properties/items/allOf/4/then/properties/type/enum',
+          'schemaPath': '#/definitions/properties/items/allOf/4/then/properties/type/enum',
           'params': {
             'allowedValues': [
               'String',
@@ -44,7 +44,7 @@ export const errors = [
   {
     'keyword': 'if',
     'dataPath': '/properties/0',
-    'schemaPath': '#/properties/properties/items/allOf/4/if',
+    'schemaPath': '#/definitions/properties/items/allOf/4/if',
     'params': {
       'failingKeyword': 'then'
     },

--- a/test/fixtures/invalid-output-parameter-type.js
+++ b/test/fixtures/invalid-output-parameter-type.js
@@ -20,13 +20,13 @@ export const errors = [
   {
     'keyword': 'errorMessage',
     'dataPath': '/properties/0/type',
-    'schemaPath': '#/properties/properties/items/allOf/3/then/properties/type/errorMessage',
+    'schemaPath': '#/definitions/properties/items/allOf/3/then/properties/type/errorMessage',
     'params': {
       'errors': [
         {
           'keyword': 'enum',
           'dataPath': '/properties/0/type',
-          'schemaPath': '#/properties/properties/items/allOf/3/then/properties/type/enum',
+          'schemaPath': '#/definitions/properties/items/allOf/3/then/properties/type/enum',
           'params': {
             'allowedValues': [
               'String',
@@ -43,7 +43,7 @@ export const errors = [
   {
     'keyword': 'if',
     'dataPath': '/properties/0',
-    'schemaPath': '#/properties/properties/items/allOf/3/if',
+    'schemaPath': '#/definitions/properties/items/allOf/3/if',
     'params': {
       'failingKeyword': 'then'
     },

--- a/test/fixtures/invalid-property-type.js
+++ b/test/fixtures/invalid-property-type.js
@@ -28,13 +28,13 @@ export const errors = [
   {
     'keyword': 'errorMessage',
     'dataPath': '/properties/1/type',
-    'schemaPath': '#/properties/properties/items/allOf/1/then/properties/type/errorMessage',
+    'schemaPath': '#/definitions/properties/items/allOf/1/then/properties/type/errorMessage',
     'params': {
       'errors': [
         {
           'keyword': 'enum',
           'dataPath': '/properties/1/type',
-          'schemaPath': '#/properties/properties/items/allOf/1/then/properties/type/enum',
+          'schemaPath': '#/definitions/properties/items/allOf/1/then/properties/type/enum',
           'params': {
             'allowedValues': [
               'String',
@@ -53,7 +53,7 @@ export const errors = [
   {
     'keyword': 'if',
     'dataPath': '/properties/1',
-    'schemaPath': '#/properties/properties/items/allOf/1/if',
+    'schemaPath': '#/definitions/properties/items/allOf/1/if',
     'params': {
       'failingKeyword': 'then'
     },

--- a/test/fixtures/missing-binding-name.js
+++ b/test/fixtures/missing-binding-name.js
@@ -27,13 +27,13 @@ export const errors = [
   {
     'keyword': 'errorMessage',
     'dataPath': '/properties/1/binding',
-    'schemaPath': '#/properties/properties/items/properties/binding/allOf/0/then/errorMessage',
+    'schemaPath': '#/definitions/properties/items/properties/binding/allOf/0/then/errorMessage',
     'params': {
       'errors': [
         {
           'keyword': 'required',
           'dataPath': '/properties/1/binding',
-          'schemaPath': '#/properties/properties/items/properties/binding/allOf/0/then/required',
+          'schemaPath': '#/definitions/properties/items/properties/binding/allOf/0/then/required',
           'params': {
             'missingProperty': 'name'
           },
@@ -46,7 +46,7 @@ export const errors = [
   {
     'keyword': 'if',
     'dataPath': '/properties/1/binding',
-    'schemaPath': '#/properties/properties/items/properties/binding/allOf/0/if',
+    'schemaPath': '#/definitions/properties/items/properties/binding/allOf/0/if',
     'params': {
       'failingKeyword': 'then'
     },

--- a/test/fixtures/missing-binding-source.js
+++ b/test/fixtures/missing-binding-source.js
@@ -27,13 +27,13 @@ export const errors = [
   {
     'keyword': 'errorMessage',
     'dataPath': '/properties/1/binding',
-    'schemaPath': '#/properties/properties/items/properties/binding/allOf/1/then/errorMessage',
+    'schemaPath': '#/definitions/properties/items/properties/binding/allOf/1/then/errorMessage',
     'params': {
       'errors': [
         {
           'keyword': 'required',
           'dataPath': '/properties/1/binding',
-          'schemaPath': '#/properties/properties/items/properties/binding/allOf/1/then/required',
+          'schemaPath': '#/definitions/properties/items/properties/binding/allOf/1/then/required',
           'params': {
             'missingProperty': 'source'
           },
@@ -46,7 +46,7 @@ export const errors = [
   {
     'keyword': 'if',
     'dataPath': '/properties/1/binding',
-    'schemaPath': '#/properties/properties/items/properties/binding/allOf/1/if',
+    'schemaPath': '#/definitions/properties/items/properties/binding/allOf/1/if',
     'params': {
       'failingKeyword': 'then'
     },

--- a/test/fixtures/missing-binding-variables-target.js
+++ b/test/fixtures/missing-binding-variables-target.js
@@ -27,13 +27,13 @@ export const errors = [
   {
     'keyword': 'errorMessage',
     'dataPath': '/properties/1/binding',
-    'schemaPath': '#/properties/properties/items/properties/binding/allOf/2/then/errorMessage',
+    'schemaPath': '#/definitions/properties/items/properties/binding/allOf/2/then/errorMessage',
     'params': {
       'errors': [
         {
           'keyword': 'required',
           'dataPath': '/properties/1/binding',
-          'schemaPath': '#/properties/properties/items/properties/binding/allOf/2/then/oneOf/0/required',
+          'schemaPath': '#/definitions/properties/items/properties/binding/allOf/2/then/oneOf/0/required',
           'params': {
             'missingProperty': 'variables'
           },
@@ -42,7 +42,7 @@ export const errors = [
         {
           'keyword': 'required',
           'dataPath': '/properties/1/binding',
-          'schemaPath': '#/properties/properties/items/properties/binding/allOf/2/then/oneOf/1/required',
+          'schemaPath': '#/definitions/properties/items/properties/binding/allOf/2/then/oneOf/1/required',
           'params': {
             'missingProperty': 'target'
           },
@@ -51,7 +51,7 @@ export const errors = [
         {
           'keyword': 'oneOf',
           'dataPath': '/properties/1/binding',
-          'schemaPath': '#/properties/properties/items/properties/binding/allOf/2/then/oneOf',
+          'schemaPath': '#/definitions/properties/items/properties/binding/allOf/2/then/oneOf',
           'params': {
             'passingSchemas': null
           },
@@ -64,7 +64,7 @@ export const errors = [
   {
     'keyword': 'if',
     'dataPath': '/properties/1/binding',
-    'schemaPath': '#/properties/properties/items/properties/binding/allOf/2/if',
+    'schemaPath': '#/definitions/properties/items/properties/binding/allOf/2/if',
     'params': {
       'failingKeyword': 'then'
     },

--- a/test/fixtures/missing-binding.js
+++ b/test/fixtures/missing-binding.js
@@ -17,7 +17,7 @@ export const errors = [
   {
     keyword: 'required',
     dataPath: '/properties/0',
-    schemaPath: '#/properties/properties/items/required',
+    schemaPath: '#/definitions/properties/items/required',
     params: { missingProperty: 'binding' },
     message: "should have required property 'binding'"
   }

--- a/test/fixtures/missing-choices.js
+++ b/test/fixtures/missing-choices.js
@@ -21,13 +21,13 @@ export const errors = [
   {
     'keyword': 'errorMessage',
     'dataPath': '/properties/0',
-    'schemaPath': '#/properties/properties/items/allOf/0/then/errorMessage',
+    'schemaPath': '#/definitions/properties/items/allOf/0/then/errorMessage',
     'params': {
       'errors': [
         {
           'keyword': 'required',
           'dataPath': '/properties/0',
-          'schemaPath': '#/properties/properties/items/allOf/0/then/required',
+          'schemaPath': '#/definitions/properties/items/allOf/0/then/required',
           'params': {
             'missingProperty': 'choices'
           },
@@ -40,7 +40,7 @@ export const errors = [
   {
     'keyword': 'if',
     'dataPath': '/properties/0',
-    'schemaPath': '#/properties/properties/items/allOf/0/if',
+    'schemaPath': '#/definitions/properties/items/allOf/0/if',
     'params': {
       'failingKeyword': 'then'
     },

--- a/test/fixtures/multiple-errors.js
+++ b/test/fixtures/multiple-errors.js
@@ -45,13 +45,13 @@ export const errors = [
   {
     'keyword': 'errorMessage',
     'dataPath': '/properties/0/type',
-    'schemaPath': '#/properties/properties/items/allOf/1/then/properties/type/errorMessage',
+    'schemaPath': '#/definitions/properties/items/allOf/1/then/properties/type/errorMessage',
     'params': {
       'errors': [
         {
           'keyword': 'enum',
           'dataPath': '/properties/0/type',
-          'schemaPath': '#/properties/properties/items/allOf/1/then/properties/type/enum',
+          'schemaPath': '#/definitions/properties/items/allOf/1/then/properties/type/enum',
           'params': {
             'allowedValues': [
               'String',
@@ -74,18 +74,18 @@ export const errors = [
     'params': {
       'failingKeyword': 'then'
     },
-    'schemaPath': '#/properties/properties/items/allOf/1/if'
+    'schemaPath': '#/definitions/properties/items/allOf/1/if'
   },
   {
     'keyword': 'errorMessage',
     'dataPath': '/properties/1',
-    'schemaPath': '#/properties/properties/items/allOf/0/then/errorMessage',
+    'schemaPath': '#/definitions/properties/items/allOf/0/then/errorMessage',
     'params': {
       'errors': [
         {
           'keyword': 'required',
           'dataPath': '/properties/1',
-          'schemaPath': '#/properties/properties/items/allOf/0/then/required',
+          'schemaPath': '#/definitions/properties/items/allOf/0/then/required',
           'params': {
             'missingProperty': 'choices'
           },
@@ -98,7 +98,7 @@ export const errors = [
   {
     'keyword': 'if',
     'dataPath': '/properties/1',
-    'schemaPath': '#/properties/properties/items/allOf/0/if',
+    'schemaPath': '#/definitions/properties/items/allOf/0/if',
     'params': {
       'failingKeyword': 'then'
     },
@@ -107,13 +107,13 @@ export const errors = [
   {
     'keyword': 'errorMessage',
     'dataPath': '/properties/2/binding',
-    'schemaPath': '#/properties/properties/items/properties/binding/allOf/1/then/errorMessage',
+    'schemaPath': '#/definitions/properties/items/properties/binding/allOf/1/then/errorMessage',
     'params': {
       'errors': [
         {
           'keyword': 'required',
           'dataPath': '/properties/2/binding',
-          'schemaPath': '#/properties/properties/items/properties/binding/allOf/1/then/required',
+          'schemaPath': '#/definitions/properties/items/properties/binding/allOf/1/then/required',
           'params': {
             'missingProperty': 'source'
           },
@@ -126,7 +126,7 @@ export const errors = [
   {
     'keyword': 'if',
     'dataPath': '/properties/2/binding',
-    'schemaPath': '#/properties/properties/items/properties/binding/allOf/1/if',
+    'schemaPath': '#/definitions/properties/items/properties/binding/allOf/1/if',
     'params': {
       'failingKeyword': 'then'
     },
@@ -135,13 +135,13 @@ export const errors = [
   {
     'keyword': 'errorMessage',
     'dataPath': '/properties/3/binding',
-    'schemaPath': '#/properties/properties/items/properties/binding/allOf/0/then/errorMessage',
+    'schemaPath': '#/definitions/properties/items/properties/binding/allOf/0/then/errorMessage',
     'params': {
       'errors': [
         {
           'keyword': 'required',
           'dataPath': '/properties/3/binding',
-          'schemaPath': '#/properties/properties/items/properties/binding/allOf/0/then/required',
+          'schemaPath': '#/definitions/properties/items/properties/binding/allOf/0/then/required',
           'params': {
             'missingProperty': 'name'
           },
@@ -154,7 +154,7 @@ export const errors = [
   {
     'keyword': 'if',
     'dataPath': '/properties/3/binding',
-    'schemaPath': '#/properties/properties/items/properties/binding/allOf/0/if',
+    'schemaPath': '#/definitions/properties/items/properties/binding/allOf/0/if',
     'params': {
       'failingKeyword': 'then'
     },

--- a/test/fixtures/number-value.js
+++ b/test/fixtures/number-value.js
@@ -21,7 +21,7 @@ export const errors = [
   {
     'keyword': 'type',
     'dataPath': '/properties/0/value',
-    'schemaPath': '#/properties/properties/items/properties/value/type',
+    'schemaPath': '#/definitions/properties/items/properties/value/type',
     'params': {
       'type': 'string,boolean'
     },

--- a/test/fixtures/scope-connector-missing-binding.js
+++ b/test/fixtures/scope-connector-missing-binding.js
@@ -1,0 +1,29 @@
+export const template = {
+  'name': 'ConnectorGetTask',
+  'id': 'my.connector.http.get.Task',
+  'appliesTo': [
+    'bpmn:Task'
+  ],
+  'properties': [],
+  'scopes': {
+    'camunda:Connector': {
+      'properties': [
+        {
+          'label': 'ConnectorId',
+          'type': 'String',
+          'value': 'My Connector HTTP - GET'
+        }
+      ]
+    }
+  }
+};
+
+export const errors = [
+  {
+    keyword: 'required',
+    dataPath: '/scopes/camunda:Connector/properties/0',
+    schemaPath: '#/definitions/properties/items/required',
+    params: { missingProperty: 'binding' },
+    message: "should have required property 'binding'"
+  }
+];

--- a/test/fixtures/scope-connector.js
+++ b/test/fixtures/scope-connector.js
@@ -1,0 +1,25 @@
+export const template = {
+  'name': 'ConnectorGetTask',
+  'id': 'my.connector.http.get.Task',
+  'appliesTo': [
+    'bpmn:Task'
+  ],
+  'properties': [],
+  'scopes': {
+    'camunda:Connector': {
+      'properties': [
+        {
+          'label': 'ConnectorId',
+          'type': 'String',
+          'value': 'My Connector HTTP - GET',
+          'binding': {
+            'type': 'property',
+            'name': 'connectorId'
+          }
+        }
+      ]
+    }
+  }
+};
+
+export const errors = null;

--- a/test/fixtures/scope-invalid.js
+++ b/test/fixtures/scope-invalid.js
@@ -1,0 +1,35 @@
+export const template = {
+  'name': 'ConnectorGetTask',
+  'id': 'my.connector.http.get.Task',
+  'appliesTo': [
+    'bpmn:Task'
+  ],
+  'properties': [],
+  'scopes': {
+    'foo': {
+      'properties': []
+    }
+  }
+};
+
+export const errors = [
+  {
+    'keyword': 'errorMessage',
+    'dataPath': '/scopes',
+    'schemaPath': '#/properties/scopes/errorMessage',
+    'params': {
+      'errors': [
+        {
+          'keyword': 'additionalProperties',
+          'dataPath': '/scopes',
+          'schemaPath': '#/properties/scopes/additionalProperties',
+          'params': {
+            'additionalProperty': 'foo'
+          },
+          'message': 'should NOT have additional properties'
+        }
+      ]
+    },
+    'message': 'scope must be defined as element type'
+  }
+];

--- a/test/spec/validationSpec.js
+++ b/test/spec/validationSpec.js
@@ -145,4 +145,17 @@ describe('validation', function() {
 
   });
 
+
+  describe('scoped binding', function() {
+
+    testTemplate('scope-connector', '../fixtures/scope-connector.js');
+
+
+    testTemplate('scope-connector-missing-binding', '../fixtures/scope-connector-missing-binding.js');
+
+
+    testTemplate('scope-invalid', '../fixtures/scope-invalid.js');
+
+  });
+
 });


### PR DESCRIPTION
* Moves `properties` schema to own definition, to make it reusable for scopes
* Add schema for `scopes`

valid

```js
'scopes': {
  'camunda:Connector': {
    'properties': [
      {
        'label': 'ConnectorId',
        'type': 'String',
        'value': 'My Connector HTTP - GET'      
      }
    ]
  }
}
```

invalid

```js
'scopes': {
  'foo': {
    'properties': []
  }
}
```

Closes #14 