### PR TITLE
Array Scopes, Error Event Definitions & Scoped Error Bindings

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "lint": "eslint .",
     "test": "mocha -r esm --reporter=spec --recursive test/spec",
+    "dev": "npm run test -- --watch",
     "all": "run-s lint test"
   },
   "repository": {

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -343,6 +343,28 @@
                   ],
                   "errorMessage": "property.binding ${0/type} requires variables, sourceExpression or source"
                 }
+              },
+              {
+                "if": {
+                  "properties": {
+                    "type": {
+                      "const": "camunda:errorEventDefinition"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ]
+                },
+                "then": {
+                  "oneOf": [
+                    {
+                      "required": [
+                        "errorRef"
+                      ]
+                    }
+                  ],
+                  "errorMessage": "property.binding ${0/type} requires errorRef"
+                }
               }
             ],
             "properties": {
@@ -359,7 +381,8 @@
                   "camunda:out",
                   "camunda:in:businessKey",
                   "camunda:executionListener",
-                  "camunda:field"
+                  "camunda:field",
+                  "camunda:errorEventDefinition"
                 ],
                 "errorMessage": "invalid property.binding type ${0}; must be any of { property, camunda:property, camunda:inputParameter, camunda:outputParameter, camunda:in, camunda:out, camunda:in:businessKey, camunda:executionListener, camunda:field }",
                 "description": "The type of the property binding"

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -110,7 +110,8 @@
                         "camunda:outputParameter",
                         "camunda:in",
                         "camunda:in:businessKey",
-                        "camunda:out"
+                        "camunda:out",
+                        "camunda:errorEventDefinition"
                       ]
                     }
                   },

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -467,6 +467,52 @@
         }
       }
     },
