### PR TITLE
Schema Adjustments + Cleanups

### DIFF
--- a/resources/schema.json
+++ b/resources/schema.json
@@ -473,23 +473,31 @@
               },
               "pattern": {
                 "$id": "#/properties/property/constraints/pattern",
-                "type": "object",
+                
                 "title": "property constraints pattern",
                 "description": "A regular expression pattern for the constraints",
-                "properties": {
-                  "value": {
-                    "$id": "#/properties/property/constraints/pattern/value",
-                    "type": "string",
-                    "title": "property constraints pattern value",
-                    "description": "The regular expression of the pattern constraint"
+                "oneOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "value": {
+                        "$id": "#/properties/property/constraints/pattern/value",
+                        "type": "string",
+                        "title": "property constraints pattern value",
+                        "description": "The regular expression of the pattern constraint"
+                      },
+                      "message": {
+                        "$id": "#/properties/property/constraints/pattern/message",
+                        "type": "string",
+                        "title": "property constraints pattern message",
+                        "description": "The validation message of the pattern constraint"
+                      }
+                    }
                   },
-                  "message": {
-                    "$id": "#/properties/property/constraints/pattern/message",
-                    "type": "string",
-                    "title": "property constraints pattern message",
-                    "description": "The validation message of the pattern constraint"
+                  {
+                    "type": "string"
                   }
-                }
+                ]
               }
             }
           }

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -625,7 +625,10 @@
           "items": {
             "$id": "#/appliesTo/items",
             "type": "string",
-            "pattern": "^(bpmn:)"
+            "pattern": "^(.*?:)",
+            "errorMessage": {
+              "pattern": "invalid item for \"appliesTo\", should contain namespaced property, example: \"bpmn:Task\""
+            }
           }
         },
         "properties": {

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -385,7 +385,7 @@
                   "camunda:field",
                   "camunda:errorEventDefinition"
                 ],
-                "errorMessage": "invalid property.binding type ${0}; must be any of { property, camunda:property, camunda:inputParameter, camunda:outputParameter, camunda:in, camunda:out, camunda:in:businessKey, camunda:executionListener, camunda:field }",
+                "errorMessage": "invalid property.binding type ${0}; must be any of { property, camunda:property, camunda:inputParameter, camunda:outputParameter, camunda:in, camunda:out, camunda:in:businessKey, camunda:executionListener, camunda:field, camunda:errorEventDefinition }",
                 "description": "The type of the property binding"
               },
               "name": {

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -456,13 +456,13 @@
               },
               "minLength": {
                 "$id": "#/properties/property/constraints/minLength",
-                "type": "string",
+                "type": "number",
                 "title": "property constraints min length",
                 "description": "The minimal length for the control field value"
               },
               "maxLength": {
                 "$id": "#/properties/property/constraints/maxLength",
-                "type": "string",
+                "type": "number",
                 "title": "property constraints max length",
                 "description": "The maximal length for the control field value"
               },

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -18,6 +18,11 @@
         "required": [
           "binding"
         ],
+        "errorMessage": {
+          "required": {
+            "binding": "missing binding for property \"${0#}\""
+          }
+        },
         "allOf": [
           {
             "if": {
@@ -542,6 +547,12 @@
           "type",
           "properties"
         ],
+        "errorMessage": {
+          "required": {
+            "type": "invalid scope, missing type",
+            "properties": "invalid scope ${0/type}, missing properties=[]"
+          }
+        },
         "allOf": [
           {
             "if": {
@@ -560,7 +571,7 @@
               "required": [
                 "id"
               ],
-              "errorMessage": "scoped binding of type ${0/type} requires id"
+              "errorMessage": "invalid scope ${0/type}, missing id"
             }
           }
         ]
@@ -643,6 +654,14 @@
           "type": "object",
           "title": "element template entries visible",
           "description": "@Deprecated - Select which entries are visible in the properties panel"
+        }
+      },
+      "errorMessage": {
+        "required": {
+          "name": "missing template name",
+          "id": "missing template id",
+          "appliesTo": "missing appliesTo=[]",
+          "properties": "missing properties=[]"
         }
       }
     }

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -502,9 +502,9 @@
       "title": "element template scope",
       "deprecated": true,
       "description": "@Deprecated - Special scoped bindings that allow you to configure nested elements",
