### PR TITLE
test: initialize validator only once

### DIFF
--- a/test/spec/validationSpec.js
+++ b/test/spec/validationSpec.js
@@ -8,10 +8,12 @@ import {
   createValidator
 } from '../helpers';
 
+const validator = createValidator(schema);
+
+
 describe('validation', function() {
 
   function validateTemplate(template) {
-    const validator = createValidator(schema);
 
     const valid = validator(template);
 


### PR DESCRIPTION
This ensures we initialize the validator only once for our tests suite. Otherwise, it would compile the schema _every single time_. The schema itself does not change, so there is no need to do this extra.

Also, compare the execution tests for single tests

**Before**

<img width="639" alt="Bildschirmfoto 2021-03-30 um 11 53 25" src="https://user-images.githubusercontent.com/9433996/112971416-7c5f5b00-914f-11eb-8905-274f9a808325.png">

**After**

<img width="628" alt="Bildschirmfoto 2021-03-30 um 11 53 04" src="https://user-images.githubusercontent.com/9433996/112971424-7ec1b500-914f-11eb-8e05-1007a87a8a4e.png">