+    "scopes_old":  {
+      "$id": "#/definitions/scopes_old",
+      "type": "object",
+      "title": "element template scope",
+      "deprecated": true,
+      "description": "@Deprecated - Special scoped bindings that allow you to configure nested elements",
+      "additionalProperties": false,
+      "errorMessage": {
+        "additionalProperties": "invalid scope, object descriptor is only supported for camunda:Connector"
+      },
+      "properties": {
+        "camunda:Connector": {
+          "type": "object",
+          "title": "element template scoped connector binding",
+          "description": "A scoped binding for a camunda connector inside the element",
+          "properties": {
+            "properties": {
+              "$ref": "#/definitions/properties"
+            }
+          }
+        }
+      }
+    },
+    "scopes": {
+      "$id": "#/definitions/scopes",
+      "type": "array",
+      "description": "Special scoped bindings that allow you to configure nested elements",
+      "items": {
+        "$id": "#/scopes/item",
+        "type": "object",
+        "properties": {
+          "type": {
+            "$id": "#scopes/item/type",
+            "type": "string",
+            "pattern": "^(camunda|bpmn):"
+          },
+          "properties": {
+            "$ref": "#/definitions/properties"
+          }
+        },
+        "required": [
+          "type",
+          "properties"
+        ]
+      }
+    },
     "template": {
       "type": "object",
       "required": [
@@ -529,26 +575,14 @@
           "description": "Some metadata for further configuration"
         },
         "scopes": {
-          "$id": "#/scopes",
-          "type": "object",
-          "title": "element template scope",
-          "description": "Special scoped bindings that allow you to configure nested elements",
-          "additionalProperties": false,
-          "errorMessage": {
-            "additionalProperties": "scope must be defined as element type"
-          },
-          "patternProperties": {
-            "^(bpmn|camunda):": {
-              "type": "object",
-              "title": "element template scoped connector binding",
-              "description": "A scoped binding for a camunda connector inside the element",
-              "properties": {
-                "properties": {
-                  "$ref": "#/definitions/properties"
-                }
-              }
+          "oneOf": [
+            {
+              "$ref": "#/definitions/scopes_old"
+            },
+            {
+              "$ref": "#/definitions/scopes"
             }
-          }
+          ]
         },
         "entriesVisible": {
           "$id": "#/entriesVisible",

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -517,15 +517,22 @@
     "scopes": {
       "$id": "#/definitions/scopes",
       "type": "array",
+      "title": "element template scope",
       "description": "Special scoped bindings that allow you to configure nested elements",
       "items": {
         "$id": "#/scopes/item",
         "type": "object",
+        "title": "element template scope item",
+        "description": "Scoped binding to configure nested elements",
         "properties": {
           "type": {
             "$id": "#scopes/item/type",
             "type": "string",
-            "pattern": "^(camunda|bpmn):"
+            "enum": [
+              "camunda:Connector",
+              "bpmn:Error"
+            ],
+            "errorMessage": "invalid scope type ${0}; must be any of { camunda:Connector, bpmn:Error }"
           },
           "properties": {
             "$ref": "#/definitions/properties"

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -533,6 +533,28 @@
         "required": [
           "type",
           "properties"
+        ],
+        "allOf": [
+          {
+            "if": {
+              "properties": {
+                "type": {
+                  "enum": [
+                    "bpmn:Error"
+                  ]
+                }
+              },
+              "required": [
+                "type"
+              ]
+            },
+            "then": {
+              "required": [
+                "id"
+              ],
+              "errorMessage": "scoped binding of type ${0/type} requires id"
+            }
+          }
         ]
       }
     },

--- a/test/fixtures/error-task-multiple.js
+++ b/test/fixtures/error-task-multiple.js
@@ -1,0 +1,95 @@
+export const template = {
+  name: 'eventDefinitionDraft',
+  id: 'max.eventDefinitionDraft',
+  appliesTo: [
+    'bpmn:ServiceTask'
+  ],
+  properties: [
+    {
+      label: 'errorNameA',
+      value: '${ true }',
+      binding: {
+        type: 'camunda:errorEventDefinition',
+        errorRef: 'error1'
+      }
+    },
+    {
+      label: 'errorNameB',
+      value: '${ someVar == 123 }',
+      binding: {
+        type: 'camunda:errorEventDefinition',
+        errorRef: 'error2'
+      }
+    }
+  ],
+  scopes: [
+    {
+      type: 'bpmn:Error',
+      id: 'error1',
+      properties: [
+        {
+          label: 'Error Code',
+          type: 'Hidden',
+          value: 'my Error code',
+          binding: {
+            type: 'property',
+            name: 'errorCode'
+          }
+        },
+        {
+          label: 'Error Message',
+          type: 'Hidden',
+          value: 'my Error message',
+          binding: {
+            type: 'property',
+            name: 'camunda:errorMessage'
+          }
+        },
+        {
+          label: 'Error Name',
+          type: 'Hidden',
+          value: 'my Error Name',
+          binding: {
+            type: 'property',
+            name: 'name'
+          }
+        }
+      ]
+    },
+    {
+      type: 'bpmn:Error',
+      id: 'error2',
+      properties: [
+        {
+          label: 'Error Code',
+          type: 'Hidden',
+          value: '405',
+          binding: {
+            type: 'property',
+            name: 'errorCode'
+          }
+        },
+        {
+          label: 'Error Message',
+          type: 'Hidden',
+          value: '',
+          binding: {
+            type: 'property',
+            name: 'camunda:errorMessage'
+          }
+        },
+        {
+          label: 'Error Name',
+          type: 'Hidden',
+          value: 'errorNameB',
+          binding: {
+            type: 'property',
+            name: 'name'
+          }
+        }
+      ]
+    }
+  ]
+};
+
+export const errors = null;

--- a/test/fixtures/error-task.js
+++ b/test/fixtures/error-task.js
@@ -1,0 +1,47 @@
+export const template = {
+  name: 'Error template',
+  id: 'error-template',
+  appliesTo: [
+    'bpmn:ServiceTask'
+  ],
+  properties: [
+    {
+      value: 'expression-value',
+      binding: {
+        type: 'camunda:errorEventDefinition',
+        errorRef: 'Error_1'
+      }
+    }
+  ],
+  scopes: [
+    {
+      type: 'bpmn:Error',
+      id: 'Error_1',
+      properties: [
+        {
+          value: 'error-code',
+          binding: {
+            type: 'property',
+            name: 'errorCode'
+          }
+        },
+        {
+          value: 'error-message',
+          binding: {
+            type: 'property',
+            name: 'camunda:errorMessage'
+          }
+        },
+        {
+          value: 'error-name',
+          binding: {
+            type: 'property',
+            name: 'name'
+          }
+        }
+      ]
+    }
+  ]
+};
+
+export const errors = null;

--- a/test/fixtures/invalid-binding-type.js
+++ b/test/fixtures/invalid-binding-type.js
@@ -45,7 +45,8 @@ export const errors = [
               'camunda:out',
               'camunda:in:businessKey',
               'camunda:executionListener',
-              'camunda:field'
+              'camunda:field',
+              'camunda:errorEventDefinition'
             ]
           },
           message: 'should be equal to one of the allowed values'

--- a/test/fixtures/invalid-camunda-error-event-definition-type.js
+++ b/test/fixtures/invalid-camunda-error-event-definition-type.js
@@ -1,0 +1,87 @@
+export const template = {
+  name: 'Error template',
+  id: 'error-template',
+  appliesTo: [
+    'bpmn:ServiceTask'
+  ],
+  properties: [
+    {
+      value: 'expression-value',
+      type: 'Text',
+      binding: {
+        type: 'camunda:errorEventDefinition',
+        errorRef: 'Error_1'
+      }
+    }
+  ],
+  scopes: [
+    {
+      type: 'bpmn:Error',
+      id: 'Error_1',
+      properties: [
+        {
+          value: 'error-code',
+          binding: {
+            type: 'property',
+            name: 'errorCode'
+          }
+        },
+        {
+          value: 'error-message',
+          binding: {
+            type: 'property',
+            name: 'camunda:errorMessage'
+          }
+        },
+        {
+          value: 'error-name',
+          binding: {
+            type: 'property',
+            name: 'name'
+          }
+        }
+      ]
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'errorMessage',
+    dataPath: '/properties/0/type',
+    schemaPath: '#/definitions/properties/items/allOf/3/then/properties/type/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'enum',
+          dataPath: '/properties/0/type',
+          schemaPath: '#/definitions/properties/items/allOf/3/then/properties/type/enum',
+          params: { allowedValues: [ 'String', 'Hidden', 'Dropdown' ] },
+          message: 'should be equal to one of the allowed values'
+        }
+      ]
+    },
+    message: 'invalid property type "Text" for binding type "camunda:errorEventDefinition"; must be any of { String, Hidden, Dropdown }'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/0',
+    schemaPath: '#/definitions/properties/items/allOf/3/if',
+    params: { failingKeyword: 'then' },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: { type: 'array' },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: { passingSchemas: null },
+    message: 'should match exactly one schema in oneOf'
+  }
+];

--- a/test/fixtures/missing-binding-errorRef.js
+++ b/test/fixtures/missing-binding-errorRef.js
@@ -1,0 +1,92 @@
+export const template = {
+  name: 'Error template',
+  id: 'error-template',
+  appliesTo: [
+    'bpmn:ServiceTask'
+  ],
+  properties: [
+    {
+      value: 'expression-value',
+      binding: {
+        type: 'camunda:errorEventDefinition'
+      }
+    }
+  ],
+  scopes: [
+    {
+      type: 'bpmn:Error',
+      id: 'Error_1',
+      properties: [
+        {
+          value: 'error-code',
+          binding: {
+            type: 'property',
+            name: 'errorCode'
+          }
+        },
+        {
+          value: 'error-message',
+          binding: {
+            type: 'property',
+            name: 'camunda:errorMessage'
+          }
+        },
+        {
+          value: 'error-name',
+          binding: {
+            type: 'property',
+            name: 'name'
+          }
+        }
+      ]
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'errorMessage',
+    dataPath: '/properties/0/binding',
+    schemaPath: '#/definitions/properties/items/properties/binding/allOf/4/then/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'required',
+          dataPath: '/properties/0/binding',
+          schemaPath: '#/definitions/properties/items/properties/binding/allOf/4/then/oneOf/0/required',
+          params: { missingProperty: 'errorRef' },
+          message: "should have required property 'errorRef'"
+        },
+        {
+          keyword: 'oneOf',
+          dataPath: '/properties/0/binding',
+          schemaPath: '#/definitions/properties/items/properties/binding/allOf/4/then/oneOf',
+          params: { passingSchemas: null },
+          message: 'should match exactly one schema in oneOf'
+        }
+      ]
+    },
+    message: 'property.binding "camunda:errorEventDefinition" requires errorRef'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/0/binding',
+    schemaPath: '#/definitions/properties/items/properties/binding/allOf/4/if',
+    params: { failingKeyword: 'then' },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: { type: 'array' },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: { passingSchemas: null },
+    message: 'should match exactly one schema in oneOf'
+  }
+];