-      "additionalProperties": false,
-      "errorMessage": {
-        "additionalProperties": "invalid scope, object descriptor is only supported for camunda:Connector"
+      "additionalProperties": {
+        "not": true,
+        "errorMessage": "invalid scope ${0#}, object descriptor is only supported for \"camunda:Connector\""
       },
       "properties": {
         "camunda:Connector": {

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -654,7 +654,7 @@
         "entriesVisible": {
           "$id": "#/entriesVisible",
           "deprecated": true,
-          "type": "object",
+          "type": [ "object", "boolean" ],
           "title": "element template entries visible",
           "description": "@Deprecated - Select which entries are visible in the properties panel"
         }

--- a/test/fixtures/complex.js
+++ b/test/fixtures/complex.js
@@ -1,0 +1,728 @@
+export const template = [
+  {
+    'name': 'ConnectorTask',
+    'id': 'my.connector.Task',
+    'appliesTo': [
+      'bpmn:ServiceTask'
+    ],
+    'properties': [],
+    'scopes': [
+      {
+        'type': 'camunda:Connector',
+        'properties': [
+          {
+            'label': 'ConnectorId',
+            'type': 'String',
+            'value': 'My Connector HTTP',
+            'binding': {
+              'type': 'property',
+              'name': 'connectorId'
+            },
+            'constraints': {
+              'notEmpty': true
+            }
+          },
+          {
+            'label': 'URL',
+            'type': 'String',
+            'binding': {
+              'type': 'camunda:inputParameter',
+              'name': 'url'
+            },
+            'constraints': {
+              'notEmpty': true
+            }
+          },
+          {
+            'label': 'Method',
+            'type': 'Dropdown',
+            'choices': [
+              {
+                'value': 'GET',
+                'name':'GET'
+              },
+              {
+                'value': 'POST',
+                'name': 'POST'
+              },
+              {
+                'value': 'PUT',
+                'name': 'PUT'
+              },
+              {
+                'value': 'PATCH',
+                'name': 'PATCH'
+              },
+              {
+                'value': 'DELETE',
+                'name': 'DELETE'
+              }
+            ],
+            'binding': {
+              'type': 'camunda:inputParameter',
+              'name': 'method'
+            },
+            'constraints': {
+              'notEmpty': true
+            }
+          },
+          {
+            'type': 'Hidden',
+            'value': 'Camunda',
+            'binding': {
+              'type': 'camunda:inputParameter',
+              'name': 'agent'
+            }
+          },
+          {
+            'label': 'Template',
+            'type': 'Text',
+            'description': 'By the way, you can use freemarker templates ${...} here',
+            'value': 'Hello ${firstName}!',
+            'binding': {
+              'type': 'camunda:inputParameter',
+              'name': 'messageBody',
+              'scriptFormat': 'freemarker'
+            }
+          },
+          {
+            'label': 'Response',
+            'type': 'String',
+            'value': '${S(response)}',
+            'binding': {
+              'type': 'camunda:outputParameter',
+              'name': 'wsResponse',
+              'source': 'wsResponse'
+            }
+          },
+          {
+            'label': 'Result',
+            'type': 'String',
+            'value': 'httpResult',
+            'binding': {
+              'type': 'camunda:outputParameter',
+              'source': '${httpResult}',
+              'scriptFormat': 'freemarker'
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    'name': 'ConnectorTask_legacy',
+    'id': 'my.connector.legacy.Task',
+    'appliesTo': [
+      'bpmn:ServiceTask'
+    ],
+    'properties': [],
+    'scopes': {
+      'camunda:Connector': {
+        'properties': [
+          {
+            'label': 'ConnectorId',
+            'type': 'String',
+            'value': 'My Connector HTTP',
+            'binding': {
+              'type': 'property',
+              'name': 'connectorId'
+            },
+            'constraints': {
+              'notEmpty': true
+            }
+          },
+          {
+            'label': 'URL',
+            'type': 'String',
+            'binding': {
+              'type': 'camunda:inputParameter',
+              'name': 'url'
+            },
+            'constraints': {
+              'notEmpty': true
+            }
+          },
+          {
+            'label': 'Method',
+            'type': 'Dropdown',
+            'choices': [
+              {
+                'value': 'GET',
+                'name':'GET'
+              },
+              {
+                'value': 'POST',
+                'name': 'POST'
+              },
+              {
+                'value': 'PUT',
+                'name': 'PUT'
+              },
+              {
+                'value': 'PATCH',
+                'name': 'PATCH'
+              },
+              {
+                'value': 'DELETE',
+                'name': 'DELETE'
+              }
+            ],
+            'binding': {
+              'type': 'camunda:inputParameter',
+              'name': 'method'
+            },
+            'constraints': {
+              'notEmpty': true
+            }
+          },
+          {
+            'type': 'Hidden',
+            'value': 'Camunda',
+            'binding': {
+              'type': 'camunda:inputParameter',
+              'name': 'agent'
+            }
+          },
+          {
+            'label': 'Template',
+            'type': 'Text',
+            'description': 'By the way, you can use freemarker templates ${...} here',
+            'value': 'Hello ${firstName}!',
+            'binding': {
+              'type': 'camunda:inputParameter',
+              'name': 'messageBody',
+              'scriptFormat': 'freemarker'
+            }
+          },
+          {
+            'label': 'Response',
+            'type': 'String',
+            'value': '${S(response)}',
+            'binding': {
+              'type': 'camunda:outputParameter',
+              'name': 'wsResponse',
+              'source': 'wsResponse'
+            }
+          },
+          {
+            'label': 'Result',
+            'type': 'String',
+            'value': 'httpResult',
+            'binding': {
+              'type': 'camunda:outputParameter',
+              'source': '${httpResult}',
+              'scriptFormat': 'freemarker'
+            }
+          }
+        ]
+      }
+    }
+  },
+  {
+    'name': 'MailTask',
+    'id': 'my.mail.Task',
+    'appliesTo': [
+      'bpmn:Task'
+    ],
+    'properties': [
+      {
+        'label': 'Recipient',
+        'type': 'String',
+        'binding': {
+          'type': 'camunda:inputParameter',
+          'name': 'recipient'
+        }
+      },
+      {
+        'label': 'Template',
+        'type': 'Text',
+        'description': 'By the way, you can use freemarker templates ${...} here',
+        'value': 'Hello ${firstName}!',
+        'binding': {
+          'type': 'camunda:inputParameter',
+          'name': 'messageBody',
+          'scriptFormat': 'freemarker'
+        }
+      },
+      {
+        'label': 'Ergebnisvariable',
+        'type': 'String',
+        'value': 'mailResult',
+        'binding': {
+          'type': 'camunda:outputParameter',
+          'source': '${mailResult}',
+          'scriptFormat': 'freemarker'
+        }
+      },
+      {
+        'type': 'Hidden',
+        'value': 'SECRET',
+        'binding': {
+          'type': 'camunda:inputParameter',
+          'name': 'hiddenField'
+        }
+      }
+    ]
+  },
+  {
+    'name': 'AsyncAwesomeTask',
+    'id': 'my.awesome.Task',
+    'appliesTo': [
+      'bpmn:Task'
+    ],
+    'properties': [
+      {
+        'id': '1',
+        'label': 'Are you awesome?',
+        'type': 'Boolean',
+        'value': true,
+        'binding': {
+          'type': 'property',
+          'name': 'camunda:asyncBefore'
+        }
+      }
+    ],
+    'entriesVisible': {
+      '_all': false,
+      'id': true,
+      'name': true,
+      'asyncBefore': true,
+      'asyncAfter': true,
+      'executionListeners': true,
+      'documentation': true
+    }
+  },
+  {
+    'name': 'Custom ServiceTask',
+    'id': 'my.custom.ServiceTask',
+    'appliesTo': [
+      'bpmn:ServiceTask'
+    ],
+    'properties': [
+      {
+        'label': 'STUFF TO CALL',
+        'type': 'String',
+        'editable': false,
+        'value': 'com.my.custom.Foo',
+        'binding': {
+          'type': 'property',
+          'name': 'camunda:delegateExpression'
+        }
+      }
+    ],
+    'entriesVisible': true
+  },
+  {
+    'name': 'VIP-Order Path',
+    'id': 'e.com.merce.FastPath',
+    'appliesTo': [
+      'bpmn:SequenceFlow'
+    ],
+    'properties': [
+      {
+        'label': 'VIP-Ordering',
+        'type': 'String',
+        'editable': false,
+        'value': '${ customer.vip }',
+        'binding': {
+          'type': 'property',
+          'name': 'conditionExpression'
+        }
+      },
+      {
+        'label': 'Label',
+        'type': 'Text',
+        'value': 'YEY YEA!',
+        'binding': {
+          'type': 'property',
+          'name': 'name'
+        }
+      }
+    ]
+  },
+  {
+    'name': 'WS Caller Task',
+    'id': 'com.mycompany.WsCaller',
+    'appliesTo': [
+      'bpmn:Task'
+    ],
+    'properties': [
+      {
+        'label': 'Web Service URL',
+        'description': 'Specify the url of the web service to talk to',
+        'type': 'String',
+        'binding': {
+          'type': 'camunda:property',
+          'name': 'webServiceUrl'
+        },
+        'constraints': {
+          'notEmpty': true,
+          'pattern': {
+            'value': 'https://.*',
+            'message': 'Must be https URL'
+          }
+        }
+      }
+    ]
+  },
+  {
+    'name': 'Priority Task',
+    'id': 'my.priority.Task',
+    'appliesTo': [
+      'bpmn:UserTask'
+    ],
+    'properties': [
+      {
+        'label': 'Priority',
+        'description': 'The priority assigned to this task',
+        'type': 'Dropdown',
+        'choices': [
+          { 'name': 'low', 'value': '50' },
+          { 'name': 'medium', 'value': '100' },
+          { 'name': 'high', 'value': '150' }
+        ],
+        'value': '50',
+        'binding': {
+          'type': 'property',
+          'name': 'camunda:priority'
+        }
+      }
+    ]
+  },
+  {
+    'name': 'Validated Inputs Task',
+    'id': 'com.validated-inputs.Task',
+    'appliesTo': [
+      'bpmn:Task'
+    ],
+    'properties': [
+      {
+        'label': 'NotEmpty',
+        'description': 'Must not be empty',
+        'type': 'String',
+        'binding': {
+          'type': 'camunda:property',
+          'name': 'prop'
+        },
+        'constraints': {
+          'notEmpty': true
+        }
+      },
+      {
+        'label': 'MinLength',
+        'description': 'Must have min length 5',
+        'type': 'String',
+        'binding': {
+          'type': 'camunda:property',
+          'name': 'prop'
+        },
+        'constraints': {
+          'minLength': 5
+        }
+      },
+      {
+        'label': 'MaxLength',
+        'description': 'Must have max length 5',
+        'type': 'String',
+        'binding': {
+          'type': 'camunda:property',
+          'name': 'prop'
+        },
+        'constraints': {
+          'maxLength': 5
+        }
+      },
+      {
+        'label': 'Pattern (String)',
+        'description': 'Must match /A+B/',
+        'type': 'String',
+        'binding': {
+          'type': 'camunda:property',
+          'name': 'prop'
+        },
+        'constraints': {
+          'pattern': 'A+B'
+        }
+      },
+      {
+        'label': 'Pattern (String + Message)',
+        'description': 'Must be https url',
+        'type': 'String',
+        'binding': {
+          'type': 'camunda:property',
+          'name': 'prop'
+        },
+        'constraints': {
+          'pattern': {
+            'message': 'Must start with https://',
+            'value': 'https://.*'
+          }
+        }
+      },
+      {
+        'label': 'Pattern (Integer)',
+        'description': 'Must be integer',
+        'type': 'String',
+        'binding': {
+          'type': 'camunda:property',
+          'name': 'prop'
+        },
+        'constraints': {
+          'pattern': {
+            'message': 'Must be positive integer',
+            'value': '\\d+'
+          }
+        }
+      }
+    ]
+  },
+  {
+    'name': 'Caller',
+    'id': 'my.Caller',
+    'appliesTo': [
+      'bpmn:CallActivity'
+    ],
+    'properties': [
+      {
+        'label': 'Called Process',
+        'type': 'String',
+        'editable': false,
+        'value': 'calledProcess',
+        'binding': {
+          'type': 'property',
+          'name': 'calledElement'
+        }
+      },
+      {
+        'label': 'Input source variable',
+        'type': 'String',
+        'value': 'var_local',
+        'binding': {
+          'type': 'camunda:in',
+          'target': 'var_called_source'
+        }
+      },
+      {
+        'label': 'Output target (source variable)',
+        'type': 'String',
+        'value': 'var_called',
+        'binding': {
+          'type': 'camunda:out',
+          'source': 'var_local_source'
+        }
+      },
+      {
+        'label': 'Input sourceExpression',
+        'type': 'String',
+        'value': '${expr_local}',
+        'binding': {
+          'type': 'camunda:in',
+          'target': 'var_called_expr',
+          'expression': true
+        }
+      },
+      {
+        'label': 'Output target (sourceExpression)',
+        'type': 'String',
+        'value': 'var_local_expr',
+        'binding': {
+          'type': 'camunda:out',
+          'sourceExpression': '${expr_called}'
+        }
+      },
+      {
+        'label': 'Input all',
+        'type': 'Hidden',
+        'binding': {
+          'type': 'camunda:in',
+          'variables': 'all'
+        }
+      },
+      {
+        'label': 'Output all',
+        'type': 'Hidden',
+        'binding': {
+          'type': 'camunda:out',
+          'variables': 'all'
+        }
+      },
+      {
+        'label': 'Input all local',
+        'type': 'Hidden',
+        'binding': {
+          'type': 'camunda:in',
+          'variables': 'local'
+        }
+      },
+      {
+        'label': 'Output all local',
+        'type': 'Hidden',
+        'binding': {
+          'type': 'camunda:out',
+          'variables': 'local'
+        }
+      },
+      {
+        'label': 'Input business key',
+        'description': 'Provide the expression retrieving the business key.',
+        'type': 'String',
+        'value': '${execution.processBusinessKey}',
+        'binding': {
+          'type': 'camunda:in:businessKey'
+        }
+      }
+    ]
+  },
+  {
+    'name': 'Execution Listener',
+    'id': 'my.execution.listener.task',
+    'appliesTo': [
+      'bpmn:Task'
+    ],
+    'properties': [
+      {
+        'value': 'println execution.eventName',
+        'type': 'Hidden',
+        'binding': {
+          'type': 'camunda:executionListener',
+          'event': 'start',
+          'scriptFormat': 'groovy'
+        }
+      },
+      {
+        'value': 'println end',
+        'type': 'Hidden',
+        'binding': {
+          'type': 'camunda:executionListener',
+          'event': 'end',
+          'scriptFormat': 'groovy'
+        }
+      }
+    ]
+  },
+  {
+    'name': 'Valid',
+    'id': 'com.camunda.example.CustomServiceTaskFieldInjection',
+    'appliesTo': [
+      'bpmn:ServiceTask'
+    ],
+    'properties': [
+      {
+        'label': 'Sender',
+        'type': 'String',
+        'value': 'My Field Injection Value',
+        'binding': {
+          'type': 'camunda:field',
+          'name': 'sender',
+          'expression': false
+        }
+      }
+    ]
+  },
+  {
+    'name': 'ExternalErrorTask',
+    'id': 'com.camunda.example.ExternalErrorTask',
+    'appliesTo': [
+      'bpmn:ServiceTask'
+    ],
+    'properties': [
+      {
+        'type': 'Hidden',
+        'value': 'external',
+        'binding': {
+          'type': 'property',
+          'name': 'camunda:type'
+        }
+      },
+      {
+        'label': 'Error Expression',
+        'value': 'error-expression',
+        'type': 'String',
+        'binding': {
+          'type': 'camunda:errorEventDefinition',
+          'errorRef': 'error-1'
+        }
+      }
+    ],
+    'scopes': [
+      {
+        'type': 'bpmn:Error',
+        'id': 'error-1',
+        'properties': [
+          {
+            'label': 'Error Code',
+            'type': 'String',
+            'value': 'my-code',
+            'binding': {
+              'type': 'property',
+              'name': 'errorCode'
+            }
+          },
+          {
+            'label': 'Error Message',
+            'type': 'String',
+            'value': 'error-message',
+            'binding': {
+              'type': 'property',
+              'name': 'camunda:errorMessage'
+            }
+          },
+          {
+            'label': 'Error Name',
+            'type': 'String',
+            'value': 'error-name',
+            'binding': {
+              'type': 'property',
+              'name': 'name'
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    'name': 'SimpleErrorScope',
+    'id': 'com.camunda.example.SimpleErrorScope',
+    'appliesTo': [
+      'bpmn:ServiceTask'
+    ],
+    'properties': [],
+    'scopes': [
+      {
+        'type': 'bpmn:Error',
+        'id': 'error-simple',
+        'properties': [
+          {
+            'label': 'Error Code',
+            'type': 'String',
+            'value': 'my-code',
+            'binding': {
+              'type': 'property',
+              'name': 'errorCode'
+            }
+          },
+          {
+            'label': 'Error Message',
+            'type': 'String',
+            'value': 'error-message',
+            'binding': {
+              'type': 'property',
+              'name': 'camunda:errorMessage'
+            }
+          },
+          {
+            'label': 'Error Name',
+            'type': 'String',
+            'value': 'error-name',
+            'binding': {
+              'type': 'property',
+              'name': 'name'
+            }
+          }
+        ]
+      }
+    ]
+  }
+];
+
+export const errors = null;

--- a/test/fixtures/constraints.js
+++ b/test/fixtures/constraints.js
@@ -1,0 +1,29 @@
+export const template = {
+  'name': 'Custom Whatever',
+  'id': 'com.mycompany.whateverdomain.ShoeTask',
+  'appliesTo': [
+    'bpmn:ServiceTask'
+  ],
+  'properties': [
+    {
+      'label': 'Schuhgröße',
+      'type': 'String',
+      'value': '45',
+      'binding': {
+        'type': 'camunda:inputParameter',
+        'name': 'shoeSize'
+      },
+      'constraints': {
+        'mandatory': true,
+        'minLength': 10,
+        'maxLength': 20,
+        'pattern': {
+          'message': 'Must be valid shoe size (>20 && <49)',
+          'match': '/[2-4][0-9]/'
+        }
+      }
+    }
+  ]
+};
+
+export const errors = null;

--- a/test/fixtures/entries-visible-boolean.js
+++ b/test/fixtures/entries-visible-boolean.js
@@ -1,0 +1,11 @@
+export const template = {
+  'name': 'Custom ServiceTask',
+  'id': 'my.custom.ServiceTask',
+  'appliesTo': [
+    'bpmn:ServiceTask'
+  ],
+  'properties': [],
+  'entriesVisible': true
+};
+
+export const errors = null;

--- a/test/fixtures/invalid-applies-to.js
+++ b/test/fixtures/invalid-applies-to.js
@@ -1,0 +1,41 @@
+export const template = {
+  'name': 'Invalid',
+  'id': 'foo',
+  'properties': [],
+  'appliesTo': [ 'Task' ]
+};
+
+export const errors = [
+  {
+    keyword: 'errorMessage',
+    dataPath: '/appliesTo/0',
+    schemaPath: '#/properties/appliesTo/items/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'pattern',
+          dataPath: '/appliesTo/0',
+          schemaPath: '#/properties/appliesTo/items/pattern',
+          params: { pattern: '^(.*?:)' },
+          message: 'should match pattern "^(.*?:)"',
+          emUsed: true
+        }
+      ]
+    },
+    message: 'invalid item for "appliesTo", should contain namespaced property, example: "bpmn:Task"'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: { type: 'array' },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: { passingSchemas: null },
+    message: 'should match exactly one schema in oneOf'
+  }
+];

--- a/test/fixtures/invalid-binding-type.js
+++ b/test/fixtures/invalid-binding-type.js
@@ -54,7 +54,7 @@ export const errors = [
         }
       ]
     },
-    message: 'invalid property.binding type "foo"; must be any of { property, camunda:property, camunda:inputParameter, camunda:outputParameter, camunda:in, camunda:out, camunda:in:businessKey, camunda:executionListener, camunda:field }'
+    message: 'invalid property.binding type "foo"; must be any of { property, camunda:property, camunda:inputParameter, camunda:outputParameter, camunda:in, camunda:out, camunda:in:businessKey, camunda:executionListener, camunda:field, camunda:errorEventDefinition }'
   },
   {
     dataPath: '',

--- a/test/fixtures/invalid-constraints.js
+++ b/test/fixtures/invalid-constraints.js
@@ -1,0 +1,58 @@
+export const template = {
+  'name': 'Custom Whatever',
+  'id': 'com.mycompany.whateverdomain.ShoeTask',
+  'appliesTo': [
+    'bpmn:ServiceTask'
+  ],
+  'properties': [
+    {
+      'label': 'Schuhgröße',
+      'type': 'String',
+      'value': '45',
+      'binding': {
+        'type': 'camunda:inputParameter',
+        'name': 'shoeSize'
+      },
+      'constraints': {
+        'mandatory': true,
+        'minLength': '100',
+        'maxLength': '200',
+        'pattern': {
+          'message': 'Must be valid shoe size (>20 && <49)',
+          'match': '/[2-4][0-9]/'
+        }
+      }
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'type',
+    dataPath: '/properties/0/constraints/minLength',
+    schemaPath: '#/definitions/properties/items/properties/constraints/properties/minLength/type',
+    params: { type: 'number' },
+    message: 'should be number'
+  },
+  {
+    keyword: 'type',
+    dataPath: '/properties/0/constraints/maxLength',
+    schemaPath: '#/definitions/properties/items/properties/constraints/properties/maxLength/type',
+    params: { type: 'number' },
+    message: 'should be number'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: { type: 'array' },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: { passingSchemas: null },
+    message: 'should match exactly one schema in oneOf'
+  }
+];

--- a/test/fixtures/invalid-multiple-mail-tasks.js
+++ b/test/fixtures/invalid-multiple-mail-tasks.js
@@ -153,18 +153,40 @@ export const errors = [
     message: 'should be object'
   },
   {
-    keyword: 'required',
+    keyword: 'errorMessage',
     dataPath: '/0',
-    schemaPath: '#/required',
-    params: { missingProperty: 'appliesTo' },
-    message: "should have required property 'appliesTo'"
+    schemaPath: '#/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'required',
+          dataPath: '/0',
+          schemaPath: '#/required',
+          params: { missingProperty: 'appliesTo' },
+          message: "should have required property 'appliesTo'",
+          emUsed: true
+        }
+      ]
+    },
+    message: 'missing appliesTo=[]'
   },
   {
-    keyword: 'required',
+    keyword: 'errorMessage',
     dataPath: '/1',
-    schemaPath: '#/required',
-    params: { missingProperty: 'appliesTo' },
-    message: "should have required property 'appliesTo'"
+    schemaPath: '#/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'required',
+          dataPath: '/1',
+          schemaPath: '#/required',
+          params: { missingProperty: 'appliesTo' },
+          message: "should have required property 'appliesTo'",
+          emUsed: true
+        }
+      ]
+    },
+    message: 'missing appliesTo=[]'
   },
   {
     keyword: 'oneOf',

--- a/test/fixtures/invalid-version.js
+++ b/test/fixtures/invalid-version.js
@@ -1,4 +1,4 @@
-export const templates = {
+export const template = {
   'name': 'InvalidVersion',
   'id': 'com.camunda.example.InvalidVersion',
   'version': 'foo',
@@ -11,29 +11,23 @@ export const templates = {
 export const errors = [
   {
     keyword: 'type',
-    dataPath: '',
-    schemaPath: '#/type',
-    params: {
-      'type': 'object'
-    },
-    message: 'should be object'
+    dataPath: '/version',
+    schemaPath: '#/properties/version/type',
+    params: { type: 'number' },
+    message: 'should be number'
   },
   {
-    dataPath: '',
     keyword: 'type',
-    message: 'should be array',
-    params: {
-      type: 'array',
-    },
+    dataPath: '',
     schemaPath: '#/oneOf/1/type',
+    params: { type: 'array' },
+    message: 'should be array'
   },
   {
-    dataPath: '',
     keyword: 'oneOf',
-    message: 'should match exactly one schema in oneOf',
-    params: {
-      passingSchemas: null
-    },
-    schemaPath: '#/oneOf'
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: { passingSchemas: null },
+    message: 'should match exactly one schema in oneOf'
   }
 ];

--- a/test/fixtures/missing-binding.js
+++ b/test/fixtures/missing-binding.js
@@ -15,28 +15,35 @@ export const template = {
 
 export const errors = [
   {
-    keyword: 'required',
+    keyword: 'errorMessage',
     dataPath: '/properties/0',
-    schemaPath: '#/definitions/properties/items/required',
-    params: { missingProperty: 'binding' },
-    message: "should have required property 'binding'"
+    schemaPath: '#/definitions/properties/items/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'required',
+          dataPath: '/properties/0',
+          schemaPath: '#/definitions/properties/items/required',
+          params: { missingProperty: 'binding' },
+          message: "should have required property 'binding'",
+          emUsed: true
+        }
+      ]
+    },
+    message: 'missing binding for property "0"'
   },
   {
-    dataPath: '',
     keyword: 'type',
-    message: 'should be array',
-    params: {
-      type: 'array',
-    },
+    dataPath: '',
     schemaPath: '#/oneOf/1/type',
+    params: { type: 'array' },
+    message: 'should be array'
   },
   {
-    dataPath: '',
     keyword: 'oneOf',
-    message: 'should match exactly one schema in oneOf',
-    params: {
-      passingSchemas: null
-    },
-    schemaPath: '#/oneOf'
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: { passingSchemas: null },
+    message: 'should match exactly one schema in oneOf'
   }
 ];

--- a/test/fixtures/missing-properties.js
+++ b/test/fixtures/missing-properties.js
@@ -1,7 +1,7 @@
 export const template = {
   'name': 'Invalid',
   'id': 'foo',
-  'properties': []
+  'appliesTo': []
 };
 
 export const errors = [
@@ -15,13 +15,13 @@ export const errors = [
           keyword: 'required',
           dataPath: '',
           schemaPath: '#/required',
-          params: { missingProperty: 'appliesTo' },
-          message: "should have required property 'appliesTo'",
+          params: { missingProperty: 'properties' },
+          message: "should have required property 'properties'",
           emUsed: true
         }
       ]
     },
-    message: 'missing appliesTo=[]'
+    message: 'missing properties=[]'
   },
   {
     keyword: 'type',

--- a/test/fixtures/missing-template-id.js
+++ b/test/fixtures/missing-template-id.js
@@ -1,7 +1,7 @@
 export const template = {
-  'name': 'Invalid',
-  'id': 'foo',
-  'properties': []
+  'name': 'foo',
+  'properties': [],
+  'appliesTo': []
 };
 
 export const errors = [
@@ -15,13 +15,13 @@ export const errors = [
           keyword: 'required',
           dataPath: '',
           schemaPath: '#/required',
-          params: { missingProperty: 'appliesTo' },
-          message: "should have required property 'appliesTo'",
+          params: { missingProperty: 'id' },
+          message: "should have required property 'id'",
           emUsed: true
         }
       ]
     },
-    message: 'missing appliesTo=[]'
+    message: 'missing template id'
   },
   {
     keyword: 'type',

--- a/test/fixtures/missing-template-name.js
+++ b/test/fixtures/missing-template-name.js
@@ -1,7 +1,7 @@
 export const template = {
-  'name': 'Invalid',
   'id': 'foo',
-  'properties': []
+  'properties': [],
+  'appliesTo': []
 };
 
 export const errors = [
@@ -15,13 +15,13 @@ export const errors = [
           keyword: 'required',
           dataPath: '',
           schemaPath: '#/required',
-          params: { missingProperty: 'appliesTo' },
-          message: "should have required property 'appliesTo'",
+          params: { missingProperty: 'name' },
+          message: "should have required property 'name'",
           emUsed: true
         }
       ]
     },
-    message: 'missing appliesTo=[]'
+    message: 'missing template name'
   },
   {
     keyword: 'type',

--- a/test/fixtures/pattern-string.js
+++ b/test/fixtures/pattern-string.js
@@ -1,0 +1,23 @@
+export const template = {
+  'name': 'Pattern Template',
+  'id': 'com.example.PatternTemplate',
+  'appliesTo': [
+    'bpmn:Task'
+  ],
+  'properties': [
+    {
+      'label': 'Pattern (String)',
+      'description': 'Must match /A+B/',
+      'type': 'String',
+      'binding': {
+        'type': 'camunda:property',
+        'name': 'prop'
+      },
+      'constraints': {
+        'pattern': 'A+B'
+      }
+    }
+  ]
+};
+
+export const errors = null;

--- a/test/fixtures/rpa-templates.js
+++ b/test/fixtures/rpa-templates.js
@@ -1,0 +1,180 @@
+export const template = [
+  {
+    'appliesTo': [
+      'bpmn:ServiceTask'
+    ],
+    'description': 'foo',
+    'id': '16319b98-513f-400e-b596-2944c7530d6c',
+    'metadata': {
+      'catalogOrganizationId': 'b810760f-167f-4b54-bd30-37cafcfdd08e',
+      'created': 1616669450772,
+      'tags': [
+        'Walts Templates'
+      ],
+      'templateVersionId': '5e48cd6b-b4d3-419d-8e1a-d11dee88d400',
+      'updated': 1616669450772
+    },
+    'name': 'New RPA template',
+    'properties': [
+      {
+        'binding': {
+          'name': 'bot',
+          'type': 'camunda:property'
+        },
+        'editable': false,
+        'label': 'UiPath Package Name',
+        'type': 'String',
+        'value': 'foo'
+      },
+      {
+        'binding': {
+          'name': 'camunda:asyncAfter',
+          'type': 'property'
+        },
+        'type': 'Hidden',
+        'value': 'true'
+      },
+      {
+        'binding': {
+          'name': 'camunda:type',
+          'type': 'property'
+        },
+        'type': 'Hidden',
+        'value': 'external'
+      },
+      {
+        'binding': {
+          'name': 'camunda:topic',
+          'type': 'property'
+        },
+        'type': 'Hidden',
+        'value': 'uipath'
+      },
+      {
+        'binding': {
+          'name': 'foo',
+          'type': 'camunda:inputParameter'
+        },
+        'description': '<Description of the IN argument, e.g. expected format of the value>',
+        'label': 'foo',
+        'value': '${foo}'
+      },
+      {
+        'binding': {
+          'source': '${bar}',
+          'type': 'camunda:outputParameter'
+        },
+        'description': '<Description of the OUT argument, e.g. format of the returned value>',
+        'label': 'bar',
+        'value': 'bar'
+      },
+      {
+        'binding': {
+          'errorRef': 'fd47d07f-8060-4b2d-b536-dc3ae15cfa19',
+          'type': 'camunda:errorEventDefinition'
+        },
+        'label': 'my-error',
+        'value': '${true}'
+      }
+    ],
+    'scopes': [
+      {
+        'id': 'fd47d07f-8060-4b2d-b536-dc3ae15cfa19',
+        'properties': [
+          {
+            'binding': {
+              'name': 'errorCode',
+              'type': 'property'
+            },
+            'label': 'Error Code',
+            'type': 'Hidden',
+            'value': '500'
+          },
+          {
+            'binding': {
+              'name': 'camunda:errorMessage',
+              'type': 'property'
+            },
+            'label': 'Error Message',
+            'type': 'Hidden',
+            'value': 'custom error thrown'
+          },
+          {
+            'binding': {
+              'name': 'name',
+              'type': 'property'
+            },
+            'label': 'Error Name',
+            'type': 'Hidden',
+            'value': 'my-error'
+          }
+        ],
+        'type': 'bpmn:Error'
+      }
+    ],
+    'version': 1616669450772
+  },
+  {
+    'name': 'RPA Template v2',
+    'description': 'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet',
+    'id': '0a7096fb-47e8-4b4c-9da0-ecaee7af225e',
+    'appliesTo': [
+      'bpmn:ServiceTask',
+      'bpmn:StartEvent'
+    ],
+    'properties': [
+      {
+        'label': 'Name',
+        'type': 'String',
+        'editable': false,
+        'value': 'Bar',
+        'binding': {
+          'type': 'property',
+          'name': 'name'
+        }
+      }
+    ],
+    'version': 946771200000,
+    'metadata': {
+      'templateVersionId': 'c74fee95-b75d-4d80-aa7d-c153dcc90cb8',
+      'catalogOrganizationId': '82527756-ffbe-46bf-a27b-f12880878e77',
+      'created': 946771200000,
+      'updated': 946771200000,
+      'tags': [
+        "Walt's Catalog"
+      ]
+    }
+  },
+  {
+    'name': 'RPA Template v1',
+    'description': 'At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.',
+    'id': '0a7096fb-47e8-4b4c-9da0-ecaee7af225e',
+    'appliesTo': [
+      'bpmn:ServiceTask'
+    ],
+    'properties': [
+      {
+        'label': 'Name',
+        'type': 'String',
+        'editable': false,
+        'value': 'Foo',
+        'binding': {
+          'type': 'property',
+          'name': 'name'
+        }
+      }
+    ],
+    'version': 946684800000,
+    'metadata': {
+      'templateVersionId': 'df7d377e-e543-4d08-abd1-7014151b668f',
+      'catalogOrganizationId': '82527756-ffbe-46bf-a27b-f12880878e77',
+      'created': 946684800000,
+      'updated': 946684800000,
+      'tags': [
+        "Walt's Catalog"
+      ]
+    }
+  }
+];
+
+export const errors = null;

--- a/test/fixtures/scope-connector-missing-binding-legacy.js
+++ b/test/fixtures/scope-connector-missing-binding-legacy.js
@@ -20,46 +20,49 @@ export const template = {
 
 export const errors = [
   {
-    keyword: 'required',
+    keyword: 'errorMessage',
     dataPath: '/scopes/camunda:Connector/properties/0',
-    schemaPath: '#/definitions/properties/items/required',
-    params: { missingProperty: 'binding' },
-    message: "should have required property 'binding'"
+    schemaPath: '#/definitions/properties/items/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'required',
+          dataPath: '/scopes/camunda:Connector/properties/0',
+          schemaPath: '#/definitions/properties/items/required',
+          params: { missingProperty: 'binding' },
+          message: "should have required property 'binding'",
+          emUsed: true
+        }
+      ]
+    },
+    message: 'missing binding for property "0"'
   },
   {
     keyword: 'type',
     dataPath: '/scopes',
-    message: 'should be array',
-    params: {
-      type: 'array'
-    },
-    schemaPath: '#/type'
+    schemaPath: '#/type',
+    params: { type: 'array' },
+    message: 'should be array'
   },
   {
     keyword: 'oneOf',
     dataPath: '/scopes',
-    message: 'should match exactly one schema in oneOf',
-    params: {
-      passingSchemas: null
-    },
-    schemaPath: '#/properties/scopes/oneOf'
+    schemaPath: '#/properties/scopes/oneOf',
+    params: { passingSchemas: null },
+    message: 'should match exactly one schema in oneOf'
   },
   {
-    dataPath: '',
     keyword: 'type',
-    message: 'should be array',
-    params: {
-      type: 'array',
-    },
+    dataPath: '',
     schemaPath: '#/oneOf/1/type',
+    params: { type: 'array' },
+    message: 'should be array'
   },
   {
-    dataPath: '',
     keyword: 'oneOf',
-    message: 'should match exactly one schema in oneOf',
-    params: {
-      passingSchemas: null
-    },
-    schemaPath: '#/oneOf'
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: { passingSchemas: null },
+    message: 'should match exactly one schema in oneOf'
   }
 ];

--- a/test/fixtures/scope-invalid-legacy.js
+++ b/test/fixtures/scope-invalid-legacy.js
@@ -15,58 +15,48 @@ export const template = {
 export const errors = [
   {
     keyword: 'errorMessage',
-    dataPath: '/scopes',
-    schemaPath: '#/errorMessage',
+    dataPath: '/scopes/foo',
+    schemaPath: '#/additionalProperties/errorMessage',
     params: {
       errors: [
         {
-          keyword: 'additionalProperties',
-          emUsed: true,
-          dataPath: '/scopes',
-          schemaPath: '#/additionalProperties',
-          params: {
-            'additionalProperty': 'foo'
-          },
-          message: 'should NOT have additional properties'
+          keyword: 'not',
+          dataPath: '/scopes/foo',
+          schemaPath: '#/additionalProperties/not',
+          params: {},
+          message: 'should NOT be valid',
+          emUsed: true
         }
       ]
     },
-    message: 'invalid scope, object descriptor is only supported for camunda:Connector'
+    message: 'invalid scope "foo", object descriptor is only supported for "camunda:Connector"'
   },
   {
     keyword: 'type',
     dataPath: '/scopes',
-    message: 'should be array',
-    params: {
-      type: 'array'
-    },
-    schemaPath: '#/type'
+    schemaPath: '#/type',
+    params: { type: 'array' },
+    message: 'should be array'
   },
   {
     keyword: 'oneOf',
     dataPath: '/scopes',
-    message: 'should match exactly one schema in oneOf',
-    params: {
-      passingSchemas: null
-    },
-    schemaPath: '#/properties/scopes/oneOf'
+    schemaPath: '#/properties/scopes/oneOf',
+    params: { passingSchemas: null },
+    message: 'should match exactly one schema in oneOf'
   },
   {
-    dataPath: '',
     keyword: 'type',
-    message: 'should be array',
-    params: {
-      type: 'array',
-    },
+    dataPath: '',
     schemaPath: '#/oneOf/1/type',
+    params: { type: 'array' },
+    message: 'should be array'
   },
   {
-    dataPath: '',
     keyword: 'oneOf',
-    message: 'should match exactly one schema in oneOf',
-    params: {
-      passingSchemas: null
-    },
-    schemaPath: '#/oneOf'
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: { passingSchemas: null },
+    message: 'should match exactly one schema in oneOf'
   }
 ];

--- a/test/fixtures/scope-missing-binding.js
+++ b/test/fixtures/scope-missing-binding.js
@@ -28,11 +28,22 @@ export const errors = [
     message: 'should be object'
   },
   {
-    keyword: 'required',
+    keyword: 'errorMessage',
     dataPath: '/scopes/0/properties/0',
-    schemaPath: '#/definitions/properties/items/required',
-    params: { missingProperty: 'binding' },
-    message: "should have required property 'binding'"
+    schemaPath: '#/definitions/properties/items/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'required',
+          dataPath: '/scopes/0/properties/0',
+          schemaPath: '#/definitions/properties/items/required',
+          params: { missingProperty: 'binding' },
+          message: "should have required property 'binding'",
+          emUsed: true
+        }
+      ]
+    },
+    message: 'missing binding for property "0"'
   },
   {
     keyword: 'oneOf',

--- a/test/fixtures/scope-missing-error-id.js
+++ b/test/fixtures/scope-missing-error-id.js
@@ -67,7 +67,7 @@ export const errors = [
         }
       ]
     },