--- a/test/fixtures/scope-connector-legacy.js
+++ b/test/fixtures/scope-connector-legacy.js
@@ -5,9 +5,8 @@ export const template = {
     'bpmn:Task'
   ],
   properties: [],
-  scopes: [
-    {
-      type: 'camunda:Connector',
+  scopes: {
+    'camunda:Connector': {
       properties: [
         {
           label: 'ConnectorId',
@@ -48,7 +47,7 @@ export const template = {
         }
       ]
     }
-  ]
+  }
 };
 
 export const errors = null;

--- a/test/fixtures/scope-connector-missing-binding-legacy.js
+++ b/test/fixtures/scope-connector-missing-binding-legacy.js
@@ -27,6 +27,24 @@ export const errors = [
     message: "should have required property 'binding'"
   },
   {
+    keyword: 'type',
+    dataPath: '/scopes',
+    message: 'should be array',
+    params: {
+      type: 'array'
+    },
+    schemaPath: '#/type'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '/scopes',
+    message: 'should match exactly one schema in oneOf',
+    params: {
+      passingSchemas: null
+    },
+    schemaPath: '#/properties/scopes/oneOf'
+  },
+  {
     dataPath: '',
     keyword: 'type',
     message: 'should be array',

--- a/test/fixtures/scope-invalid-legacy.js
+++ b/test/fixtures/scope-invalid-legacy.js
@@ -16,13 +16,13 @@ export const errors = [
   {
     keyword: 'errorMessage',
     dataPath: '/scopes',
-    schemaPath: '#/properties/scopes/errorMessage',
+    schemaPath: '#/errorMessage',
     params: {
       errors: [
         {
           keyword: 'additionalProperties',
           dataPath: '/scopes',
-          schemaPath: '#/properties/scopes/additionalProperties',
+          schemaPath: '#/additionalProperties',
           params: {
             'additionalProperty': 'foo'
           },
@@ -30,7 +30,25 @@ export const errors = [
         }
       ]
     },
-    message: 'scope must be defined as element type'
+    message: 'invalid scope, object descriptor is only supported for camunda:Connector'
+  },
+  {
+    keyword: 'type',
+    dataPath: '/scopes',
+    message: 'should be array',
+    params: {
+      type: 'array'
+    },
+    schemaPath: '#/type'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '/scopes',
+    message: 'should match exactly one schema in oneOf',
+    params: {
+      passingSchemas: null
+    },
+    schemaPath: '#/properties/scopes/oneOf'
   },
   {
     dataPath: '',

--- a/test/fixtures/scope-invalid-type.js
+++ b/test/fixtures/scope-invalid-type.js
@@ -22,11 +22,21 @@ export const errors = [
     message: 'should be object'
   },
   {
-    keyword: 'pattern',
+    keyword: 'errorMessage',
     dataPath: '/scopes/0/type',
-    schemaPath: '#/items/properties/type/pattern',
-    params: { pattern: '^(camunda|bpmn):' },
-    message: 'should match pattern "^(camunda|bpmn):"'
+    schemaPath: '#/items/properties/type/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'enum',
+          dataPath: '/scopes/0/type',
+          schemaPath: '#/items/properties/type/enum',
+          params: { allowedValues: [ 'camunda:Connector', 'bpmn:Error' ] },
+          message: 'should be equal to one of the allowed values'
+        }
+      ]
+    },
+    message: 'invalid scope type "foo"; must be any of { camunda:Connector, bpmn:Error }'
   },
   {
     keyword: 'oneOf',

--- a/test/fixtures/scope-invalid-type.js
+++ b/test/fixtures/scope-invalid-type.js
@@ -1,0 +1,52 @@
+export const template = {
+  name: 'Task',
+  id: 'my.Task.template',
+  appliesTo: [
+    'bpmn:Task'
+  ],
+  properties: [],
+  scopes: [
+    {
+      type: 'foo',
+      properties: []
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'type',
+    dataPath: '/scopes',
+    schemaPath: '#/type',
+    params: { type: 'object' },
+    message: 'should be object'
+  },
+  {
+    keyword: 'pattern',
+    dataPath: '/scopes/0/type',
+    schemaPath: '#/items/properties/type/pattern',
+    params: { pattern: '^(camunda|bpmn):' },
+    message: 'should match pattern "^(camunda|bpmn):"'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '/scopes',
+    schemaPath: '#/properties/scopes/oneOf',
+    params: { passingSchemas: null },
+    message: 'should match exactly one schema in oneOf'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: { type: 'array' },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: { passingSchemas: null },
+    message: 'should match exactly one schema in oneOf'
+  }
+];

--- a/test/fixtures/scope-missing-binding.js
+++ b/test/fixtures/scope-missing-binding.js
@@ -1,0 +1,58 @@
+export const template = {
+  name: 'ConnectorGetTask',
+  id: 'my.connector.http.get.Task',
+  appliesTo: [
+    'bpmn:Task'
+  ],
+  properties: [],
+  scopes: [
+    {
+      type: 'camunda:Connector',
+      properties: [
+        {
+          label: 'ConnectorId',
+          type: 'String',
+          value: 'My Connector HTTP - GET'
+        }
+      ]
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'type',
+    dataPath: '/scopes',
+    schemaPath: '#/type',
+    params: { type: 'object' },
+    message: 'should be object'
+  },
+  {
+    keyword: 'required',
+    dataPath: '/scopes/0/properties/0',
+    schemaPath: '#/definitions/properties/items/required',
+    params: { missingProperty: 'binding' },
+    message: "should have required property 'binding'"
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '/scopes',
+    schemaPath: '#/properties/scopes/oneOf',
+    params: { passingSchemas: null },
+    message: 'should match exactly one schema in oneOf'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: { type: 'array' },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: { passingSchemas: null },
+    message: 'should match exactly one schema in oneOf'
+  }
+];

--- a/test/fixtures/scope-missing-error-id.js
+++ b/test/fixtures/scope-missing-error-id.js
@@ -1,0 +1,99 @@
+export const template = {
+  name: 'Error template',
+  id: 'error-template',
+  appliesTo: [
+    'bpmn:ServiceTask'
+  ],
+  properties: [
+    {
+      value: 'expression-value',
+      binding: {
+        type: 'camunda:errorEventDefinition',
+        errorRef: 'Error_1'
+      }
+    }
+  ],
+  scopes: [
+    {
+      type: 'bpmn:Error',
+      properties: [
+        {
+          value: 'error-code',
+          binding: {
+            type: 'property',
+            name: 'errorCode'
+          }
+        },
+        {
+          value: 'error-message',
+          binding: {
+            type: 'property',
+            name: 'camunda:errorMessage'
+          }
+        },
+        {
+          value: 'error-name',
+          binding: {
+            type: 'property',
+            name: 'name'
+          }
+        }
+      ]
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'type',
+    dataPath: '/scopes',
+    schemaPath: '#/type',
+    params: { type: 'object' },
+    message: 'should be object'
+  },
+  {
+    keyword: 'errorMessage',
+    dataPath: '/scopes/0',
+    schemaPath: '#/items/allOf/0/then/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'required',
+          dataPath: '/scopes/0',
+          schemaPath: '#/items/allOf/0/then/required',
+          params: { missingProperty: 'id' },
+          message: "should have required property 'id'"
+        }
+      ]
+    },
+    message: 'scoped binding of type "bpmn:Error" requires id'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/scopes/0',
+    schemaPath: '#/items/allOf/0/if',
+    params: { failingKeyword: 'then' },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '/scopes',
+    schemaPath: '#/properties/scopes/oneOf',
+    params: { passingSchemas: null },
+    message: 'should match exactly one schema in oneOf'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: { type: 'array' },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: { passingSchemas: null },
+    message: 'should match exactly one schema in oneOf'
+  }
+];

--- a/test/fixtures/scope-missing-properties.js
+++ b/test/fixtures/scope-missing-properties.js
@@ -1,0 +1,51 @@
+export const template = {
+  name: 'ConnectorGetTask',
+  id: 'my.connector.http.get.Task',
+  appliesTo: [
+    'bpmn:Task'
+  ],
+  properties: [],
+  scopes: [
+    {
+      type: 'camunda:Connector'
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'type',
+    dataPath: '/scopes',
+    schemaPath: '#/type',
+    params: { type: 'object' },
+    message: 'should be object'
+  },
+  {
+    keyword: 'required',
+    dataPath: '/scopes/0',
+    schemaPath: '#/items/required',
+    params: { missingProperty: 'properties' },
+    message: "should have required property 'properties'"
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '/scopes',
+    schemaPath: '#/properties/scopes/oneOf',
+    params: { passingSchemas: null },
+    message: 'should match exactly one schema in oneOf'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: { type: 'array' },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: { passingSchemas: null },
+    message: 'should match exactly one schema in oneOf'
+  }
+];

--- a/test/fixtures/scope-missing-type.js
+++ b/test/fixtures/scope-missing-type.js
@@ -1,0 +1,51 @@
+export const template = {
+  name: 'Task',
+  id: 'my.Task.template',
+  appliesTo: [
+    'bpmn:Task'
+  ],
+  properties: [],
+  scopes: [
+    {
+      properties: []
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'type',
+    dataPath: '/scopes',
+    schemaPath: '#/type',
+    params: { type: 'object' },
+    message: 'should be object'
+  },
+  {
+    keyword: 'required',
+    dataPath: '/scopes/0',
+    schemaPath: '#/items/required',
+    params: { missingProperty: 'type' },
+    message: "should have required property 'type'"
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '/scopes',
+    schemaPath: '#/properties/scopes/oneOf',
+    params: { passingSchemas: null },
+    message: 'should match exactly one schema in oneOf'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: { type: 'array' },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: { passingSchemas: null },
+    message: 'should match exactly one schema in oneOf'
+  }
+];

--- a/test/fixtures/scopes-multiple.js
+++ b/test/fixtures/scopes-multiple.js
@@ -1,0 +1,40 @@
+export const template = {
+  name: 'ConnectorGetTask',
+  id: 'my.connector.http.get.Task',
+  appliesTo: [
+    'bpmn:Task'
+  ],
+  properties: [],
+  scopes: [
+    {
+      type: 'camunda:Connector',
+      properties: [
+        {
+          label: 'ConnectorId',
+          type: 'String',
+          value: 'My Connector HTTP - GET',
+          binding: {
+            type: 'property',
+            name: 'connectorId'
+          }
+        }
+      ]
+    },
+    {
+      type: 'camunda:Connector',
+      properties: [
+        {
+          label: 'ConnectorId',
+          type: 'String',
+          value: 'My Connector HTTP - GET',
+          binding: {
+            type: 'property',
+            name: 'connectorId'
+          }
+        }
+      ]
+    }
+  ]
+};
+
+export const errors = null;

--- a/test/spec/validationSpec.js
+++ b/test/spec/validationSpec.js
@@ -150,13 +150,31 @@ describe('validation', function() {
 
     describe('scoped binding', function() {
 
+      testTemplate('scope-connector-legacy', '../fixtures/scope-connector-legacy.js');
+
+
+      testTemplate('scope-invalid-legacy', '../fixtures/scope-invalid-legacy.js');
+
+
+      testTemplate('scope-connector-missing-binding-legacy', '../fixtures/scope-connector-missing-binding-legacy.js');
+
+
       testTemplate('scope-connector', '../fixtures/scope-connector.js');
 
 
-      testTemplate('scope-connector-missing-binding', '../fixtures/scope-connector-missing-binding.js');
+      testTemplate('scope-missing-binding', '../fixtures/scope-missing-binding.js');
 
 
-      testTemplate('scope-invalid', '../fixtures/scope-invalid.js');
+      testTemplate('scopes-multiple', '../fixtures/scopes-multiple.js');
+
+
+      testTemplate('scope-missing-type', '../fixtures/scope-missing-type.js');
+
+
+      testTemplate('scope-invalid-type', '../fixtures/scope-invalid-type.js');
+
+
+      testTemplate('scope-missing-properties', '../fixtures/scope-missing-properties.js');
 
     });
 

--- a/test/spec/validationSpec.js
+++ b/test/spec/validationSpec.js
@@ -1,5 +1,7 @@
 import { expect } from 'chai';
 
+import util from 'util';
+
 import schema from '../../resources/schema.json';
 
 import {
@@ -121,6 +123,15 @@ describe('validation', function() {
     testTemplate('multiple-errors');
 
 
+    testTemplate('error-task');
+
+
+    testTemplate('error-task-multiple');
+
+
+    testTemplate('missing-binding-errorRef');
+
+
     describe('property type - binding type', function() {
 
       testTemplate('invalid-property-type');
@@ -198,3 +209,15 @@ describe('validation', function() {
   });
 
 });
+
+
+// helpers /////////////////
+
+// eslint-disable-next-line no-unused-vars
+function printNested(object) {
+  console.log(util.inspect(object, {
+    showHidden: false,
+    depth: null,
+    colors: true
+  }));
+}

--- a/test/spec/validationSpec.js
+++ b/test/spec/validationSpec.js
@@ -160,6 +160,9 @@ describe('validation', function() {
 
       testTemplate('invalid-field-type');
 
+
+      testTemplate('invalid-camunda-error-event-definition-type');
+
     });
 
 

--- a/test/spec/validationSpec.js
+++ b/test/spec/validationSpec.js
@@ -191,6 +191,9 @@ describe('validation', function() {
 
       testTemplate('scope-missing-properties');
 
+
+      testTemplate('scope-missing-error-id');
+
     });
 
   });

--- a/test/spec/validationSpec.js
+++ b/test/spec/validationSpec.js
@@ -23,6 +23,10 @@ describe('validation', function() {
 
   function testTemplate(name, file, only = false) {
 
+    if (!file) {
+      file = `../fixtures/${name}.js`;
+    }
+
     (only ? it.only : it)('should validate template - ' + name, function() {
 
       // given
@@ -51,130 +55,130 @@ describe('validation', function() {
 
   describe('single template', function() {
 
-    testTemplate('mail-task', '../fixtures/mail-task.js');
+    testTemplate('mail-task');
 
 
-    testTemplate('async-awesome-task', '../fixtures/async-awesome-task.js');
+    testTemplate('async-awesome-task');
 
 
-    testTemplate('missing-type', '../fixtures/missing-type.js');
+    testTemplate('missing-type');
 
 
-    testTemplate('missing-applies-to', '../fixtures/missing-applies-to.js');
+    testTemplate('missing-applies-to');
 
 
-    testTemplate('missing-binding', '../fixtures/missing-binding.js');
+    testTemplate('missing-binding');
 
 
-    testTemplate('applies-to-single', '../fixtures/applies-to-single.js');
+    testTemplate('applies-to-single');
 
 
-    testTemplate('number-value', '../fixtures/number-value.js');
+    testTemplate('number-value');
 
 
-    testTemplate('additional-property', '../fixtures/additional-property.js');
+    testTemplate('additional-property');
 
 
-    testTemplate('invalid-binding-type', '../fixtures/invalid-binding-type.js');
+    testTemplate('invalid-binding-type');
 
 
-    testTemplate('choices-missing-value', '../fixtures/choices-missing-value.js');
+    testTemplate('choices-missing-value');
 
 
-    testTemplate('choices-missing-name', '../fixtures/choices-missing-name.js');
+    testTemplate('choices-missing-name');
 
 
-    testTemplate('missing-choices', '../fixtures/missing-choices.js');
+    testTemplate('missing-choices');
 
 
-    testTemplate('missing-binding-name', '../fixtures/missing-binding-name.js');
+    testTemplate('missing-binding-name');
 
 
-    testTemplate('missing-binding-source', '../fixtures/missing-binding-source.js');
+    testTemplate('missing-binding-source');
 
 
-    testTemplate('missing-binding-variables-target', '../fixtures/missing-binding-variables-target.js');
+    testTemplate('missing-binding-variables-target');
 
 
-    testTemplate('camunda-in-binding', '../fixtures/camunda-in-binding.js');
+    testTemplate('camunda-in-binding');
 
 
-    testTemplate('invalid-camunda-out', '../fixtures/invalid-camunda-out.js');
+    testTemplate('invalid-camunda-out');
 
 
-    testTemplate('camunda-out-binding', '../fixtures/camunda-out-binding.js');
+    testTemplate('camunda-out-binding');
 
 
-    testTemplate('camunda-execution-listener', '../fixtures/camunda-execution-listener.js');
+    testTemplate('camunda-execution-listener');
 
 
-    testTemplate('with-version', '../fixtures/with-version.js');
+    testTemplate('with-version');
 
 
-    testTemplate('invalid-version', '../fixtures/invalid-version.js');
+    testTemplate('invalid-version');
 
 
-    testTemplate('multiple-errors', '../fixtures/multiple-errors.js');
+    testTemplate('multiple-errors');
 
 
     describe('property type - binding type', function() {
 
-      testTemplate('invalid-property-type', '../fixtures/invalid-property-type.js');
+      testTemplate('invalid-property-type');
 
 
-      testTemplate('invalid-camunda-property-type', '../fixtures/invalid-camunda-property-type.js');
+      testTemplate('invalid-camunda-property-type');
 
 
-      testTemplate('invalid-input-parameter-type', '../fixtures/invalid-input-parameter-type.js');
+      testTemplate('invalid-input-parameter-type');
 
 
-      testTemplate('invalid-output-parameter-type', '../fixtures/invalid-output-parameter-type.js');
+      testTemplate('invalid-output-parameter-type');
 
 
-      testTemplate('invalid-camunda-in-type', '../fixtures/invalid-camunda-in-type.js');
+      testTemplate('invalid-camunda-in-type');
 
 
-      testTemplate('invalid-camunda-in-business-key-type', '../fixtures/invalid-camunda-in-business-key-type.js');
+      testTemplate('invalid-camunda-in-business-key-type');
 
 
-      testTemplate('invalid-camunda-out-type', '../fixtures/invalid-camunda-out-type.js');
+      testTemplate('invalid-camunda-out-type');
 
 
-      testTemplate('invalid-execution-listener-type', '../fixtures/invalid-execution-listener-type.js');
+      testTemplate('invalid-execution-listener-type');
 
 
-      testTemplate('invalid-field-type', '../fixtures/invalid-field-type.js');
+      testTemplate('invalid-field-type');
 
     });
 
 
     describe('scoped binding', function() {
 
-      testTemplate('scope-connector-legacy', '../fixtures/scope-connector-legacy.js');
+      testTemplate('scope-connector-legacy');
 
 
-      testTemplate('scope-invalid-legacy', '../fixtures/scope-invalid-legacy.js');
+      testTemplate('scope-invalid-legacy');
 
 
-      testTemplate('scope-connector-missing-binding-legacy', '../fixtures/scope-connector-missing-binding-legacy.js');
+      testTemplate('scope-connector-missing-binding-legacy');
 
 
-      testTemplate('scope-connector', '../fixtures/scope-connector.js');
+      testTemplate('scope-connector');
 
 
-      testTemplate('scope-missing-binding', '../fixtures/scope-missing-binding.js');
+      testTemplate('scope-missing-binding');
 
 
-      testTemplate('scopes-multiple', '../fixtures/scopes-multiple.js');
+      testTemplate('scopes-multiple');
 
 
-      testTemplate('scope-missing-type', '../fixtures/scope-missing-type.js');
+      testTemplate('scope-missing-type');
 
 
-      testTemplate('scope-invalid-type', '../fixtures/scope-invalid-type.js');
+      testTemplate('scope-invalid-type');
 
 
-      testTemplate('scope-missing-properties', '../fixtures/scope-missing-properties.js');
+      testTemplate('scope-missing-properties');
 
     });
 
@@ -183,13 +187,13 @@ describe('validation', function() {
 
   describe('multiple templates', function() {
 
-    testTemplate('multiple-mail-task', '../fixtures/multiple-mail-tasks.js');
+    testTemplate('multiple-mail-tasks');
 
 
-    testTemplate('single-template-in-array', '../fixtures/single-template-in-array.js');
+    testTemplate('single-template-in-array');
 
 
-    testTemplate('invalid-multiple-mail-task', '../fixtures/invalid-multiple-mail-tasks.js');
+    testTemplate('invalid-multiple-mail-tasks');
 
   });
 


### PR DESCRIPTION
Closes #20

* handle array scopes
* allow error event definitions
  * validate for missing errorRef
  * validate for property type ("String", "Hidden", "Dropdown")
* allow error scopes
  * validate for missing id