-    message: 'scoped binding of type "bpmn:Error" requires id'
+    message: 'invalid scope "bpmn:Error", missing id'
   },
   {
     keyword: 'if',

--- a/test/fixtures/scope-missing-properties.js
+++ b/test/fixtures/scope-missing-properties.js
@@ -21,11 +21,22 @@ export const errors = [
     message: 'should be object'
   },
   {
-    keyword: 'required',
+    keyword: 'errorMessage',
     dataPath: '/scopes/0',
-    schemaPath: '#/items/required',
-    params: { missingProperty: 'properties' },
-    message: "should have required property 'properties'"
+    schemaPath: '#/items/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'required',
+          dataPath: '/scopes/0',
+          schemaPath: '#/items/required',
+          params: { missingProperty: 'properties' },
+          message: "should have required property 'properties'",
+          emUsed: true
+        }
+      ]
+    },
+    message: 'invalid scope "camunda:Connector", missing properties=[]'
   },
   {
     keyword: 'oneOf',

--- a/test/fixtures/scope-missing-type.js
+++ b/test/fixtures/scope-missing-type.js
@@ -21,11 +21,22 @@ export const errors = [
     message: 'should be object'
   },
   {
-    keyword: 'required',
+    keyword: 'errorMessage',
     dataPath: '/scopes/0',
-    schemaPath: '#/items/required',
-    params: { missingProperty: 'type' },
-    message: "should have required property 'type'"
+    schemaPath: '#/items/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'required',
+          dataPath: '/scopes/0',
+          schemaPath: '#/items/required',
+          params: { missingProperty: 'type' },
+          message: "should have required property 'type'",
+          emUsed: true
+        }
+      ]
+    },
+    message: 'invalid scope, missing type'
   },
   {
     keyword: 'oneOf',

--- a/test/spec/validationSpec.js
+++ b/test/spec/validationSpec.js
@@ -69,6 +69,15 @@ describe('validation', function() {
     testTemplate('missing-applies-to');
 
 
+    testTemplate('missing-template-name');
+
+
+    testTemplate('missing-template-id');
+
+
+    testTemplate('missing-properties');
+
+
     testTemplate('missing-binding');
 
 

--- a/test/spec/validationSpec.js
+++ b/test/spec/validationSpec.js
@@ -132,6 +132,12 @@ describe('validation', function() {
     testTemplate('missing-binding-errorRef');
 
 
+    testTemplate('constraints');
+
+
+    testTemplate('invalid-constraints');
+
+
     describe('property type - binding type', function() {
 
       testTemplate('invalid-property-type');

--- a/test/spec/validationSpec.js
+++ b/test/spec/validationSpec.js
@@ -147,6 +147,8 @@ describe('validation', function() {
     testTemplate('invalid-constraints');
 
 
+    testTemplate('invalid-applies-to');
+
     describe('property type - binding type', function() {
 
       testTemplate('invalid-property-type');

--- a/test/spec/validationSpec.js
+++ b/test/spec/validationSpec.js
@@ -152,6 +152,9 @@ describe('validation', function() {
 
     testTemplate('entries-visible-boolean');
 
+
+    testTemplate('pattern-string');
+
     describe('property type - binding type', function() {
 
       testTemplate('invalid-property-type');

--- a/test/spec/validationSpec.js
+++ b/test/spec/validationSpec.js
@@ -155,6 +155,7 @@ describe('validation', function() {
 
     testTemplate('pattern-string');
 
+
     describe('property type - binding type', function() {
 
       testTemplate('invalid-property-type');
@@ -234,6 +235,12 @@ describe('validation', function() {
 
 
     testTemplate('invalid-multiple-mail-tasks');
+
+
+    testTemplate('complex');
+
+
+    testTemplate('rpa-templates');
 
   });
 

--- a/test/spec/validationSpec.js
+++ b/test/spec/validationSpec.js
@@ -149,6 +149,9 @@ describe('validation', function() {
 
     testTemplate('invalid-applies-to');
 
+
+    testTemplate('entries-visible-boolean');
+
     describe('property type - binding type', function() {
 
       testTemplate('invalid-property-type');


### PR DESCRIPTION
Fix smaller Schema issues while working on camunda/camunda-modeler#2159, especially to align with the existing Properties Panel behavior. That includes
* correct data types for `constraints.{minLength | maxLength}` properties (cf. #24)
* adjust error message for invalid binding type (cf. #25)
* adjust error messages for required properties
* adjust error message for legacy scope type
* adjust error message for `appliesTo` pattern
* fix a test case for template versions
* add additional allowed data types for `entriesVisible` & `property.constraints.pattern`
* add more complex test cases

----

Related to camunda/camunda-modeler#2159
Closes #24 
Closes #25 