### PR TITLE
Split up schema and add C8 JSON Schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,34 @@ You can also use a specific version.
 
 Additionally, it's possible to use the schema on top of existing validation libraries and tools. Follow the [example](./example) for further instructions.
 
+
+## Build and Run
+
+Prepare the project by installing all dependencies:
+
+```sh
+npm install
+```
+
+Then, depending on your use case, bundle [the source schema files](./src) together
+
+```sh
+# bundle all schema files
+npm run build
+
+# bundle platform schema
+npm run build:platform
+
+# bundle cloud schema
+npm run build:cloud
+```
+
+Furthermore, execute the following command to run the generated schema against our tests
+
+```sh
+npm run test
+```
+
 ## License
 
 MIT

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,35 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@apidevtools/json-schema-ref-parser": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.9.tgz",
+      "integrity": "sha512-GBD2Le9w2+lVFoc4vswGI/TjkNIZSVp7+9xPf+X3uidBfWnAeUWmquteSyt0+VCrhNMWj/FTABISQrD3Z/YA+w==",
+      "dev": true,
+      "requires": {
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.6",
+        "call-me-maybe": "^1.0.1",
+        "js-yaml": "^4.1.0"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+          "dev": true
+        },
+        "js-yaml": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+          "dev": true,
+          "requires": {
+            "argparse": "^2.0.1"
+          }
+        }
+      }
+    },
     "@babel/code-frame": {
       "version": "7.12.11",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
@@ -283,6 +312,18 @@
           "dev": true
         }
       }
+    },
+    "@jsdevtools/ono": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
+      "dev": true
+    },
+    "@types/json-schema": {
+      "version": "7.0.9",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
+      "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
+      "dev": true
     },
     "@ungap/promise-all-settled": {
       "version": "1.1.2",
@@ -656,6 +697,12 @@
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
       }
+    },
+    "call-me-maybe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
+      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
+      "dev": true
     },
     "callsites": {
       "version": "3.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1871,6 +1871,12 @@
         }
       }
     },
+    "mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "dev": true
+    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "@camunda/element-templates-json-schema",
   "version": "0.6.0",
   "description": "JSON Schema for (Camunda) Element Templates",
+  "files": [
+    "resources"
+  ],
   "scripts": {
     "lint": "eslint .",
     "test": "mocha -r esm --reporter=spec --recursive test/spec",
@@ -9,7 +12,9 @@
     "all": "run-s build lint test",
     "build": "run-s build:platform build:cloud",
     "build:platform": "node tasks/generate-schema.js --input=./src/platform.json --output=./resources/schema.json",
-    "build:cloud": "node tasks/generate-schema.js --input=./src/cloud.json --output=./resources/cloud.json"
+    "build:cloud": "node tasks/generate-schema.js --input=./src/cloud.json --output=./resources/cloud.json",
+    "prepare": "run-s build",
+    "prepublishOnly": "run-s build test"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "lint": "eslint .",
     "test": "mocha -r esm --reporter=spec --recursive test/spec",
     "dev": "npm run test -- --watch",
-    "all": "run-s lint test"
+    "all": "run-s build:schema lint test",
+    "build:schema": "node tasks/generate-schemas.js"
   },
   "repository": {
     "type": "git",
@@ -24,6 +25,7 @@
   },
   "homepage": "https://github.com/camunda/element-templates-json-schema#readme",
   "devDependencies": {
+    "@apidevtools/json-schema-ref-parser": "^9.0.9",
     "ajv": "^7.2.3",
     "ajv-errors": "^2.0.1",
     "chai": "^4.3.4",

--- a/package.json
+++ b/package.json
@@ -6,8 +6,10 @@
     "lint": "eslint .",
     "test": "mocha -r esm --reporter=spec --recursive test/spec",
     "dev": "npm run test -- --watch",
-    "all": "run-s build:schema lint test",
-    "build:schema": "node tasks/generate-schemas.js"
+    "all": "run-s build lint test",
+    "build": "run-s build:platform build:cloud",
+    "build:platform": "node tasks/generate-schema.js --input=./src/platform.json --output=./resources/schema.json",
+    "build:cloud": "node tasks/generate-schema.js --input=./src/cloud.json --output=./resources/cloud.json"
   },
   "repository": {
     "type": "git",
@@ -33,6 +35,7 @@
     "eslint-plugin-bpmn-io": "^0.13.0",
     "esm": "^3.2.25",
     "mocha": "^8.3.2",
+    "mri": "^1.2.0",
     "npm-run-all": "^4.1.5"
   }
 }

--- a/resources/cloud.json
+++ b/resources/cloud.json
@@ -1,0 +1,535 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "http://camunda.org/schema/cloud-element-templates/1.0",
+  "title": "Cloud Element Template Schema",
+  "description": "A single element template configuration or an array of element template configurations",
+  "definitions": {
+    "properties": {
+      "allOf": [
+        {
+          "type": "array",
+          "title": "element template properties",
+          "description": "The properties of the element template",
+          "default": [],
+          "items": {
+            "type": "object",
+            "title": "element template property",
+            "description": "A property defined for the element template",
+            "default": {},
+            "allOf": [
+              {
+                "if": {
+                  "properties": {
+                    "type": {
+                      "const": "Dropdown"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ]
+                },
+                "then": {
+                  "required": [
+                    "choices"
+                  ],
+                  "errorMessage": "must provide choices=[] with \"Dropdown\" type"
+                }
+              }
+            ],
+            "properties": {
+              "value": {
+                "$id": "#/properties/property/value",
+                "type": [
+                  "string",
+                  "boolean"
+                ],
+                "title": "property value",
+                "description": "The value of the control field for the property"
+              },
+              "description": {
+                "$id": "#/properties/property/description",
+                "type": "string",
+                "title": "property description",
+                "description": "The description of the control field"
+              },
+              "label": {
+                "$id": "#/properties/property/label",
+                "type": "string",
+                "title": "property label",
+                "description": "The label of the control field for the property"
+              },
+              "type": {
+                "$id": "#/properties/property/type",
+                "type": "string",
+                "title": "property type",
+                "description": "The type of the control field"
+              },
+              "editable": {
+                "$id": "#/properties/property/editable",
+                "type": "boolean",
+                "title": "property editable",
+                "description": "Indicates whether the property is editable or not"
+              },
+              "choices": {
+                "$id": "#/properties/property/choices",
+                "type": "array",
+                "title": "property choices",
+                "description": "The choices for dropdown properties",
+                "items": {
+                  "$id": "#/properties/property/choices/item",
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "$id": "#/properties/property/choices/item/name",
+                      "type": "string",
+                      "title": "choice name",
+                      "description": "The name of the choice"
+                    },
+                    "value": {
+                      "$id": "#/properties/property/choices/item/value",
+                      "type": "string",
+                      "title": "choice value",
+                      "description": "The value of the choice"
+                    }
+                  },
+                  "required": [
+                    "value",
+                    "name"
+                  ],
+                  "errorMessage": "{ name, value } must be specified for \"Dropdown\" choices"
+                }
+              },
+              "constraints": {
+                "$id": "#/properties/property/constraints",
+                "type": "object",
+                "title": "property constraints",
+                "description": "The validation constraints",
+                "properties": {
+                  "notEmpty": {
+                    "$id": "#/properties/property/constraints/notEmpty",
+                    "type": "boolean",
+                    "title": "property constraints not empty",
+                    "description": "The control field must not be empty"
+                  },
+                  "minLength": {
+                    "$id": "#/properties/property/constraints/minLength",
+                    "type": "number",
+                    "title": "property constraints min length",
+                    "description": "The minimal length for the control field value"
+                  },
+                  "maxLength": {
+                    "$id": "#/properties/property/constraints/maxLength",
+                    "type": "number",
+                    "title": "property constraints max length",
+                    "description": "The maximal length for the control field value"
+                  },
+                  "pattern": {
+                    "$id": "#/properties/property/constraints/pattern",
+                    "title": "property constraints pattern",
+                    "description": "A regular expression pattern for the constraints",
+                    "oneOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "value": {
+                            "$id": "#/properties/property/constraints/pattern/value",
+                            "type": "string",
+                            "title": "property constraints pattern value",
+                            "description": "The regular expression of the pattern constraint"
+                          },
+                          "message": {
+                            "$id": "#/properties/property/constraints/pattern/message",
+                            "type": "string",
+                            "title": "property constraints pattern message",
+                            "description": "The validation message of the pattern constraint"
+                          }
+                        }
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  }
+                }
+              },
+              "group": {
+                "$id": "#/properties/property/group",
+                "type": "string",
+                "title": "property group",
+                "description": "The custom group of the control field for the property"
+              }
+            }
+          }
+        },
+        {
+          "$schema": "http://json-schema.org/draft-07/schema",
+          "type": "array",
+          "title": "element template properties",
+          "description": "The properties of the element template",
+          "default": [],
+          "items": {
+            "type": "object",
+            "title": "element template property",
+            "description": "A property defined for the element template",
+            "default": {},
+            "required": [
+              "binding"
+            ],
+            "errorMessage": {
+              "required": {
+                "binding": "missing binding for property \"${0#}\""
+              }
+            },
+            "allOf": [
+              {
+                "if": {
+                  "properties": {
+                    "binding": {
+                      "properties": {
+                        "type": {
+                          "const": "property"
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "binding"
+                  ]
+                },
+                "then": {
+                  "properties": {
+                    "type": {
+                      "enum": [
+                        "String",
+                        "Text",
+                        "Hidden",
+                        "Dropdown",
+                        "Boolean"
+                      ],
+                      "errorMessage": "invalid property type ${0} for binding type \"property\"; must be any of { String, Text, Hidden, Dropdown, Boolean }"
+                    }
+                  }
+                }
+              },
+              {
+                "if": {
+                  "properties": {
+                    "binding": {
+                      "properties": {
+                        "type": {
+                          "enum": [
+                            "zeebe:input",
+                            "zeebe:output",
+                            "zeebe:taskHeader",
+                            "zeebe:taskDefinition:type"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "binding"
+                  ]
+                },
+                "then": {
+                  "properties": {
+                    "type": {
+                      "enum": [
+                        "String",
+                        "Text",
+                        "Hidden",
+                        "Dropdown"
+                      ],
+                      "errorMessage": "invalid property type ${0} for binding type ${1/binding/type}; must be any of { String, Text, Hidden, Dropdown }"
+                    }
+                  }
+                }
+              },
+              {
+                "if": {
+                  "properties": {
+                    "optional": {
+                      "const": true
+                    }
+                  },
+                  "required": [
+                    "optional"
+                  ]
+                },
+                "then": {
+                  "properties": {
+                    "binding": {
+                      "properties": {
+                        "type": {
+                          "enum": [
+                            "zeebe:input",
+                            "zeebe:output"
+                          ],
+                          "errorMessage": "optional is not supported for binding type ${0}; must be any of { zeebe:input, zeebe:output }"
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ]
+                    }
+                  }
+                }
+              }
+            ],
+            "properties": {
+              "binding": {
+                "$id": "#/properties/property/binding",
+                "type": "object",
+                "title": "property binding",
+                "description": "A binding to a BPMN 2.0 property",
+                "required": [
+                  "type"
+                ],
+                "allOf": [
+                  {
+                    "if": {
+                      "properties": {
+                        "type": {
+                          "enum": [
+                            "property",
+                            "zeebe:input"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ]
+                    },
+                    "then": {
+                      "required": [
+                        "name"
+                      ],
+                      "errorMessage": "property.binding ${0/type} requires name"
+                    }
+                  },
+                  {
+                    "if": {
+                      "properties": {
+                        "type": {
+                          "const": "zeebe:output"
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ]
+                    },
+                    "then": {
+                      "required": [
+                        "source"
+                      ],
+                      "errorMessage": "property.binding ${0/type} requires source"
+                    }
+                  },
+                  {
+                    "if": {
+                      "properties": {
+                        "type": {
+                          "const": "zeebe:taskHeader"
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ]
+                    },
+                    "then": {
+                      "required": [
+                        "key"
+                      ],
+                      "errorMessage": "property.binding ${0/type} requires key"
+                    }
+                  }
+                ],
+                "properties": {
+                  "type": {
+                    "$id": "#/properties/property/binding/type",
+                    "type": "string",
+                    "title": "property binding type",
+                    "enum": [
+                      "property",
+                      "zeebe:taskDefinition:type",
+                      "zeebe:input",
+                      "zeebe:output",
+                      "zeebe:taskHeader"
+                    ],
+                    "errorMessage": "invalid property.binding type ${0}; must be any of { property, zeebe:taskDefinition:type, zeebe:input, zeebe:output, zeebe:taskHeader }",
+                    "description": "The type of the property binding"
+                  },
+                  "name": {
+                    "$id": "#/properties/property/binding/name",
+                    "type": "string",
+                    "title": "property binding name",
+                    "description": "The name of binding xml property"
+                  },
+                  "source": {
+                    "$id": "#/properties/property/binding/source",
+                    "type": "string",
+                    "title": "property binding source",
+                    "description": "The source value of a property binding (zeebe:output)"
+                  },
+                  "key": {
+                    "$id": "#/properties/property/binding/key",
+                    "type": "string",
+                    "title": "property binding key",
+                    "description": "The key value of a property binding (zeebe:taskHeader)"
+                  }
+                }
+              },
+              "optional": {
+                "$id": "#/optional",
+                "type": "boolean",
+                "title": "element template optional",
+                "description": "Indicates whether a property is optional"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "template": {
+      "type": "object",
+      "allOf": [
+        {
+          "required": [
+            "name",
+            "id",
+            "appliesTo",
+            "properties"
+          ],
+          "properties": {
+            "name": {
+              "$id": "#/name",
+              "type": "string",
+              "title": "element template name",
+              "description": "The name of the element template"
+            },
+            "id": {
+              "$id": "#/id",
+              "type": "string",
+              "title": "element template id",
+              "description": "The identifier of the element template"
+            },
+            "description": {
+              "$id": "#/description",
+              "type": "string",
+              "title": "element template description",
+              "description": "The description of the element template"
+            },
+            "version": {
+              "$id": "#/version",
+              "type": "number",
+              "title": "element template version",
+              "description": "The version of the element template"
+            },
+            "isDefault": {
+              "$id": "#/isDefault",
+              "type": "boolean",
+              "title": "element template is default",
+              "description": "Indicates whether the element template is a default template"
+            },
+            "appliesTo": {
+              "$id": "#/appliesTo",
+              "type": "array",
+              "title": "element template applies to",
+              "description": "The definition for which element types the element template can be applied",
+              "default": [],
+              "items": {
+                "$id": "#/appliesTo/items",
+                "type": "string",
+                "pattern": "^(.*?:)",
+                "errorMessage": {
+                  "pattern": "invalid item for \"appliesTo\", should contain namespaced property, example: \"bpmn:Task\""
+                }
+              }
+            },
+            "metadata": {
+              "$id": "#/metadata",
+              "type": "object",
+              "title": "element template metadata",
+              "description": "Some metadata for further configuration"
+            },
+            "entriesVisible": {
+              "$id": "#/entriesVisible",
+              "type": "boolean",
+              "title": "element template entries visible",
+              "description": "Select whether non-template entries are visible in the properties panel"
+            },
+            "groups": {
+              "$id": "#/groups",
+              "type": "array",
+              "title": "element template properties groups",
+              "description": "The custom defined groups of the element template",
+              "default": [],
+              "items": {
+                "$id": "#/groups/group",
+                "type": "object",
+                "title": "element template group",
+                "description": "A custom defined group for the element template",
+                "default": {},
+                "required": [
+                  "id",
+                  "label"
+                ],
+                "errorMessage": {
+                  "required": {
+                    "id": "missing id for group \"${0#}\"",
+                    "label": "missing label for group \"${0#}\""
+                  }
+                },
+                "properties": {
+                  "id": {
+                    "$id": "#/groups/group/id",
+                    "type": "string",
+                    "title": "group id",
+                    "description": "The id of the custom group"
+                  },
+                  "label": {
+                    "$id": "#/groups/group/label",
+                    "type": "string",
+                    "title": "group label",
+                    "description": "The label of the custom group"
+                  }
+                }
+              }
+            }
+          },
+          "errorMessage": {
+            "required": {
+              "name": "missing template name",
+              "id": "missing template id",
+              "appliesTo": "missing appliesTo=[]",
+              "properties": "missing properties=[]"
+            }
+          }
+        }
+      ],
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/properties",
+          "$id": "#/properties"
+        }
+      }
+    }
+  },
+  "oneOf": [
+    {
+      "$ref": "#/definitions/template"
+    },
+    {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/template"
+      }
+    }
+  ]
+}

--- a/resources/cloud.json
+++ b/resources/cloud.json
@@ -280,6 +280,33 @@
                     }
                   }
                 }
+              },
+              {
+                "if": {
+                  "properties": {
+                    "optional": {
+                      "const": true
+                    }
+                  },
+                  "required": [
+                    "optional"
+                  ]
+                },
+                "then": {
+                  "properties": {
+                    "constraints": {
+                      "properties": {
+                        "notEmpty": {
+                          "const": false,
+                          "errorMessage": "optional is not allowed for truthy \"notEmpty\" constraint"
+                        }
+                      },
+                      "required": [
+                        "notEmpty"
+                      ]
+                    }
+                  }
+                }
               }
             ],
             "properties": {

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -5,260 +5,765 @@
   "description": "A single element template configuration or an array of element template configurations",
   "definitions": {
     "properties": {
-      "type": "array",
-      "title": "element template properties",
-      "description": "The properties of the element template",
-      "default": [],
-      "items": {
-        "$id": "#/properties/property",
-        "type": "object",
-        "title": "element template property",
-        "description": "A property defined for the element template",
-        "default": {},
-        "required": [
-          "binding"
-        ],
-        "errorMessage": {
-          "required": {
-            "binding": "missing binding for property \"${0#}\""
+      "allOf": [
+        {
+          "type": "array",
+          "title": "element template properties",
+          "description": "The properties of the element template",
+          "default": [],
+          "items": {
+            "type": "object",
+            "title": "element template property",
+            "description": "A property defined for the element template",
+            "default": {},
+            "allOf": [
+              {
+                "if": {
+                  "properties": {
+                    "type": {
+                      "const": "Dropdown"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ]
+                },
+                "then": {
+                  "required": [
+                    "choices"
+                  ],
+                  "errorMessage": "must provide choices=[] with \"Dropdown\" type"
+                }
+              }
+            ],
+            "properties": {
+              "value": {
+                "$id": "#/properties/property/value",
+                "type": [
+                  "string",
+                  "boolean"
+                ],
+                "title": "property value",
+                "description": "The value of the control field for the property"
+              },
+              "description": {
+                "$id": "#/properties/property/description",
+                "type": "string",
+                "title": "property description",
+                "description": "The description of the control field"
+              },
+              "label": {
+                "$id": "#/properties/property/label",
+                "type": "string",
+                "title": "property label",
+                "description": "The label of the control field for the property"
+              },
+              "type": {
+                "$id": "#/properties/property/type",
+                "type": "string",
+                "title": "property type",
+                "description": "The type of the control field"
+              },
+              "editable": {
+                "$id": "#/properties/property/editable",
+                "type": "boolean",
+                "title": "property editable",
+                "description": "Indicates whether the property is editable or not"
+              },
+              "choices": {
+                "$id": "#/properties/property/choices",
+                "type": "array",
+                "title": "property choices",
+                "description": "The choices for dropdown properties",
+                "items": {
+                  "$id": "#/properties/property/choices/item",
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "$id": "#/properties/property/choices/item/name",
+                      "type": "string",
+                      "title": "choice name",
+                      "description": "The name of the choice"
+                    },
+                    "value": {
+                      "$id": "#/properties/property/choices/item/value",
+                      "type": "string",
+                      "title": "choice value",
+                      "description": "The value of the choice"
+                    }
+                  },
+                  "required": [
+                    "value",
+                    "name"
+                  ],
+                  "errorMessage": "{ name, value } must be specified for \"Dropdown\" choices"
+                }
+              },
+              "constraints": {
+                "$id": "#/properties/property/constraints",
+                "type": "object",
+                "title": "property constraints",
+                "description": "The validation constraints",
+                "properties": {
+                  "notEmpty": {
+                    "$id": "#/properties/property/constraints/notEmpty",
+                    "type": "boolean",
+                    "title": "property constraints not empty",
+                    "description": "The control field must not be empty"
+                  },
+                  "minLength": {
+                    "$id": "#/properties/property/constraints/minLength",
+                    "type": "number",
+                    "title": "property constraints min length",
+                    "description": "The minimal length for the control field value"
+                  },
+                  "maxLength": {
+                    "$id": "#/properties/property/constraints/maxLength",
+                    "type": "number",
+                    "title": "property constraints max length",
+                    "description": "The maximal length for the control field value"
+                  },
+                  "pattern": {
+                    "$id": "#/properties/property/constraints/pattern",
+                    "title": "property constraints pattern",
+                    "description": "A regular expression pattern for the constraints",
+                    "oneOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "value": {
+                            "$id": "#/properties/property/constraints/pattern/value",
+                            "type": "string",
+                            "title": "property constraints pattern value",
+                            "description": "The regular expression of the pattern constraint"
+                          },
+                          "message": {
+                            "$id": "#/properties/property/constraints/pattern/message",
+                            "type": "string",
+                            "title": "property constraints pattern message",
+                            "description": "The validation message of the pattern constraint"
+                          }
+                        }
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  }
+                }
+              },
+              "group": {
+                "$id": "#/properties/property/group",
+                "type": "string",
+                "title": "property group",
+                "description": "The custom group of the control field for the property"
+              }
+            }
           }
         },
-        "allOf": [
-          {
-            "if": {
-              "properties": {
-                "type": {
-                  "const": "Dropdown"
-                }
-              },
-              "required": [
-                "type"
-              ]
-            },
-            "then": {
-              "required": [
-                "choices"
-              ],
-              "errorMessage": "must provide choices=[] with \"Dropdown\" type"
-            }
-          },
-          {
-            "if": {
-              "properties": {
-                "binding": {
-                  "properties": {
-                    "type": {
-                      "const": "property"
-                    }
-                  },
-                  "required": [
-                    "type"
-                  ]
-                }
-              },
-              "required": [
-                "binding"
-              ]
-            },
-            "then": {
-              "properties": {
-                "type": {
-                  "enum": [
-                    "String",
-                    "Text",
-                    "Hidden",
-                    "Dropdown",
-                    "Boolean"
-                  ],
-                  "errorMessage": "invalid property type ${0} for binding type \"property\"; must be any of { String, Text, Hidden, Dropdown, Boolean }"
-                }
+        {
+          "$schema": "http://json-schema.org/draft-07/schema",
+          "type": "array",
+          "title": "element template properties",
+          "description": "The properties of the element template",
+          "default": [],
+          "items": {
+            "type": "object",
+            "title": "element template property",
+            "description": "A property defined for the element template",
+            "default": {},
+            "required": [
+              "binding"
+            ],
+            "errorMessage": {
+              "required": {
+                "binding": "missing binding for property \"${0#}\""
               }
-            }
-          },
-          {
-            "if": {
-              "properties": {
-                "binding": {
-                  "properties": {
-                    "type": {
-                      "const": "camunda:executionListener"
-                    }
-                  },
-                  "required": [
-                    "type"
-                  ]
-                }
-              },
-              "required": [
-                "binding"
-              ]
             },
-            "then": {
-              "properties": {
-                "type": {
-                  "enum": [
-                    "Hidden"
-                  ],
-                  "errorMessage": "invalid property type ${1/type} for binding type \"camunda:executionListener\"; must be \"Hidden\""
-                }
-              }
-            }
-          },
-          {
-            "if": {
-              "properties": {
-                "binding": {
+            "allOf": [
+              {
+                "if": {
                   "properties": {
-                    "type": {
-                      "enum": [
-                        "camunda:property",
-                        "camunda:outputParameter",
-                        "camunda:in",
-                        "camunda:in:businessKey",
-                        "camunda:out",
-                        "camunda:errorEventDefinition"
+                    "binding": {
+                      "properties": {
+                        "type": {
+                          "const": "property"
+                        }
+                      },
+                      "required": [
+                        "type"
                       ]
                     }
                   },
                   "required": [
-                    "type"
+                    "binding"
                   ]
-                }
-              },
-              "required": [
-                "binding"
-              ]
-            },
-            "then": {
-              "properties": {
-                "type": {
-                  "enum": [
-                    "String",
-                    "Hidden",
-                    "Dropdown"
-                  ],
-                  "errorMessage": "invalid property type ${0} for binding type ${1/binding/type}; must be any of { String, Hidden, Dropdown }"
-                }
-              }
-            }
-          },
-          {
-            "if": {
-              "properties": {
-                "binding": {
+                },
+                "then": {
                   "properties": {
                     "type": {
                       "enum": [
-                        "camunda:inputParameter",
-                        "camunda:field"
+                        "String",
+                        "Text",
+                        "Hidden",
+                        "Dropdown",
+                        "Boolean"
+                      ],
+                      "errorMessage": "invalid property type ${0} for binding type \"property\"; must be any of { String, Text, Hidden, Dropdown, Boolean }"
+                    }
+                  }
+                }
+              },
+              {
+                "if": {
+                  "properties": {
+                    "binding": {
+                      "properties": {
+                        "type": {
+                          "const": "camunda:executionListener"
+                        }
+                      },
+                      "required": [
+                        "type"
                       ]
                     }
                   },
                   "required": [
-                    "type"
+                    "binding"
                   ]
+                },
+                "then": {
+                  "properties": {
+                    "type": {
+                      "enum": [
+                        "Hidden"
+                      ],
+                      "errorMessage": "invalid property type ${1/type} for binding type \"camunda:executionListener\"; must be \"Hidden\""
+                    }
+                  }
                 }
               },
-              "required": [
-                "binding"
-              ]
-            },
-            "then": {
-              "properties": {
-                "type": {
-                  "enum": [
-                    "String",
-                    "Text",
-                    "Hidden",
-                    "Dropdown"
-                  ],
-                  "errorMessage": "invalid property type ${0} for binding type ${1/binding/type}; must be any of { String, Text, Hidden, Dropdown }"
+              {
+                "if": {
+                  "properties": {
+                    "binding": {
+                      "properties": {
+                        "type": {
+                          "enum": [
+                            "camunda:property",
+                            "camunda:outputParameter",
+                            "camunda:in",
+                            "camunda:in:businessKey",
+                            "camunda:out",
+                            "camunda:errorEventDefinition"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "binding"
+                  ]
+                },
+                "then": {
+                  "properties": {
+                    "type": {
+                      "enum": [
+                        "String",
+                        "Hidden",
+                        "Dropdown"
+                      ],
+                      "errorMessage": "invalid property type ${0} for binding type ${1/binding/type}; must be any of { String, Hidden, Dropdown }"
+                    }
+                  }
+                }
+              },
+              {
+                "if": {
+                  "properties": {
+                    "binding": {
+                      "properties": {
+                        "type": {
+                          "enum": [
+                            "camunda:inputParameter",
+                            "camunda:field"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "binding"
+                  ]
+                },
+                "then": {
+                  "properties": {
+                    "type": {
+                      "enum": [
+                        "String",
+                        "Text",
+                        "Hidden",
+                        "Dropdown"
+                      ],
+                      "errorMessage": "invalid property type ${0} for binding type ${1/binding/type}; must be any of { String, Text, Hidden, Dropdown }"
+                    }
+                  }
+                }
+              }
+            ],
+            "properties": {
+              "binding": {
+                "$id": "#/properties/property/binding",
+                "type": "object",
+                "title": "property binding",
+                "description": "A binding to a BPMN 2.0 property",
+                "required": [
+                  "type"
+                ],
+                "allOf": [
+                  {
+                    "if": {
+                      "properties": {
+                        "type": {
+                          "enum": [
+                            "property",
+                            "camunda:property",
+                            "camunda:inputParameter",
+                            "camunda:field"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ]
+                    },
+                    "then": {
+                      "required": [
+                        "name"
+                      ],
+                      "errorMessage": "property.binding ${0/type} requires name"
+                    }
+                  },
+                  {
+                    "if": {
+                      "properties": {
+                        "type": {
+                          "const": "camunda:outputParameter"
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ]
+                    },
+                    "then": {
+                      "required": [
+                        "source"
+                      ],
+                      "errorMessage": "property.binding ${0/type} requires source"
+                    }
+                  },
+                  {
+                    "if": {
+                      "properties": {
+                        "type": {
+                          "const": "camunda:in"
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ]
+                    },
+                    "then": {
+                      "anyOf": [
+                        {
+                          "required": [
+                            "variables"
+                          ]
+                        },
+                        {
+                          "required": [
+                            "target"
+                          ]
+                        }
+                      ],
+                      "errorMessage": "property.binding ${0/type} requires variables, target, or both"
+                    }
+                  },
+                  {
+                    "if": {
+                      "properties": {
+                        "type": {
+                          "const": "camunda:out"
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ]
+                    },
+                    "then": {
+                      "oneOf": [
+                        {
+                          "required": [
+                            "variables"
+                          ],
+                          "not": {
+                            "anyOf": [
+                              {
+                                "required": [
+                                  "source"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "sourceExpression"
+                                ]
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "required": [
+                            "source"
+                          ],
+                          "not": {
+                            "anyOf": [
+                              {
+                                "required": [
+                                  "variables"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "sourceExpression"
+                                ]
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "required": [
+                            "sourceExpression"
+                          ],
+                          "not": {
+                            "anyOf": [
+                              {
+                                "required": [
+                                  "variables"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "source"
+                                ]
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "required": [
+                            "variables",
+                            "sourceExpression"
+                          ],
+                          "not": {
+                            "required": [
+                              "source"
+                            ]
+                          }
+                        },
+                        {
+                          "required": [
+                            "variables",
+                            "source"
+                          ],
+                          "not": {
+                            "required": [
+                              "sourceExpression"
+                            ]
+                          }
+                        }
+                      ],
+                      "errorMessage": "property.binding ${0/type} requires one of the following: variables, sourceExpression, source, (sourceExpression and variables), or (source and variables)"
+                    }
+                  },
+                  {
+                    "if": {
+                      "properties": {
+                        "type": {
+                          "const": "camunda:errorEventDefinition"
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ]
+                    },
+                    "then": {
+                      "oneOf": [
+                        {
+                          "required": [
+                            "errorRef"
+                          ]
+                        }
+                      ],
+                      "errorMessage": "property.binding ${0/type} requires errorRef"
+                    }
+                  }
+                ],
+                "properties": {
+                  "type": {
+                    "$id": "#/properties/property/binding/type",
+                    "type": "string",
+                    "title": "property binding type",
+                    "enum": [
+                      "property",
+                      "camunda:property",
+                      "camunda:inputParameter",
+                      "camunda:outputParameter",
+                      "camunda:in",
+                      "camunda:out",
+                      "camunda:in:businessKey",
+                      "camunda:executionListener",
+                      "camunda:field",
+                      "camunda:errorEventDefinition"
+                    ],
+                    "errorMessage": "invalid property.binding type ${0}; must be any of { property, camunda:property, camunda:inputParameter, camunda:outputParameter, camunda:in, camunda:out, camunda:in:businessKey, camunda:executionListener, camunda:field, camunda:errorEventDefinition }",
+                    "description": "The type of the property binding"
+                  },
+                  "name": {
+                    "$id": "#/properties/property/binding/name",
+                    "type": "string",
+                    "title": "property binding name",
+                    "description": "The name of binding xml property"
+                  },
+                  "event": {
+                    "$id": "#/properties/property/binding/event",
+                    "type": "string",
+                    "title": "property binding event",
+                    "description": "The event type of an execution listener binding"
+                  },
+                  "scriptFormat": {
+                    "$id": "#/properties/property/binding/scriptFormat",
+                    "type": "string",
+                    "title": "property binding script format",
+                    "description": "The format of a script property binding (camunda:outputParameter, camunda:inputParameter)"
+                  },
+                  "source": {
+                    "$id": "#/properties/property/binding/source",
+                    "type": "string",
+                    "title": "property binding source",
+                    "description": "The source value of a property binding (camunda:outputParameter, camunda:out)"
+                  },
+                  "target": {
+                    "$id": "#/properties/property/binding/target",
+                    "type": "string",
+                    "title": "property binding target",
+                    "description": "The target value to be mapped to (camunda:in)"
+                  },
+                  "expression": {
+                    "$id": "#/properties/property/binding/expression",
+                    "type": "boolean",
+                    "title": "property binding expression",
+                    "description": "True indicates that the control field value is an expression (camunda:in, camunda:field)"
+                  },
+                  "variables": {
+                    "$id": "#/properties/property/binding/variables",
+                    "type": "string",
+                    "title": "property binding variables",
+                    "enum": [
+                      "all",
+                      "local"
+                    ],
+                    "description": "Either all or local indicating the variable mapping (camunda:in)"
+                  },
+                  "sourceExpression": {
+                    "$id": "#/properties/property/binding/sourceExpression",
+                    "type": "string",
+                    "title": "property binding source expression",
+                    "description": "The string containing the expression for the source attribute (camunda:out)"
+                  }
                 }
               }
             }
           }
-        ],
-        "properties": {
-          "value": {
-            "$id": "#/properties/property/value",
-            "type": [
-              "string",
-              "boolean"
-            ],
-            "title": "property value",
-            "description": "The value of the control field for the property"
-          },
-          "description": {
-            "$id": "#/properties/property/description",
-            "type": "string",
-            "title": "property description",
-            "description": "The description of the control field"
-          },
-          "label": {
-            "$id": "#/properties/property/label",
-            "type": "string",
-            "title": "property label",
-            "description": "The label of the control field for the property"
-          },
-          "type": {
-            "$id": "#/properties/property/type",
-            "type": "string",
-            "title": "property type",
-            "description": "The type of the control field"
-          },
-          "editable": {
-            "$id": "#/properties/property/editable",
-            "type": "boolean",
-            "title": "property editable",
-            "description": "Indicates whether the property is editable or not"
-          },
-          "choices": {
-            "$id": "#/properties/property/choices",
-            "type": "array",
-            "title": "property choices",
-            "description": "The choices for dropdown properties",
-            "items": {
-              "$id": "#/properties/property/choices/item",
-              "type": "object",
-              "properties": {
-                "name": {
-                  "$id": "#/properties/property/choices/item/name",
-                  "type": "string",
-                  "title": "choice name",
-                  "description": "The name of the choice"
-                },
-                "value": {
-                  "$id": "#/properties/property/choices/item/value",
-                  "type": "string",
-                  "title": "choice value",
-                  "description": "The value of the choice"
+        }
+      ]
+    },
+    "template": {
+      "type": "object",
+      "allOf": [
+        {
+          "required": [
+            "name",
+            "id",
+            "appliesTo",
+            "properties"
+          ],
+          "properties": {
+            "name": {
+              "$id": "#/name",
+              "type": "string",
+              "title": "element template name",
+              "description": "The name of the element template"
+            },
+            "id": {
+              "$id": "#/id",
+              "type": "string",
+              "title": "element template id",
+              "description": "The identifier of the element template"
+            },
+            "description": {
+              "$id": "#/description",
+              "type": "string",
+              "title": "element template description",
+              "description": "The description of the element template"
+            },
+            "version": {
+              "$id": "#/version",
+              "type": "number",
+              "title": "element template version",
+              "description": "The version of the element template"
+            },
+            "isDefault": {
+              "$id": "#/isDefault",
+              "type": "boolean",
+              "title": "element template is default",
+              "description": "Indicates whether the element template is a default template"
+            },
+            "appliesTo": {
+              "$id": "#/appliesTo",
+              "type": "array",
+              "title": "element template applies to",
+              "description": "The definition for which element types the element template can be applied",
+              "default": [],
+              "items": {
+                "$id": "#/appliesTo/items",
+                "type": "string",
+                "pattern": "^(.*?:)",
+                "errorMessage": {
+                  "pattern": "invalid item for \"appliesTo\", should contain namespaced property, example: \"bpmn:Task\""
                 }
-              },
-              "required": [
-                "value",
-                "name"
-              ],
-              "errorMessage": "{ name, value } must be specified for \"Dropdown\" choices"
+              }
+            },
+            "metadata": {
+              "$id": "#/metadata",
+              "type": "object",
+              "title": "element template metadata",
+              "description": "Some metadata for further configuration"
+            },
+            "entriesVisible": {
+              "$id": "#/entriesVisible",
+              "type": "boolean",
+              "title": "element template entries visible",
+              "description": "Select whether non-template entries are visible in the properties panel"
+            },
+            "groups": {
+              "$id": "#/groups",
+              "type": "array",
+              "title": "element template properties groups",
+              "description": "The custom defined groups of the element template",
+              "default": [],
+              "items": {
+                "$id": "#/groups/group",
+                "type": "object",
+                "title": "element template group",
+                "description": "A custom defined group for the element template",
+                "default": {},
+                "required": [
+                  "id",
+                  "label"
+                ],
+                "errorMessage": {
+                  "required": {
+                    "id": "missing id for group \"${0#}\"",
+                    "label": "missing label for group \"${0#}\""
+                  }
+                },
+                "properties": {
+                  "id": {
+                    "$id": "#/groups/group/id",
+                    "type": "string",
+                    "title": "group id",
+                    "description": "The id of the custom group"
+                  },
+                  "label": {
+                    "$id": "#/groups/group/label",
+                    "type": "string",
+                    "title": "group label",
+                    "description": "The label of the custom group"
+                  }
+                }
+              }
             }
           },
-          "binding": {
-            "$id": "#/properties/property/binding",
+          "errorMessage": {
+            "required": {
+              "name": "missing template name",
+              "id": "missing template id",
+              "appliesTo": "missing appliesTo=[]",
+              "properties": "missing properties=[]"
+            }
+          }
+        }
+      ],
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/properties",
+          "$id": "#/properties"
+        },
+        "scopes": {
+          "$id": "#/scopes",
+          "type": "array",
+          "title": "element template scope",
+          "description": "Special scoped bindings that allow you to configure nested elements",
+          "items": {
+            "$id": "#/scopes/item",
             "type": "object",
-            "title": "property binding",
-            "description": "A binding to a BPMN 2.0 property",
+            "title": "element template scope item",
+            "description": "Scoped binding to configure nested elements",
+            "properties": {
+              "type": {
+                "$id": "#scopes/item/type",
+                "type": "string",
+                "enum": [
+                  "camunda:Connector",
+                  "bpmn:Error"
+                ],
+                "errorMessage": "invalid scope type ${0}; must be any of { camunda:Connector, bpmn:Error }"
+              },
+              "properties": {
+                "$id": "#/scopes/properties",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/properties/allOf/0"
+                  },
+                  {
+                    "$ref": "#/definitions/properties/allOf/1"
+                  }
+                ]
+              }
+            },
             "required": [
-              "type"
+              "type",
+              "properties"
             ],
+            "errorMessage": {
+              "required": {
+                "type": "invalid scope, missing type",
+                "properties": "invalid scope ${0/type}, missing properties=[]"
+              }
+            },
             "allOf": [
               {
                 "if": {
                   "properties": {
                     "type": {
                       "enum": [
-                        "property",
-                        "camunda:property",
-                        "camunda:inputParameter",
-                        "camunda:field"
+                        "bpmn:Error"
                       ]
                     }
                   },
@@ -268,488 +773,13 @@
                 },
                 "then": {
                   "required": [
-                    "name"
+                    "id"
                   ],
-                  "errorMessage": "property.binding ${0/type} requires name"
-                }
-              },
-              {
-                "if": {
-                  "properties": {
-                    "type": {
-                      "const": "camunda:outputParameter"
-                    }
-                  },
-                  "required": [
-                    "type"
-                  ]
-                },
-                "then": {
-                  "required": [
-                    "source"
-                  ],
-                  "errorMessage": "property.binding ${0/type} requires source"
-                }
-              },
-              {
-                "if": {
-                  "properties": {
-                    "type": {
-                      "const": "camunda:in"
-                    }
-                  },
-                  "required": [
-                    "type"
-                  ]
-                },
-                "then": {
-                  "anyOf": [
-                    {
-                      "required": [
-                        "variables"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "target"
-                      ]
-                    }
-                  ],
-                  "errorMessage": "property.binding ${0/type} requires variables, target, or both"
-                }
-              },
-              {
-                "if": {
-                  "properties": {
-                    "type": {
-                      "const": "camunda:out"
-                    }
-                  },
-                  "required": [
-                    "type"
-                  ]
-                },
-                "then": {
-                  "oneOf": [
-                    {
-                      "required": [
-                        "variables"
-                      ],
-                      "not": {
-                        "anyOf": [
-                          {
-                            "required": [
-                              "source"
-                            ]
-                          },
-                          {
-                            "required": [
-                              "sourceExpression"
-                            ]
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "required": [
-                        "source"
-                      ],
-                      "not": {
-                        "anyOf": [
-                          {
-                            "required": [
-                              "variables"
-                            ]
-                          },
-                          {
-                            "required": [
-                              "sourceExpression"
-                            ]
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "required": [
-                        "sourceExpression"
-                      ],
-                      "not": {
-                        "anyOf": [
-                          {
-                            "required": [
-                              "variables"
-                            ]
-                          },
-                          {
-                            "required": [
-                              "source"
-                            ]
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "required": [
-                        "variables",
-                        "sourceExpression"
-                      ],
-                      "not": {
-                        "required": [
-                          "source"
-                        ]
-                      }
-                    },
-                    {
-                      "required": [
-                        "variables",
-                        "source"
-                      ],
-                      "not": {
-                        "required": [
-                          "sourceExpression"
-                        ]
-                      }
-                    }
-                  ],
-                  "errorMessage": "property.binding ${0/type} requires one of the following: variables, sourceExpression, source, (sourceExpression and variables), or (source and variables)"
-                }
-              },
-              {
-                "if": {
-                  "properties": {
-                    "type": {
-                      "const": "camunda:errorEventDefinition"
-                    }
-                  },
-                  "required": [
-                    "type"
-                  ]
-                },
-                "then": {
-                  "oneOf": [
-                    {
-                      "required": [
-                        "errorRef"
-                      ]
-                    }
-                  ],
-                  "errorMessage": "property.binding ${0/type} requires errorRef"
+                  "errorMessage": "invalid scope ${0/type}, missing id"
                 }
               }
-            ],
-            "properties": {
-              "type": {
-                "$id": "#/properties/property/binding/type",
-                "type": "string",
-                "title": "property binding type",
-                "enum": [
-                  "property",
-                  "camunda:property",
-                  "camunda:inputParameter",
-                  "camunda:outputParameter",
-                  "camunda:in",
-                  "camunda:out",
-                  "camunda:in:businessKey",
-                  "camunda:executionListener",
-                  "camunda:field",
-                  "camunda:errorEventDefinition"
-                ],
-                "errorMessage": "invalid property.binding type ${0}; must be any of { property, camunda:property, camunda:inputParameter, camunda:outputParameter, camunda:in, camunda:out, camunda:in:businessKey, camunda:executionListener, camunda:field, camunda:errorEventDefinition }",
-                "description": "The type of the property binding"
-              },
-              "name": {
-                "$id": "#/properties/property/binding/name",
-                "type": "string",
-                "title": "property binding name",
-                "description": "The name of binding xml property"
-              },
-              "event": {
-                "$id": "#/properties/property/binding/event",
-                "type": "string",
-                "title": "property binding event",
-                "description": "The event type of an execution listener binding"
-              },
-              "scriptFormat": {
-                "$id": "#/properties/property/binding/scriptFormat",
-                "type": "string",
-                "title": "property binding script format",
-                "description": "The format of a script property binding (camunda:outputParameter, camunda:inputParameter)"
-              },
-              "source": {
-                "$id": "#/properties/property/binding/source",
-                "type": "string",
-                "title": "property binding source",
-                "description": "The source value of a property binding (camunda:outputParameter, camunda:out)"
-              },
-              "target": {
-                "$id": "#/properties/property/binding/target",
-                "type": "string",
-                "title": "property binding target",
-                "description": "The target value to be mapped to (camunda:in)"
-              },
-              "expression": {
-                "$id": "#/properties/property/binding/expression",
-                "type": "boolean",
-                "title": "property binding expression",
-                "description": "True indicates that the control field value is an expression (camunda:in, camunda:field)"
-              },
-              "variables": {
-                "$id": "#/properties/property/binding/variables",
-                "type": "string",
-                "title": "property binding variables",
-                "enum": [
-                  "all",
-                  "local"
-                ],
-                "description": "Either all or local indicating the variable mapping (camunda:in)"
-              },
-              "sourceExpression": {
-                "$id": "#/properties/property/binding/sourceExpression",
-                "type": "string",
-                "title": "property binding source expression",
-                "description": "The string containing the expression for the source attribute (camunda:out)"
-              }
-            }
-          },
-          "constraints": {
-            "$id": "#/properties/property/constraints",
-            "type": "object",
-            "title": "property constraints",
-            "description": "The validation constraints",
-            "properties": {
-              "notEmpty": {
-                "$id": "#/properties/property/constraints/notEmpty",
-                "type": "boolean",
-                "title": "property constraints not empty",
-                "description": "The control field must not be empty"
-              },
-              "minLength": {
-                "$id": "#/properties/property/constraints/minLength",
-                "type": "number",
-                "title": "property constraints min length",
-                "description": "The minimal length for the control field value"
-              },
-              "maxLength": {
-                "$id": "#/properties/property/constraints/maxLength",
-                "type": "number",
-                "title": "property constraints max length",
-                "description": "The maximal length for the control field value"
-              },
-              "pattern": {
-                "$id": "#/properties/property/constraints/pattern",
-                "title": "property constraints pattern",
-                "description": "A regular expression pattern for the constraints",
-                "oneOf": [
-                  {
-                    "type": "object",
-                    "properties": {
-                      "value": {
-                        "$id": "#/properties/property/constraints/pattern/value",
-                        "type": "string",
-                        "title": "property constraints pattern value",
-                        "description": "The regular expression of the pattern constraint"
-                      },
-                      "message": {
-                        "$id": "#/properties/property/constraints/pattern/message",
-                        "type": "string",
-                        "title": "property constraints pattern message",
-                        "description": "The validation message of the pattern constraint"
-                      }
-                    }
-                  },
-                  {
-                    "type": "string"
-                  }
-                ]
-              }
-            }
-          },
-          "group": {
-            "$id": "#/properties/property/group",
-            "type": "string",
-            "title": "property group",
-            "description": "The custom group of the control field for the property"
+            ]
           }
-        }
-      }
-    },
-    "scopes": {
-      "$id": "#/definitions/scopes",
-      "type": "array",
-      "title": "element template scope",
-      "description": "Special scoped bindings that allow you to configure nested elements",
-      "items": {
-        "$id": "#/scopes/item",
-        "type": "object",
-        "title": "element template scope item",
-        "description": "Scoped binding to configure nested elements",
-        "properties": {
-          "type": {
-            "$id": "#scopes/item/type",
-            "type": "string",
-            "enum": [
-              "camunda:Connector",
-              "bpmn:Error"
-            ],
-            "errorMessage": "invalid scope type ${0}; must be any of { camunda:Connector, bpmn:Error }"
-          },
-          "properties": {
-            "$ref": "#/definitions/properties"
-          }
-        },
-        "required": [
-          "type",
-          "properties"
-        ],
-        "errorMessage": {
-          "required": {
-            "type": "invalid scope, missing type",
-            "properties": "invalid scope ${0/type}, missing properties=[]"
-          }
-        },
-        "allOf": [
-          {
-            "if": {
-              "properties": {
-                "type": {
-                  "enum": [
-                    "bpmn:Error"
-                  ]
-                }
-              },
-              "required": [
-                "type"
-              ]
-            },
-            "then": {
-              "required": [
-                "id"
-              ],
-              "errorMessage": "invalid scope ${0/type}, missing id"
-            }
-          }
-        ]
-      }
-    },
-    "template": {
-      "type": "object",
-      "required": [
-        "name",
-        "id",
-        "appliesTo",
-        "properties"
-      ],
-      "properties": {
-        "name": {
-          "$id": "#/name",
-          "type": "string",
-          "title": "element template name",
-          "description": "The name of the element template"
-        },
-        "id": {
-          "$id": "#/id",
-          "type": "string",
-          "title": "element template id",
-          "description": "The identifier of the element template"
-        },
-        "description": {
-          "$id": "#/description",
-          "type": "string",
-          "title": "element template description",
-          "description": "The description of the element template"
-        },
-        "version": {
-          "$id": "#/version",
-          "type": "number",
-          "title": "element template version",
-          "description": "The version of the element template"
-        },
-        "isDefault": {
-          "$id": "#/isDefault",
-          "type": "boolean",
-          "title": "element template is default",
-          "description": "Indicates whether the element template is a default template"
-        },
-        "appliesTo": {
-          "$id": "#/appliesTo",
-          "type": "array",
-          "title": "element template applies to",
-          "description": "The definition for which element types the element template can be applied",
-          "default": [],
-          "items": {
-            "$id": "#/appliesTo/items",
-            "type": "string",
-            "pattern": "^(.*?:)",
-            "errorMessage": {
-              "pattern": "invalid item for \"appliesTo\", should contain namespaced property, example: \"bpmn:Task\""
-            }
-          }
-        },
-        "properties": {
-          "$ref": "#/definitions/properties",
-          "$id": "#/properties"
-        },
-        "metadata": {
-          "$id": "#/metadata",
-          "type": "object",
-          "title": "element template metadata",
-          "description": "Some metadata for further configuration"
-        },
-        "scopes": {
-          "$ref": "#/definitions/scopes",
-          "$id": "#/scopes"
-        },
-        "entriesVisible": {
-          "$id": "#/entriesVisible",
-          "type": "boolean",
-          "title": "element template entries visible",
-          "description": "Select whether non-template entries are visible in the properties panel"
-        },
-        "groups": {
-          "$id": "#/groups",
-          "type": "array",
-          "title": "element template properties groups",
-          "description": "The custom defined groups of the element template",
-          "default": [],
-          "items": {
-            "$id": "#/groups/group",
-            "type": "object",
-            "title": "element template group",
-            "description": "A custom defined group for the element template",
-            "default": {},
-            "required": [
-              "id",
-              "label"
-            ],
-            "errorMessage": {
-              "required": {
-                "id": "missing id for group \"${0#}\"",
-                "label": "missing label for group \"${0#}\""
-              }
-            },
-            "properties": {
-              "id": {
-                "$id": "#/groups/group/id",
-                "type": "string",
-                "title": "group id",
-                "description": "The id of the custom group"
-              },
-              "label": {
-                "$id": "#/groups/group/label",
-                "type": "string",
-                "title": "group label",
-                "description": "The label of the custom group"
-              }
-            }
-          }
-        }
-      },
-      "errorMessage": {
-        "required": {
-          "name": "missing template name",
-          "id": "missing template id",
-          "appliesTo": "missing appliesTo=[]",
-          "properties": "missing properties=[]"
         }
       }
     }

--- a/src/cloud.json
+++ b/src/cloud.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "http://camunda.org/schema/cloud-element-templates/1.0",
+  "title": "Cloud Element Template Schema",
+  "description": "A single element template configuration or an array of element template configurations",
+  "definitions": {
+    "properties": {
+      "allOf": [
+        {
+          "$ref": "src/defs/base-properties.json"
+        },
+        {
+          "$ref": "src/defs/cloud-properties.json"
+        }
+      ]
+    },
+    "template": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "src/defs/base.json"
+        }
+      ],
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/properties",
+          "$id": "#/properties"
+        }
+      }
+    }
+  },
+  "oneOf": [
+    {
+      "$ref": "#/definitions/template"
+    },
+    {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/template"
+      }
+    }
+  ]
+}

--- a/src/defs/base-properties.json
+++ b/src/defs/base-properties.json
@@ -1,0 +1,155 @@
+{
+  "type": "array",
+  "title": "element template properties",
+  "description": "The properties of the element template",
+  "default": [],
+  "items": {
+    "type": "object",
+    "title": "element template property",
+    "description": "A property defined for the element template",
+    "default": {},
+    "allOf": [
+      {
+        "if": {
+          "properties": {
+            "type": {
+              "const": "Dropdown"
+            }
+          },
+          "required": [
+            "type"
+          ]
+        },
+        "then": {
+          "required": [
+            "choices"
+          ],
+          "errorMessage": "must provide choices=[] with \"Dropdown\" type"
+        }
+      }
+    ],
+    "properties": {
+      "value": {
+        "$id": "#/properties/property/value",
+        "type": [
+          "string",
+          "boolean"
+        ],
+        "title": "property value",
+        "description": "The value of the control field for the property"
+      },
+      "description": {
+        "$id": "#/properties/property/description",
+        "type": "string",
+        "title": "property description",
+        "description": "The description of the control field"
+      },
+      "label": {
+        "$id": "#/properties/property/label",
+        "type": "string",
+        "title": "property label",
+        "description": "The label of the control field for the property"
+      },
+      "type": {
+        "$id": "#/properties/property/type",
+        "type": "string",
+        "title": "property type",
+        "description": "The type of the control field"
+      },
+      "editable": {
+        "$id": "#/properties/property/editable",
+        "type": "boolean",
+        "title": "property editable",
+        "description": "Indicates whether the property is editable or not"
+      },
+      "choices": {
+        "$id": "#/properties/property/choices",
+        "type": "array",
+        "title": "property choices",
+        "description": "The choices for dropdown properties",
+        "items": {
+          "$id": "#/properties/property/choices/item",
+          "type": "object",
+          "properties": {
+            "name": {
+              "$id": "#/properties/property/choices/item/name",
+              "type": "string",
+              "title": "choice name",
+              "description": "The name of the choice"
+            },
+            "value": {
+              "$id": "#/properties/property/choices/item/value",
+              "type": "string",
+              "title": "choice value",
+              "description": "The value of the choice"
+            }
+          },
+          "required": [
+            "value",
+            "name"
+          ],
+          "errorMessage": "{ name, value } must be specified for \"Dropdown\" choices"
+        }
+      },
+      "constraints": {
+        "$id": "#/properties/property/constraints",
+        "type": "object",
+        "title": "property constraints",
+        "description": "The validation constraints",
+        "properties": {
+          "notEmpty": {
+            "$id": "#/properties/property/constraints/notEmpty",
+            "type": "boolean",
+            "title": "property constraints not empty",
+            "description": "The control field must not be empty"
+          },
+          "minLength": {
+            "$id": "#/properties/property/constraints/minLength",
+            "type": "number",
+            "title": "property constraints min length",
+            "description": "The minimal length for the control field value"
+          },
+          "maxLength": {
+            "$id": "#/properties/property/constraints/maxLength",
+            "type": "number",
+            "title": "property constraints max length",
+            "description": "The maximal length for the control field value"
+          },
+          "pattern": {
+            "$id": "#/properties/property/constraints/pattern",
+            "title": "property constraints pattern",
+            "description": "A regular expression pattern for the constraints",
+            "oneOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "value": {
+                    "$id": "#/properties/property/constraints/pattern/value",
+                    "type": "string",
+                    "title": "property constraints pattern value",
+                    "description": "The regular expression of the pattern constraint"
+                  },
+                  "message": {
+                    "$id": "#/properties/property/constraints/pattern/message",
+                    "type": "string",
+                    "title": "property constraints pattern message",
+                    "description": "The validation message of the pattern constraint"
+                  }
+                }
+              },
+              {
+                "type": "string"
+              }
+            ]
+          }
+        }
+      },
+      "group": {
+        "$id": "#/properties/property/group",
+        "type": "string",
+        "title": "property group",
+        "description": "The custom group of the control field for the property"
+      }
+    }
+  }
+}

--- a/src/defs/base.json
+++ b/src/defs/base.json
@@ -1,0 +1,78 @@
+{
+  "required": [
+    "name",
+    "id",
+    "appliesTo",
+    "properties"
+  ],
+  "properties": {
+    "name": {
+      "$id": "#/name",
+      "type": "string",
+      "title": "element template name",
+      "description": "The name of the element template"
+    },
+    "id": {
+      "$id": "#/id",
+      "type": "string",
+      "title": "element template id",
+      "description": "The identifier of the element template"
+    },
+    "description": {
+      "$id": "#/description",
+      "type": "string",
+      "title": "element template description",
+      "description": "The description of the element template"
+    },
+    "version": {
+      "$id": "#/version",
+      "type": "number",
+      "title": "element template version",
+      "description": "The version of the element template"
+    },
+    "isDefault": {
+      "$id": "#/isDefault",
+      "type": "boolean",
+      "title": "element template is default",
+      "description": "Indicates whether the element template is a default template"
+    },
+    "appliesTo": {
+      "$id": "#/appliesTo",
+      "type": "array",
+      "title": "element template applies to",
+      "description": "The definition for which element types the element template can be applied",
+      "default": [],
+      "items": {
+        "$id": "#/appliesTo/items",
+        "type": "string",
+        "pattern": "^(.*?:)",
+        "errorMessage": {
+          "pattern": "invalid item for \"appliesTo\", should contain namespaced property, example: \"bpmn:Task\""
+        }
+      }
+    },
+    "metadata": {
+      "$id": "#/metadata",
+      "type": "object",
+      "title": "element template metadata",
+      "description": "Some metadata for further configuration"
+    },
+    "entriesVisible": {
+      "$id": "#/entriesVisible",
+      "type": "boolean",
+      "title": "element template entries visible",
+      "description": "Select whether non-template entries are visible in the properties panel"
+    },
+    "groups": {
+      "$ref": "groups.json"
+    }
+  },
+  "errorMessage": {
+    "required": {
+      "name": "missing template name",
+      "id": "missing template id",
+      "appliesTo": "missing appliesTo=[]",
+      "properties": "missing properties=[]"
+    }
+  }
+}

--- a/src/defs/cloud-properties.json
+++ b/src/defs/cloud-properties.json
@@ -117,6 +117,33 @@
             }
           }
         }
+      },
+      {
+        "if": {
+          "properties": {
+            "optional": {
+              "const": true
+            }
+          },
+          "required": [
+            "optional"
+          ]
+        },
+        "then": {
+          "properties": {
+            "constraints": {
+              "properties": {
+                "notEmpty": {
+                  "const": false,
+                  "errorMessage": "optional is not allowed for truthy \"notEmpty\" constraint"
+                }
+              },
+              "required": [
+                "notEmpty"
+              ]
+            }
+          }
+        }
       }
     ],
     "properties": {

--- a/src/defs/cloud-properties.json
+++ b/src/defs/cloud-properties.json
@@ -1,0 +1,233 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "type": "array",
+  "title": "element template properties",
+  "description": "The properties of the element template",
+  "default": [],
+  "items": {
+    "type": "object",
+    "title": "element template property",
+    "description": "A property defined for the element template",
+    "default": {},
+    "required": [
+      "binding"
+    ],
+    "errorMessage": {
+      "required": {
+        "binding": "missing binding for property \"${0#}\""
+      }
+    },
+    "allOf": [
+      {
+        "if": {
+          "properties": {
+            "binding": {
+              "properties": {
+                "type": {
+                  "const": "property"
+                }
+              },
+              "required": [
+                "type"
+              ]
+            }
+          },
+          "required": [
+            "binding"
+          ]
+        },
+        "then": {
+          "properties": {
+            "type": {
+              "enum": [
+                "String",
+                "Text",
+                "Hidden",
+                "Dropdown",
+                "Boolean"
+              ],
+              "errorMessage": "invalid property type ${0} for binding type \"property\"; must be any of { String, Text, Hidden, Dropdown, Boolean }"
+            }
+          }
+        }
+      },
+      {
+        "if": {
+          "properties": {
+            "binding": {
+              "properties": {
+                "type": {
+                  "enum": [
+                    "zeebe:input",
+                    "zeebe:output",
+                    "zeebe:taskHeader",
+                    "zeebe:taskDefinition:type"
+                  ]
+                }
+              },
+              "required": [
+                "type"
+              ]
+            }
+          },
+          "required": [
+            "binding"
+          ]
+        },
+        "then": {
+          "properties": {
+            "type": {
+              "enum": [
+                "String",
+                "Text",
+                "Hidden",
+                "Dropdown"
+              ],
+              "errorMessage": "invalid property type ${0} for binding type ${1/binding/type}; must be any of { String, Text, Hidden, Dropdown }"
+            }
+          }
+        }
+      },
+      {
+        "if": {
+          "properties": {
+            "optional": {
+              "const": true
+            }
+          },
+          "required": [
+            "optional"
+          ]
+        },
+        "then": {
+          "properties": {
+            "binding": {
+              "properties": {
+                "type": {
+                  "enum": [
+                    "zeebe:input",
+                    "zeebe:output"
+                  ],
+                  "errorMessage": "optional is not supported for binding type ${0}; must be any of { zeebe:input, zeebe:output }"
+                }
+              },
+              "required": [
+                "type"
+              ]
+            }
+          }
+        }
+      }
+    ],
+    "properties": {
+      "binding": {
+        "$id": "#/properties/property/binding",
+        "type": "object",
+        "title": "property binding",
+        "description": "A binding to a BPMN 2.0 property",
+        "required": [
+          "type"
+        ],
+        "allOf": [
+          {
+            "if": {
+              "properties": {
+                "type": {
+                  "enum": [
+                    "property",
+                    "zeebe:input"
+                  ]
+                }
+              },
+              "required": [
+                "type"
+              ]
+            },
+            "then": {
+              "required": [
+                "name"
+              ],
+              "errorMessage": "property.binding ${0/type} requires name"
+            }
+          },
+          {
+            "if": {
+              "properties": {
+                "type": {
+                  "const": "zeebe:output"
+                }
+              },
+              "required": [
+                "type"
+              ]
+            },
+            "then": {
+              "required": [
+                "source"
+              ],
+              "errorMessage": "property.binding ${0/type} requires source"
+            }
+          },
+          {
+            "if": {
+              "properties": {
+                "type": {
+                  "const": "zeebe:taskHeader"
+                }
+              },
+              "required": [
+                "type"
+              ]
+            },
+            "then": {
+              "required": [
+                "key"
+              ],
+              "errorMessage": "property.binding ${0/type} requires key"
+            }
+          }
+        ],
+        "properties": {
+          "type": {
+            "$id": "#/properties/property/binding/type",
+            "type": "string",
+            "title": "property binding type",
+            "enum": [
+              "property",
+              "zeebe:taskDefinition:type",
+              "zeebe:input",
+              "zeebe:output",
+              "zeebe:taskHeader"
+            ],
+            "errorMessage": "invalid property.binding type ${0}; must be any of { property, zeebe:taskDefinition:type, zeebe:input, zeebe:output, zeebe:taskHeader }",
+            "description": "The type of the property binding"
+          },
+          "name": {
+            "$id": "#/properties/property/binding/name",
+            "type": "string",
+            "title": "property binding name",
+            "description": "The name of binding xml property"
+          },
+          "source": {
+            "$id": "#/properties/property/binding/source",
+            "type": "string",
+            "title": "property binding source",
+            "description": "The source value of a property binding (zeebe:output)"
+          },
+          "key": {
+            "$id": "#/properties/property/binding/key",
+            "type": "string",
+            "title": "property binding key",
+            "description": "The key value of a property binding (zeebe:taskHeader)"
+          }
+        }
+      },
+      "optional": {
+        "$id": "#/optional",
+        "type": "boolean",
+        "title": "element template optional",
+        "description": "Indicates whether a property is optional"
+      }
+    }
+  }
+}

--- a/src/defs/groups.json
+++ b/src/defs/groups.json
@@ -1,0 +1,38 @@
+{
+  "$id": "#/groups",
+  "type": "array",
+  "title": "element template properties groups",
+  "description": "The custom defined groups of the element template",
+  "default": [],
+  "items": {
+    "$id": "#/groups/group",
+    "type": "object",
+    "title": "element template group",
+    "description": "A custom defined group for the element template",
+    "default": {},
+    "required": [
+      "id",
+      "label"
+    ],
+    "errorMessage": {
+      "required": {
+        "id": "missing id for group \"${0#}\"",
+        "label": "missing label for group \"${0#}\""
+      }
+    },
+    "properties": {
+      "id": {
+        "$id": "#/groups/group/id",
+        "type": "string",
+        "title": "group id",
+        "description": "The id of the custom group"
+      },
+      "label": {
+        "$id": "#/groups/group/label",
+        "type": "string",
+        "title": "group label",
+        "description": "The label of the custom group"
+      }
+    }
+  }
+}

--- a/src/defs/platform-properties.json
+++ b/src/defs/platform-properties.json
@@ -1,0 +1,430 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "type": "array",
+  "title": "element template properties",
+  "description": "The properties of the element template",
+  "default": [],
+  "items": {
+    "type": "object",
+    "title": "element template property",
+    "description": "A property defined for the element template",
+    "default": {},
+    "required": [
+      "binding"
+    ],
+    "errorMessage": {
+      "required": {
+        "binding": "missing binding for property \"${0#}\""
+      }
+    },
+    "allOf": [
+      {
+        "if": {
+          "properties": {
+            "binding": {
+              "properties": {
+                "type": {
+                  "const": "property"
+                }
+              },
+              "required": [
+                "type"
+              ]
+            }
+          },
+          "required": [
+            "binding"
+          ]
+        },
+        "then": {
+          "properties": {
+            "type": {
+              "enum": [
+                "String",
+                "Text",
+                "Hidden",
+                "Dropdown",
+                "Boolean"
+              ],
+              "errorMessage": "invalid property type ${0} for binding type \"property\"; must be any of { String, Text, Hidden, Dropdown, Boolean }"
+            }
+          }
+        }
+      },
+      {
+        "if": {
+          "properties": {
+            "binding": {
+              "properties": {
+                "type": {
+                  "const": "camunda:executionListener"
+                }
+              },
+              "required": [
+                "type"
+              ]
+            }
+          },
+          "required": [
+            "binding"
+          ]
+        },
+        "then": {
+          "properties": {
+            "type": {
+              "enum": [
+                "Hidden"
+              ],
+              "errorMessage": "invalid property type ${1/type} for binding type \"camunda:executionListener\"; must be \"Hidden\""
+            }
+          }
+        }
+      },
+      {
+        "if": {
+          "properties": {
+            "binding": {
+              "properties": {
+                "type": {
+                  "enum": [
+                    "camunda:property",
+                    "camunda:outputParameter",
+                    "camunda:in",
+                    "camunda:in:businessKey",
+                    "camunda:out",
+                    "camunda:errorEventDefinition"
+                  ]
+                }
+              },
+              "required": [
+                "type"
+              ]
+            }
+          },
+          "required": [
+            "binding"
+          ]
+        },
+        "then": {
+          "properties": {
+            "type": {
+              "enum": [
+                "String",
+                "Hidden",
+                "Dropdown"
+              ],
+              "errorMessage": "invalid property type ${0} for binding type ${1/binding/type}; must be any of { String, Hidden, Dropdown }"
+            }
+          }
+        }
+      },
+      {
+        "if": {
+          "properties": {
+            "binding": {
+              "properties": {
+                "type": {
+                  "enum": [
+                    "camunda:inputParameter",
+                    "camunda:field"
+                  ]
+                }
+              },
+              "required": [
+                "type"
+              ]
+            }
+          },
+          "required": [
+            "binding"
+          ]
+        },
+        "then": {
+          "properties": {
+            "type": {
+              "enum": [
+                "String",
+                "Text",
+                "Hidden",
+                "Dropdown"
+              ],
+              "errorMessage": "invalid property type ${0} for binding type ${1/binding/type}; must be any of { String, Text, Hidden, Dropdown }"
+            }
+          }
+        }
+      }
+    ],
+    "properties": {
+      "binding": {
+        "$id": "#/properties/property/binding",
+        "type": "object",
+        "title": "property binding",
+        "description": "A binding to a BPMN 2.0 property",
+        "required": [
+          "type"
+        ],
+        "allOf": [
+          {
+            "if": {
+              "properties": {
+                "type": {
+                  "enum": [
+                    "property",
+                    "camunda:property",
+                    "camunda:inputParameter",
+                    "camunda:field"
+                  ]
+                }
+              },
+              "required": [
+                "type"
+              ]
+            },
+            "then": {
+              "required": [
+                "name"
+              ],
+              "errorMessage": "property.binding ${0/type} requires name"
+            }
+          },
+          {
+            "if": {
+              "properties": {
+                "type": {
+                  "const": "camunda:outputParameter"
+                }
+              },
+              "required": [
+                "type"
+              ]
+            },
+            "then": {
+              "required": [
+                "source"
+              ],
+              "errorMessage": "property.binding ${0/type} requires source"
+            }
+          },
+          {
+            "if": {
+              "properties": {
+                "type": {
+                  "const": "camunda:in"
+                }
+              },
+              "required": [
+                "type"
+              ]
+            },
+            "then": {
+              "anyOf": [
+                {
+                  "required": [
+                    "variables"
+                  ]
+                },
+                {
+                  "required": [
+                    "target"
+                  ]
+                }
+              ],
+              "errorMessage": "property.binding ${0/type} requires variables, target, or both"
+            }
+          },
+          {
+            "if": {
+              "properties": {
+                "type": {
+                  "const": "camunda:out"
+                }
+              },
+              "required": [
+                "type"
+              ]
+            },
+            "then": {
+              "oneOf": [
+                {
+                  "required": [
+                    "variables"
+                  ],
+                  "not": {
+                    "anyOf": [
+                      {
+                        "required": [
+                          "source"
+                        ]
+                      },
+                      {
+                        "required": [
+                          "sourceExpression"
+                        ]
+                      }
+                    ]
+                  }
+                },
+                {
+                  "required": [
+                    "source"
+                  ],
+                  "not": {
+                    "anyOf": [
+                      {
+                        "required": [
+                          "variables"
+                        ]
+                      },
+                      {
+                        "required": [
+                          "sourceExpression"
+                        ]
+                      }
+                    ]
+                  }
+                },
+                {
+                  "required": [
+                    "sourceExpression"
+                  ],
+                  "not": {
+                    "anyOf": [
+                      {
+                        "required": [
+                          "variables"
+                        ]
+                      },
+                      {
+                        "required": [
+                          "source"
+                        ]
+                      }
+                    ]
+                  }
+                },
+                {
+                  "required": [
+                    "variables",
+                    "sourceExpression"
+                  ],
+                  "not": {
+                    "required": [
+                      "source"
+                    ]
+                  }
+                },
+                {
+                  "required": [
+                    "variables",
+                    "source"
+                  ],
+                  "not": {
+                    "required": [
+                      "sourceExpression"
+                    ]
+                  }
+                }
+              ],
+              "errorMessage": "property.binding ${0/type} requires one of the following: variables, sourceExpression, source, (sourceExpression and variables), or (source and variables)"
+            }
+          },
+          {
+            "if": {
+              "properties": {
+                "type": {
+                  "const": "camunda:errorEventDefinition"
+                }
+              },
+              "required": [
+                "type"
+              ]
+            },
+            "then": {
+              "oneOf": [
+                {
+                  "required": [
+                    "errorRef"
+                  ]
+                }
+              ],
+              "errorMessage": "property.binding ${0/type} requires errorRef"
+            }
+          }
+        ],
+        "properties": {
+          "type": {
+            "$id": "#/properties/property/binding/type",
+            "type": "string",
+            "title": "property binding type",
+            "enum": [
+              "property",
+              "camunda:property",
+              "camunda:inputParameter",
+              "camunda:outputParameter",
+              "camunda:in",
+              "camunda:out",
+              "camunda:in:businessKey",
+              "camunda:executionListener",
+              "camunda:field",
+              "camunda:errorEventDefinition"
+            ],
+            "errorMessage": "invalid property.binding type ${0}; must be any of { property, camunda:property, camunda:inputParameter, camunda:outputParameter, camunda:in, camunda:out, camunda:in:businessKey, camunda:executionListener, camunda:field, camunda:errorEventDefinition }",
+            "description": "The type of the property binding"
+          },
+          "name": {
+            "$id": "#/properties/property/binding/name",
+            "type": "string",
+            "title": "property binding name",
+            "description": "The name of binding xml property"
+          },
+          "event": {
+            "$id": "#/properties/property/binding/event",
+            "type": "string",
+            "title": "property binding event",
+            "description": "The event type of an execution listener binding"
+          },
+          "scriptFormat": {
+            "$id": "#/properties/property/binding/scriptFormat",
+            "type": "string",
+            "title": "property binding script format",
+            "description": "The format of a script property binding (camunda:outputParameter, camunda:inputParameter)"
+          },
+          "source": {
+            "$id": "#/properties/property/binding/source",
+            "type": "string",
+            "title": "property binding source",
+            "description": "The source value of a property binding (camunda:outputParameter, camunda:out)"
+          },
+          "target": {
+            "$id": "#/properties/property/binding/target",
+            "type": "string",
+            "title": "property binding target",
+            "description": "The target value to be mapped to (camunda:in)"
+          },
+          "expression": {
+            "$id": "#/properties/property/binding/expression",
+            "type": "boolean",
+            "title": "property binding expression",
+            "description": "True indicates that the control field value is an expression (camunda:in, camunda:field)"
+          },
+          "variables": {
+            "$id": "#/properties/property/binding/variables",
+            "type": "string",
+            "title": "property binding variables",
+            "enum": [
+              "all",
+              "local"
+            ],
+            "description": "Either all or local indicating the variable mapping (camunda:in)"
+          },
+          "sourceExpression": {
+            "$id": "#/properties/property/binding/sourceExpression",
+            "type": "string",
+            "title": "property binding source expression",
+            "description": "The string containing the expression for the source attribute (camunda:out)"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/defs/scopes.json
+++ b/src/defs/scopes.json
@@ -1,0 +1,66 @@
+{
+  "$id": "#/scopes",
+  "type": "array",
+  "title": "element template scope",
+  "description": "Special scoped bindings that allow you to configure nested elements",
+  "items": {
+    "$id": "#/scopes/item",
+    "type": "object",
+    "title": "element template scope item",
+    "description": "Scoped binding to configure nested elements",
+    "properties": {
+      "type": {
+        "$id": "#scopes/item/type",
+        "type": "string",
+        "enum": [
+          "camunda:Connector",
+          "bpmn:Error"
+        ],
+        "errorMessage": "invalid scope type ${0}; must be any of { camunda:Connector, bpmn:Error }"
+      },
+      "properties": {
+        "$id": "#/scopes/properties",
+        "allOf": [
+          {
+            "$ref": "base-properties.json"
+          },
+          {
+            "$ref": "platform-properties.json"
+          }
+        ]
+      }
+    },
+    "required": [
+      "type",
+      "properties"
+    ],
+    "errorMessage": {
+      "required": {
+        "type": "invalid scope, missing type",
+        "properties": "invalid scope ${0/type}, missing properties=[]"
+      }
+    },
+    "allOf": [
+      {
+        "if": {
+          "properties": {
+            "type": {
+              "enum": [
+                "bpmn:Error"
+              ]
+            }
+          },
+          "required": [
+            "type"
+          ]
+        },
+        "then": {
+          "required": [
+            "id"
+          ],
+          "errorMessage": "invalid scope ${0/type}, missing id"
+        }
+      }
+    ]
+  }
+}

--- a/src/platform.json
+++ b/src/platform.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "http://camunda.org/schema/element-templates/1.0",
+  "title": "Element Template Schema",
+  "description": "A single element template configuration or an array of element template configurations",
+  "definitions": {
+    "properties": {
+      "allOf": [
+        {
+          "$ref": "src/defs/base-properties.json"
+        },
+        {
+          "$ref": "src/defs/platform-properties.json"
+        }
+      ]
+    },
+    "template": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "src/defs/base.json"
+        }
+      ],
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/properties",
+          "$id": "#/properties"
+        },
+        "scopes": {
+          "$ref": "src/defs/scopes.json",
+          "$id": "#/scopes"
+        }
+      }
+    }
+  },
+  "oneOf": [
+    {
+      "$ref": "#/definitions/template"
+    },
+    {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/template"
+      }
+    }
+  ]
+}

--- a/tasks/generate-schema.js
+++ b/tasks/generate-schema.js
@@ -1,14 +1,16 @@
 const util = require('util');
 const refParser = require('@apidevtools/json-schema-ref-parser');
 
-const writeFile = require('fs').writeFileSync,
+const readFile = require('fs').readFileSync,
+      writeFile = require('fs').writeFileSync,
       mkdir = require('fs').mkdirSync;
 
 const pathJoin = require('path').join,
       dirname = require('path').dirname;
 
-const platformSchema = require('../src/platform.json');
-const cloudSchema = require('../src/cloud.json');
+const mri = require('mri');
+
+const argv = process.argv.slice(2);
 
 
 async function bundleSchema(schema, path) {
@@ -23,7 +25,7 @@ async function bundleSchema(schema, path) {
 
 
 function writeSchema(schema, path) {
-  const filePath = pathJoin('resources', path);
+  const filePath = pathJoin(path);
 
   try {
     mkdir(dirname(filePath));
@@ -38,11 +40,23 @@ function writeSchema(schema, path) {
 }
 
 
-// (1) generate Camunda Platform JSON Schema (C7)
-bundleSchema(platformSchema, 'schema.json');
+const {
+  input,
+  output
+} = mri(argv, {
+  alias: {
+    i: 'input',
+    o: 'output'
+  }
+});
 
-// (2) generate Camunda Cloud JSON Schema (C8)
-bundleSchema(cloudSchema, 'cloud.json');
+if (!input || !output) {
+  console.error('Arguments missing.');
+  console.error('Example: node tasks/generate-schema.js --input=./src/platform.json --output=./resources/schema.json');
+  process.exit(1);
+}
+
+bundleSchema(JSON.parse(readFile(input)), output);
 
 
 // helper /////////////

--- a/tasks/generate-schemas.js
+++ b/tasks/generate-schemas.js
@@ -1,0 +1,57 @@
+const util = require('util');
+const refParser = require('@apidevtools/json-schema-ref-parser');
+
+const writeFile = require('fs').writeFileSync,
+      mkdir = require('fs').mkdirSync;
+
+const pathJoin = require('path').join,
+      dirname = require('path').dirname;
+
+const platformSchema = require('../src/platform.json');
+const cloudSchema = require('../src/cloud.json');
+
+
+async function bundleSchema(schema, path) {
+  try {
+    const plainSchema = await refParser.bundle(schema);
+    return writeSchema(plainSchema, path);
+  } catch (e) {
+    console.error(e);
+    process.exit(1);
+  }
+}
+
+
+function writeSchema(schema, path) {
+  const filePath = pathJoin('resources', path);
+
+  try {
+    mkdir(dirname(filePath));
+  } catch {
+
+    // directory may already exist
+  }
+
+  writeFile(filePath, JSON.stringify(schema, 0, 2));
+
+  return filePath;
+}
+
+
+// (1) generate Camunda Platform JSON Schema (C7)
+bundleSchema(platformSchema, 'schema.json');
+
+// (2) generate Camunda Cloud JSON Schema (C8)
+bundleSchema(cloudSchema, 'cloud.json');
+
+
+// helper /////////////
+
+// eslint-disable-next-line no-unused-vars
+function printNested(object) {
+  console.log(util.inspect(object, {
+    showHidden: false,
+    depth: null,
+    colors: true
+  }));
+}

--- a/test/fixtures/applies-to-single.js
+++ b/test/fixtures/applies-to-single.js
@@ -9,7 +9,7 @@ export const errors = [
   {
     keyword: 'type',
     dataPath: '/appliesTo',
-    schemaPath: '#/properties/appliesTo/type',
+    schemaPath: '#/allOf/0/properties/appliesTo/type',
     params: { type: 'array' },
     message: 'should be array'
   },

--- a/test/fixtures/choices-missing-name.js
+++ b/test/fixtures/choices-missing-name.js
@@ -25,14 +25,14 @@ export const errors = [
   {
     keyword: 'errorMessage',
     dataPath: '/properties/0/choices/1',
-    schemaPath: '#/definitions/properties/items/properties/choices/items/errorMessage',
+    schemaPath: '#/definitions/properties/allOf/0/items/properties/choices/items/errorMessage',
     params: {
       errors: [
         {
           keyword: 'required',
           emUsed: true,
           dataPath: '/properties/0/choices/1',
-          schemaPath: '#/definitions/properties/items/properties/choices/items/required',
+          schemaPath: '#/definitions/properties/allOf/0/items/properties/choices/items/required',
           params: {
             missingProperty: 'name'
           },

--- a/test/fixtures/choices-missing-value.js
+++ b/test/fixtures/choices-missing-value.js
@@ -25,14 +25,14 @@ export const errors = [
   {
     keyword: 'errorMessage',
     dataPath: '/properties/0/choices/1',
-    schemaPath: '#/definitions/properties/items/properties/choices/items/errorMessage',
+    schemaPath: '#/definitions/properties/allOf/0/items/properties/choices/items/errorMessage',
     params: {
       errors: [
         {
           keyword: 'required',
           emUsed: true,
           dataPath: '/properties/0/choices/1',
-          schemaPath: '#/definitions/properties/items/properties/choices/items/required',
+          schemaPath: '#/definitions/properties/allOf/0/items/properties/choices/items/required',
           params: {
             missingProperty: 'value'
           },

--- a/test/fixtures/cloud-optional-inputs-outputs.js
+++ b/test/fixtures/cloud-optional-inputs-outputs.js
@@ -1,0 +1,30 @@
+export const template = {
+  'name': 'REST Connector',
+  'id': 'io.camunda.connectors.RestConnector-s1',
+  'description': 'A generic REST service.',
+  'appliesTo': [
+    'bpmn:ServiceTask'
+  ],
+  'properties': [
+    {
+      'label': 'Request Body',
+      'type': 'String',
+      'optional': true,
+      'binding': {
+        'type': 'zeebe:input',
+        'name': 'body'
+      }
+    },
+    {
+      'label': 'Result Variable',
+      'type': 'String',
+      'optional': true,
+      'binding': {
+        'type': 'zeebe:output',
+        'source': '= body'
+      }
+    }
+  ]
+};
+
+export const errors = null;

--- a/test/fixtures/cloud-optional-invalid-not-empty.js
+++ b/test/fixtures/cloud-optional-invalid-not-empty.js
@@ -1,0 +1,97 @@
+export const template = {
+  'name': 'REST Connector',
+  'id': 'io.camunda.connectors.RestConnector-s1',
+  'description': 'A generic REST service.',
+  'appliesTo': [
+    'bpmn:ServiceTask'
+  ],
+  'properties': [
+    {
+      'label': 'Request Body',
+      'type': 'String',
+      'optional': true,
+      'binding': {
+        'type': 'zeebe:input',
+        'name': 'body'
+      },
+      'constraints': {
+        'notEmpty': false
+      }
+    },
+    {
+      'label': 'Result Variable',
+      'type': 'String',
+      'optional': true,
+      'binding': {
+        'type': 'zeebe:input',
+        'name': 'key'
+      },
+      'constraints': {
+        'notEmpty': true
+      }
+    },
+    {
+      'label': 'foo',
+      'type': 'String',
+      'optional': true,
+      'binding': {
+        'type': 'zeebe:input',
+        'name': 'body'
+      }
+    },
+    {
+      'label': 'bar',
+      'type': 'String',
+      'optional': false,
+      'binding': {
+        'type': 'zeebe:input',
+        'name': 'body'
+      },
+      'constraints': {
+        'notEmpty': true
+      }
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'errorMessage',
+    dataPath: '/properties/1/constraints/notEmpty',
+    schemaPath: '#/definitions/properties/allOf/1/items/allOf/3/then/properties/constraints/properties/notEmpty/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'const',
+          dataPath: '/properties/1/constraints/notEmpty',
+          schemaPath: '#/definitions/properties/allOf/1/items/allOf/3/then/properties/constraints/properties/notEmpty/const',
+          params: { allowedValue: false },
+          message: 'should be equal to constant',
+          emUsed: true
+        }
+      ]
+    },
+    message: 'optional is not allowed for truthy "notEmpty" constraint'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/1',
+    schemaPath: '#/definitions/properties/allOf/1/items/allOf/3/if',
+    params: { failingKeyword: 'then' },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: { type: 'array' },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: { passingSchemas: null },
+    message: 'should match exactly one schema in oneOf'
+  }
+];

--- a/test/fixtures/cloud-optional-invalid-type.js
+++ b/test/fixtures/cloud-optional-invalid-type.js
@@ -1,0 +1,70 @@
+export const template = {
+  'name': 'REST Connector',
+  'id': 'io.camunda.connectors.RestConnector-s1',
+  'description': 'A generic REST service.',
+  'appliesTo': [
+    'bpmn:ServiceTask'
+  ],
+  'properties': [
+    {
+      'label': 'Request Body',
+      'type': 'String',
+      'optional': true,
+      'binding': {
+        'type': 'zeebe:input',
+        'name': 'body'
+      }
+    },
+    {
+      'label': 'Result Variable',
+      'type': 'String',
+      'optional': true,
+      'binding': {
+        'type': 'zeebe:taskHeader',
+        'key': 'key'
+      }
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'errorMessage',
+    dataPath: '/properties/1/binding/type',
+    schemaPath: '#/definitions/properties/allOf/1/items/allOf/2/then/properties/binding/properties/type/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'enum',
+          dataPath: '/properties/1/binding/type',
+          schemaPath: '#/definitions/properties/allOf/1/items/allOf/2/then/properties/binding/properties/type/enum',
+          params: { allowedValues: [ 'zeebe:input', 'zeebe:output' ] },
+          message: 'should be equal to one of the allowed values',
+          emUsed: true
+        }
+      ]
+    },
+    message: 'optional is not supported for binding type "zeebe:taskHeader"; must be any of { zeebe:input, zeebe:output }'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/1',
+    schemaPath: '#/definitions/properties/allOf/1/items/allOf/2/if',
+    params: { failingKeyword: 'then' },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: { type: 'array' },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: { passingSchemas: null },
+    message: 'should match exactly one schema in oneOf'
+  }
+];

--- a/test/fixtures/cloud-rest-connector.js
+++ b/test/fixtures/cloud-rest-connector.js
@@ -1,0 +1,73 @@
+export const template = {
+  'name': 'REST Connector',
+  'id': 'io.camunda.connectors.RestConnector-s1',
+  'description': 'A generic REST service.',
+  'appliesTo': [
+    'bpmn:ServiceTask'
+  ],
+  'properties': [
+    {
+      'type': 'Hidden',
+      'value': 'http',
+      'binding': {
+        'type': 'zeebe:taskDefinition:type'
+      }
+    },
+    {
+      'label': 'REST Endpoint URL',
+      'description': 'Specify the url of the REST API to talk to.',
+      'type': 'String',
+      'binding': {
+        'type': 'zeebe:taskHeader',
+        'key': 'url'
+      },
+      'constraints': {
+        'notEmpty': true,
+        'pattern': {
+          'value': '^https?://.*',
+          'message': 'Must be http(s) URL.'
+        }
+      }
+    },
+    {
+      'label': 'REST Method',
+      'description': 'Specify the HTTP method to use.',
+      'type': 'Dropdown',
+      'value': 'get',
+      'choices': [
+        { 'name': 'GET', 'value': 'get' },
+        { 'name': 'POST', 'value': 'post' },
+        { 'name': 'PATCH', 'value': 'patch' },
+        { 'name': 'DELETE', 'value': 'delete' }
+      ],
+      'binding': {
+        'type': 'zeebe:taskHeader',
+        'key': 'method'
+      }
+    },
+    {
+      'label': 'Request Body',
+      'description': 'Data to send to the endpoint.',
+      'value': '',
+      'type': 'String',
+      'optional': true,
+      'binding': {
+        'type': 'zeebe:input',
+        'name': 'body'
+      }
+    },
+    {
+      'label': 'Result Variable',
+      'description': 'Name of variable to store the response data in.',
+      'value': 'response',
+      'type': 'String',
+      'optional': true,
+      'binding': {
+        'type': 'zeebe:output',
+        'source': '= body'
+      }
+    }
+  ]
+};
+
+export const errors = null;

--- a/test/fixtures/constraints.js
+++ b/test/fixtures/constraints.js
@@ -10,7 +10,7 @@ export const template = {
       'type': 'String',
       'value': '45',
       'binding': {
-        'type': 'camunda:inputParameter',
+        'type': 'property',
         'name': 'shoeSize'
       },
       'constraints': {

--- a/test/fixtures/entries-visible-deprecated.js
+++ b/test/fixtures/entries-visible-deprecated.js
@@ -15,7 +15,7 @@ export const errors = [
   {
     keyword: 'type',
     dataPath: '/entriesVisible',
-    schemaPath: '#/properties/entriesVisible/type',
+    schemaPath: '#/allOf/0/properties/entriesVisible/type',
     params: { type: 'boolean' },
     message: 'should be boolean'
   },

--- a/test/fixtures/groups-missing-id.js
+++ b/test/fixtures/groups-missing-id.js
@@ -16,13 +16,13 @@ export const errors = [
   {
     keyword: 'errorMessage',
     dataPath: '/groups/0',
-    schemaPath: '#/properties/groups/items/errorMessage',
+    schemaPath: '#/allOf/0/properties/groups/items/errorMessage',
     params: {
       errors: [
         {
           keyword: 'required',
           dataPath: '/groups/0',
-          schemaPath: '#/properties/groups/items/required',
+          schemaPath: '#/allOf/0/properties/groups/items/required',
           params: { missingProperty: 'id' },
           message: "should have required property 'id'",
           emUsed: true

--- a/test/fixtures/groups-missing-label.js
+++ b/test/fixtures/groups-missing-label.js
@@ -16,13 +16,13 @@ export const errors = [
   {
     keyword: 'errorMessage',
     dataPath: '/groups/0',
-    schemaPath: '#/properties/groups/items/errorMessage',
+    schemaPath: '#/allOf/0/properties/groups/items/errorMessage',
     params: {
       errors: [
         {
           keyword: 'required',
           dataPath: '/groups/0',
-          schemaPath: '#/properties/groups/items/required',
+          schemaPath: '#/allOf/0/properties/groups/items/required',
           params: { missingProperty: 'label' },
           message: "should have required property 'label'",
           emUsed: true

--- a/test/fixtures/groups.js
+++ b/test/fixtures/groups.js
@@ -9,7 +9,7 @@ export const template = {
       'label': 'input 1',
       'type': 'String',
       'binding': {
-        'type': 'camunda:inputParameter',
+        'type': 'property',
         'name': 'input1'
       }
     },
@@ -18,7 +18,7 @@ export const template = {
       'group': 'one',
       'type': 'String',
       'binding': {
-        'type': 'camunda:inputParameter',
+        'type': 'property',
         'name': 'input2'
       }
     },
@@ -27,7 +27,7 @@ export const template = {
       'group': 'one',
       'type': 'String',
       'binding': {
-        'type': 'camunda:inputParameter',
+        'type': 'property',
         'name': 'input3'
       }
     },
@@ -36,7 +36,7 @@ export const template = {
       'group': 'two',
       'type': 'String',
       'binding': {
-        'type': 'camunda:inputParameter',
+        'type': 'property',
         'name': 'input4'
       }
     },
@@ -45,7 +45,7 @@ export const template = {
       'group': 'three',
       'type': 'String',
       'binding': {
-        'type': 'camunda:inputParameter',
+        'type': 'property',
         'name': 'input5'
       }
     }

--- a/test/fixtures/invalid-applies-to.js
+++ b/test/fixtures/invalid-applies-to.js
@@ -9,13 +9,13 @@ export const errors = [
   {
     keyword: 'errorMessage',
     dataPath: '/appliesTo/0',
-    schemaPath: '#/properties/appliesTo/items/errorMessage',
+    schemaPath: '#/allOf/0/properties/appliesTo/items/errorMessage',
     params: {
       errors: [
         {
           keyword: 'pattern',
           dataPath: '/appliesTo/0',
-          schemaPath: '#/properties/appliesTo/items/pattern',
+          schemaPath: '#/allOf/0/properties/appliesTo/items/pattern',
           params: { pattern: '^(.*?:)' },
           message: 'should match pattern "^(.*?:)"',
           emUsed: true

--- a/test/fixtures/invalid-binding-type-cloud.js
+++ b/test/fixtures/invalid-binding-type-cloud.js
@@ -1,0 +1,72 @@
+export const template = {
+  'name': 'InvalidBindingType',
+  'id': 'com.camunda.example.InvalidBindingType',
+  'appliesTo': [
+    'bpmn:Task'
+  ],
+  'properties': [
+    {
+      'label': 'Are you awesome?',
+      'type': 'String',
+      'binding': {
+        'type': 'property',
+        'name': 'foo'
+      }
+    },
+    {
+      'label': 'Are you awesome?',
+      'type': 'String',
+      'value': true,
+      'binding': {
+        'type': 'foo'
+      }
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'errorMessage',
+    dataPath: '/properties/1/binding/type',
+    schemaPath: '#/definitions/properties/allOf/1/items/properties/binding/properties/type/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'enum',
+          emUsed: true,
+          dataPath: '/properties/1/binding/type',
+          schemaPath: '#/definitions/properties/allOf/1/items/properties/binding/properties/type/enum',
+          params: {
+            allowedValues: [
+              'property',
+              'zeebe:taskDefinition:type',
+              'zeebe:input',
+              'zeebe:output',
+              'zeebe:taskHeader'
+            ]
+          },
+          message: 'should be equal to one of the allowed values'
+        }
+      ]
+    },
+    message: 'invalid property.binding type "foo"; must be any of { property, zeebe:taskDefinition:type, zeebe:input, zeebe:output, zeebe:taskHeader }'
+  },
+  {
+    dataPath: '',
+    keyword: 'type',
+    message: 'should be array',
+    params: {
+      type: 'array',
+    },
+    schemaPath: '#/oneOf/1/type',
+  },
+  {
+    dataPath: '',
+    keyword: 'oneOf',
+    message: 'should match exactly one schema in oneOf',
+    params: {
+      passingSchemas: null
+    },
+    schemaPath: '#/oneOf'
+  }
+];

--- a/test/fixtures/invalid-binding-type.js
+++ b/test/fixtures/invalid-binding-type.js
@@ -28,14 +28,14 @@ export const errors = [
   {
     keyword: 'errorMessage',
     dataPath: '/properties/1/binding/type',
-    schemaPath: '#/definitions/properties/items/properties/binding/properties/type/errorMessage',
+    schemaPath: '#/definitions/properties/allOf/1/items/properties/binding/properties/type/errorMessage',
     params: {
       errors: [
         {
           keyword: 'enum',
           emUsed: true,
           dataPath: '/properties/1/binding/type',
-          schemaPath: '#/definitions/properties/items/properties/binding/properties/type/enum',
+          schemaPath: '#/definitions/properties/allOf/1/items/properties/binding/properties/type/enum',
           params: {
             allowedValues: [
               'property',

--- a/test/fixtures/invalid-camunda-error-event-definition-type.js
+++ b/test/fixtures/invalid-camunda-error-event-definition-type.js
@@ -49,14 +49,14 @@ export const errors = [
   {
     keyword: 'errorMessage',
     dataPath: '/properties/0/type',
-    schemaPath: '#/definitions/properties/items/allOf/3/then/properties/type/errorMessage',
+    schemaPath: '#/definitions/properties/allOf/1/items/allOf/2/then/properties/type/errorMessage',
     params: {
       errors: [
         {
           keyword: 'enum',
           emUsed: true,
           dataPath: '/properties/0/type',
-          schemaPath: '#/definitions/properties/items/allOf/3/then/properties/type/enum',
+          schemaPath: '#/definitions/properties/allOf/1/items/allOf/2/then/properties/type/enum',
           params: { allowedValues: [ 'String', 'Hidden', 'Dropdown' ] },
           message: 'should be equal to one of the allowed values'
         }
@@ -67,7 +67,7 @@ export const errors = [
   {
     keyword: 'if',
     dataPath: '/properties/0',
-    schemaPath: '#/definitions/properties/items/allOf/3/if',
+    schemaPath: '#/definitions/properties/allOf/1/items/allOf/2/if',
     params: { failingKeyword: 'then' },
     message: 'should match "then" schema'
   },

--- a/test/fixtures/invalid-camunda-in-business-key-type.js
+++ b/test/fixtures/invalid-camunda-in-business-key-type.js
@@ -19,14 +19,14 @@ export const errors = [
   {
     keyword: 'errorMessage',
     dataPath: '/properties/0/type',
-    schemaPath: '#/definitions/properties/items/allOf/3/then/properties/type/errorMessage',
+    schemaPath: '#/definitions/properties/allOf/1/items/allOf/2/then/properties/type/errorMessage',
     params: {
       errors: [
         {
           keyword: 'enum',
           emUsed: true,
           dataPath: '/properties/0/type',
-          schemaPath: '#/definitions/properties/items/allOf/3/then/properties/type/enum',
+          schemaPath: '#/definitions/properties/allOf/1/items/allOf/2/then/properties/type/enum',
           params: {
             'allowedValues': [
               'String',
@@ -43,7 +43,7 @@ export const errors = [
   {
     keyword: 'if',
     dataPath: '/properties/0',
-    schemaPath: '#/definitions/properties/items/allOf/3/if',
+    schemaPath: '#/definitions/properties/allOf/1/items/allOf/2/if',
     params: {
       'failingKeyword': 'then'
     },

--- a/test/fixtures/invalid-camunda-in-type.js
+++ b/test/fixtures/invalid-camunda-in-type.js
@@ -20,14 +20,14 @@ export const errors = [
   {
     keyword: 'errorMessage',
     dataPath: '/properties/0/type',
-    schemaPath: '#/definitions/properties/items/allOf/3/then/properties/type/errorMessage',
+    schemaPath: '#/definitions/properties/allOf/1/items/allOf/2/then/properties/type/errorMessage',
     params: {
       errors: [
         {
           keyword: 'enum',
           emUsed: true,
           dataPath: '/properties/0/type',
-          schemaPath: '#/definitions/properties/items/allOf/3/then/properties/type/enum',
+          schemaPath: '#/definitions/properties/allOf/1/items/allOf/2/then/properties/type/enum',
           params: {
             'allowedValues': [
               'String',
@@ -44,7 +44,7 @@ export const errors = [
   {
     keyword: 'if',
     dataPath: '/properties/0',
-    schemaPath: '#/definitions/properties/items/allOf/3/if',
+    schemaPath: '#/definitions/properties/allOf/1/items/allOf/2/if',
     params: {
       'failingKeyword': 'then'
     },

--- a/test/fixtures/invalid-camunda-out-overloaded.js
+++ b/test/fixtures/invalid-camunda-out-overloaded.js
@@ -21,13 +21,13 @@ export const errors = [
   {
     'keyword': 'errorMessage',
     'dataPath': '/properties/0/binding',
-    'schemaPath': '#/definitions/properties/items/properties/binding/allOf/3/then/errorMessage',
+    'schemaPath': '#/definitions/properties/allOf/1/items/properties/binding/allOf/3/then/errorMessage',
     'params': {
       'errors': [
         {
           'keyword': 'not',
           'dataPath': '/properties/0/binding',
-          'schemaPath': '#/definitions/properties/items/properties/binding/allOf/3/then/oneOf/0/not',
+          'schemaPath': '#/definitions/properties/allOf/1/items/properties/binding/allOf/3/then/oneOf/0/not',
           'params': {},
           'message': 'should NOT be valid',
           'emUsed': true
@@ -35,7 +35,7 @@ export const errors = [
         {
           'keyword': 'required',
           'dataPath': '/properties/0/binding',
-          'schemaPath': '#/definitions/properties/items/properties/binding/allOf/3/then/oneOf/0/required',
+          'schemaPath': '#/definitions/properties/allOf/1/items/properties/binding/allOf/3/then/oneOf/0/required',
           'params': {
             'missingProperty': 'variables'
           },
@@ -45,7 +45,7 @@ export const errors = [
         {
           'keyword': 'not',
           'dataPath': '/properties/0/binding',
-          'schemaPath': '#/definitions/properties/items/properties/binding/allOf/3/then/oneOf/1/not',
+          'schemaPath': '#/definitions/properties/allOf/1/items/properties/binding/allOf/3/then/oneOf/1/not',
           'params': {},
           'message': 'should NOT be valid',
           'emUsed': true
@@ -53,7 +53,7 @@ export const errors = [
         {
           'keyword': 'not',
           'dataPath': '/properties/0/binding',
-          'schemaPath': '#/definitions/properties/items/properties/binding/allOf/3/then/oneOf/2/not',
+          'schemaPath': '#/definitions/properties/allOf/1/items/properties/binding/allOf/3/then/oneOf/2/not',
           'params': {},
           'message': 'should NOT be valid',
           'emUsed': true
@@ -61,7 +61,7 @@ export const errors = [
         {
           'keyword': 'not',
           'dataPath': '/properties/0/binding',
-          'schemaPath': '#/definitions/properties/items/properties/binding/allOf/3/then/oneOf/3/not',
+          'schemaPath': '#/definitions/properties/allOf/1/items/properties/binding/allOf/3/then/oneOf/3/not',
           'params': {},
           'message': 'should NOT be valid',
           'emUsed': true
@@ -69,7 +69,7 @@ export const errors = [
         {
           'keyword': 'required',
           'dataPath': '/properties/0/binding',
-          'schemaPath': '#/definitions/properties/items/properties/binding/allOf/3/then/oneOf/3/required',
+          'schemaPath': '#/definitions/properties/allOf/1/items/properties/binding/allOf/3/then/oneOf/3/required',
           'params': {
             'missingProperty': 'variables'
           },
@@ -79,7 +79,7 @@ export const errors = [
         {
           'keyword': 'not',
           'dataPath': '/properties/0/binding',
-          'schemaPath': '#/definitions/properties/items/properties/binding/allOf/3/then/oneOf/4/not',
+          'schemaPath': '#/definitions/properties/allOf/1/items/properties/binding/allOf/3/then/oneOf/4/not',
           'params': {},
           'message': 'should NOT be valid',
           'emUsed': true
@@ -87,7 +87,7 @@ export const errors = [
         {
           'keyword': 'required',
           'dataPath': '/properties/0/binding',
-          'schemaPath': '#/definitions/properties/items/properties/binding/allOf/3/then/oneOf/4/required',
+          'schemaPath': '#/definitions/properties/allOf/1/items/properties/binding/allOf/3/then/oneOf/4/required',
           'params': {
             'missingProperty': 'variables'
           },
@@ -97,7 +97,7 @@ export const errors = [
         {
           'keyword': 'oneOf',
           'dataPath': '/properties/0/binding',
-          'schemaPath': '#/definitions/properties/items/properties/binding/allOf/3/then/oneOf',
+          'schemaPath': '#/definitions/properties/allOf/1/items/properties/binding/allOf/3/then/oneOf',
           'params': {
             'passingSchemas': null
           },
@@ -111,7 +111,7 @@ export const errors = [
   {
     'keyword': 'if',
     'dataPath': '/properties/0/binding',
-    'schemaPath': '#/definitions/properties/items/properties/binding/allOf/3/if',
+    'schemaPath': '#/definitions/properties/allOf/1/items/properties/binding/allOf/3/if',
     'params': {
       'failingKeyword': 'then'
     },

--- a/test/fixtures/invalid-camunda-out-type.js
+++ b/test/fixtures/invalid-camunda-out-type.js
@@ -20,14 +20,14 @@ export const errors = [
   {
     keyword: 'errorMessage',
     dataPath: '/properties/0/type',
-    schemaPath: '#/definitions/properties/items/allOf/3/then/properties/type/errorMessage',
+    schemaPath: '#/definitions/properties/allOf/1/items/allOf/2/then/properties/type/errorMessage',
     params: {
       errors: [
         {
           keyword: 'enum',
           emUsed: true,
           dataPath: '/properties/0/type',
-          schemaPath: '#/definitions/properties/items/allOf/3/then/properties/type/enum',
+          schemaPath: '#/definitions/properties/allOf/1/items/allOf/2/then/properties/type/enum',
           params: {
             'allowedValues': [
               'String',
@@ -44,7 +44,7 @@ export const errors = [
   {
     keyword: 'if',
     dataPath: '/properties/0',
-    schemaPath: '#/definitions/properties/items/allOf/3/if',
+    schemaPath: '#/definitions/properties/allOf/1/items/allOf/2/if',
     params: {
       'failingKeyword': 'then'
     },

--- a/test/fixtures/invalid-camunda-out.js
+++ b/test/fixtures/invalid-camunda-out.js
@@ -27,13 +27,13 @@ export const errors = [
   {
     'keyword': 'errorMessage',
     'dataPath': '/properties/1/binding',
-    'schemaPath': '#/definitions/properties/items/properties/binding/allOf/3/then/errorMessage',
+    'schemaPath': '#/definitions/properties/allOf/1/items/properties/binding/allOf/3/then/errorMessage',
     'params': {
       'errors': [
         {
           'keyword': 'required',
           'dataPath': '/properties/1/binding',
-          'schemaPath': '#/definitions/properties/items/properties/binding/allOf/3/then/oneOf/0/required',
+          'schemaPath': '#/definitions/properties/allOf/1/items/properties/binding/allOf/3/then/oneOf/0/required',
           'params': {
             'missingProperty': 'variables'
           },
@@ -43,7 +43,7 @@ export const errors = [
         {
           'keyword': 'required',
           'dataPath': '/properties/1/binding',
-          'schemaPath': '#/definitions/properties/items/properties/binding/allOf/3/then/oneOf/1/required',
+          'schemaPath': '#/definitions/properties/allOf/1/items/properties/binding/allOf/3/then/oneOf/1/required',
           'params': {
             'missingProperty': 'source'
           },
@@ -53,7 +53,7 @@ export const errors = [
         {
           'keyword': 'required',
           'dataPath': '/properties/1/binding',
-          'schemaPath': '#/definitions/properties/items/properties/binding/allOf/3/then/oneOf/2/required',
+          'schemaPath': '#/definitions/properties/allOf/1/items/properties/binding/allOf/3/then/oneOf/2/required',
           'params': {
             'missingProperty': 'sourceExpression'
           },
@@ -63,7 +63,7 @@ export const errors = [
         {
           'keyword': 'required',
           'dataPath': '/properties/1/binding',
-          'schemaPath': '#/definitions/properties/items/properties/binding/allOf/3/then/oneOf/3/required',
+          'schemaPath': '#/definitions/properties/allOf/1/items/properties/binding/allOf/3/then/oneOf/3/required',
           'params': {
             'missingProperty': 'variables'
           },
@@ -73,7 +73,7 @@ export const errors = [
         {
           'keyword': 'required',
           'dataPath': '/properties/1/binding',
-          'schemaPath': '#/definitions/properties/items/properties/binding/allOf/3/then/oneOf/3/required',
+          'schemaPath': '#/definitions/properties/allOf/1/items/properties/binding/allOf/3/then/oneOf/3/required',
           'params': {
             'missingProperty': 'sourceExpression'
           },
@@ -83,7 +83,7 @@ export const errors = [
         {
           'keyword': 'required',
           'dataPath': '/properties/1/binding',
-          'schemaPath': '#/definitions/properties/items/properties/binding/allOf/3/then/oneOf/4/required',
+          'schemaPath': '#/definitions/properties/allOf/1/items/properties/binding/allOf/3/then/oneOf/4/required',
           'params': {
             'missingProperty': 'variables'
           },
@@ -93,7 +93,7 @@ export const errors = [
         {
           'keyword': 'required',
           'dataPath': '/properties/1/binding',
-          'schemaPath': '#/definitions/properties/items/properties/binding/allOf/3/then/oneOf/4/required',
+          'schemaPath': '#/definitions/properties/allOf/1/items/properties/binding/allOf/3/then/oneOf/4/required',
           'params': {
             'missingProperty': 'source'
           },
@@ -103,7 +103,7 @@ export const errors = [
         {
           'keyword': 'oneOf',
           'dataPath': '/properties/1/binding',
-          'schemaPath': '#/definitions/properties/items/properties/binding/allOf/3/then/oneOf',
+          'schemaPath': '#/definitions/properties/allOf/1/items/properties/binding/allOf/3/then/oneOf',
           'params': {
             'passingSchemas': null
           },
@@ -117,7 +117,7 @@ export const errors = [
   {
     'keyword': 'if',
     'dataPath': '/properties/1/binding',
-    'schemaPath': '#/definitions/properties/items/properties/binding/allOf/3/if',
+    'schemaPath': '#/definitions/properties/allOf/1/items/properties/binding/allOf/3/if',
     'params': {
       'failingKeyword': 'then'
     },

--- a/test/fixtures/invalid-camunda-property-type.js
+++ b/test/fixtures/invalid-camunda-property-type.js
@@ -35,14 +35,14 @@ export const errors = [
   {
     keyword: 'errorMessage',
     dataPath: '/properties/0/type',
-    schemaPath: '#/definitions/properties/items/allOf/3/then/properties/type/errorMessage',
+    schemaPath: '#/definitions/properties/allOf/1/items/allOf/2/then/properties/type/errorMessage',
     params: {
       errors: [
         {
           keyword: 'enum',
           emUsed: true,
           dataPath: '/properties/0/type',
-          schemaPath: '#/definitions/properties/items/allOf/3/then/properties/type/enum',
+          schemaPath: '#/definitions/properties/allOf/1/items/allOf/2/then/properties/type/enum',
           params: {
             'allowedValues': [
               'String',
@@ -59,7 +59,7 @@ export const errors = [
   {
     keyword: 'if',
     dataPath: '/properties/0',
-    schemaPath: '#/definitions/properties/items/allOf/3/if',
+    schemaPath: '#/definitions/properties/allOf/1/items/allOf/2/if',
     params: {
       'failingKeyword': 'then'
     },

--- a/test/fixtures/invalid-constraints.js
+++ b/test/fixtures/invalid-constraints.js
@@ -10,7 +10,7 @@ export const template = {
       'type': 'String',
       'value': '45',
       'binding': {
-        'type': 'camunda:inputParameter',
+        'type': 'property',
         'name': 'shoeSize'
       },
       'constraints': {
@@ -30,14 +30,14 @@ export const errors = [
   {
     keyword: 'type',
     dataPath: '/properties/0/constraints/minLength',
-    schemaPath: '#/definitions/properties/items/properties/constraints/properties/minLength/type',
+    schemaPath: '#/definitions/properties/allOf/0/items/properties/constraints/properties/minLength/type',
     params: { type: 'number' },
     message: 'should be number'
   },
   {
     keyword: 'type',
     dataPath: '/properties/0/constraints/maxLength',
-    schemaPath: '#/definitions/properties/items/properties/constraints/properties/maxLength/type',
+    schemaPath: '#/definitions/properties/allOf/0/items/properties/constraints/properties/maxLength/type',
     params: { type: 'number' },
     message: 'should be number'
   },

--- a/test/fixtures/invalid-execution-listener-type.js
+++ b/test/fixtures/invalid-execution-listener-type.js
@@ -32,14 +32,14 @@ export const errors = [
   {
     keyword: 'errorMessage',
     dataPath: '/properties/2/type',
-    schemaPath: '#/definitions/properties/items/allOf/2/then/properties/type/errorMessage',
+    schemaPath: '#/definitions/properties/allOf/1/items/allOf/1/then/properties/type/errorMessage',
     params: {
       errors: [
         {
           keyword: 'enum',
           emUsed: true,
           dataPath: '/properties/2/type',
-          schemaPath: '#/definitions/properties/items/allOf/2/then/properties/type/enum',
+          schemaPath: '#/definitions/properties/allOf/1/items/allOf/1/then/properties/type/enum',
           params: {
             'allowedValues': [
               'Hidden'
@@ -54,7 +54,7 @@ export const errors = [
   {
     keyword: 'if',
     dataPath: '/properties/2',
-    schemaPath: '#/definitions/properties/items/allOf/2/if',
+    schemaPath: '#/definitions/properties/allOf/1/items/allOf/1/if',
     params: {
       'failingKeyword': 'then'
     },

--- a/test/fixtures/invalid-field-type.js
+++ b/test/fixtures/invalid-field-type.js
@@ -28,14 +28,14 @@ export const errors = [
   {
     keyword: 'errorMessage',
     dataPath: '/properties/1/type',
-    schemaPath: '#/definitions/properties/items/allOf/4/then/properties/type/errorMessage',
+    schemaPath: '#/definitions/properties/allOf/1/items/allOf/3/then/properties/type/errorMessage',
     params: {
       errors: [
         {
           keyword: 'enum',
           emUsed: true,
           dataPath: '/properties/1/type',
-          schemaPath: '#/definitions/properties/items/allOf/4/then/properties/type/enum',
+          schemaPath: '#/definitions/properties/allOf/1/items/allOf/3/then/properties/type/enum',
           params: {
             'allowedValues': [
               'String',
@@ -53,7 +53,7 @@ export const errors = [
   {
     keyword: 'if',
     dataPath: '/properties/1',
-    schemaPath: '#/definitions/properties/items/allOf/4/if',
+    schemaPath: '#/definitions/properties/allOf/1/items/allOf/3/if',
     params: {
       'failingKeyword': 'then'
     },

--- a/test/fixtures/invalid-input-parameter-type.js
+++ b/test/fixtures/invalid-input-parameter-type.js
@@ -20,14 +20,14 @@ export const errors = [
   {
     keyword: 'errorMessage',
     dataPath: '/properties/0/type',
-    schemaPath: '#/definitions/properties/items/allOf/4/then/properties/type/errorMessage',
+    schemaPath: '#/definitions/properties/allOf/1/items/allOf/3/then/properties/type/errorMessage',
     params: {
       errors: [
         {
           keyword: 'enum',
           emUsed: true,
           dataPath: '/properties/0/type',
-          schemaPath: '#/definitions/properties/items/allOf/4/then/properties/type/enum',
+          schemaPath: '#/definitions/properties/allOf/1/items/allOf/3/then/properties/type/enum',
           params: {
             'allowedValues': [
               'String',
@@ -45,7 +45,7 @@ export const errors = [
   {
     keyword: 'if',
     dataPath: '/properties/0',
-    schemaPath: '#/definitions/properties/items/allOf/4/if',
+    schemaPath: '#/definitions/properties/allOf/1/items/allOf/3/if',
     params: {
       'failingKeyword': 'then'
     },

--- a/test/fixtures/invalid-multiple-mail-tasks.js
+++ b/test/fixtures/invalid-multiple-mail-tasks.js
@@ -155,13 +155,13 @@ export const errors = [
   {
     keyword: 'errorMessage',
     dataPath: '/0',
-    schemaPath: '#/errorMessage',
+    schemaPath: '#/allOf/0/errorMessage',
     params: {
       errors: [
         {
           keyword: 'required',
           dataPath: '/0',
-          schemaPath: '#/required',
+          schemaPath: '#/allOf/0/required',
           params: { missingProperty: 'appliesTo' },
           message: "should have required property 'appliesTo'",
           emUsed: true
@@ -173,13 +173,13 @@ export const errors = [
   {
     keyword: 'errorMessage',
     dataPath: '/1',
-    schemaPath: '#/errorMessage',
+    schemaPath: '#/allOf/0/errorMessage',
     params: {
       errors: [
         {
           keyword: 'required',
           dataPath: '/1',
-          schemaPath: '#/required',
+          schemaPath: '#/allOf/0/required',
           params: { missingProperty: 'appliesTo' },
           message: "should have required property 'appliesTo'",
           emUsed: true

--- a/test/fixtures/invalid-output-parameter-type.js
+++ b/test/fixtures/invalid-output-parameter-type.js
@@ -20,14 +20,14 @@ export const errors = [
   {
     keyword: 'errorMessage',
     dataPath: '/properties/0/type',
-    schemaPath: '#/definitions/properties/items/allOf/3/then/properties/type/errorMessage',
+    schemaPath: '#/definitions/properties/allOf/1/items/allOf/2/then/properties/type/errorMessage',
     params: {
       errors: [
         {
           keyword: 'enum',
           emUsed: true,
           dataPath: '/properties/0/type',
-          schemaPath: '#/definitions/properties/items/allOf/3/then/properties/type/enum',
+          schemaPath: '#/definitions/properties/allOf/1/items/allOf/2/then/properties/type/enum',
           params: {
             'allowedValues': [
               'String',
@@ -44,7 +44,7 @@ export const errors = [
   {
     keyword: 'if',
     dataPath: '/properties/0',
-    schemaPath: '#/definitions/properties/items/allOf/3/if',
+    schemaPath: '#/definitions/properties/allOf/1/items/allOf/2/if',
     params: {
       'failingKeyword': 'then'
     },

--- a/test/fixtures/invalid-property-type.js
+++ b/test/fixtures/invalid-property-type.js
@@ -28,14 +28,14 @@ export const errors = [
   {
     keyword: 'errorMessage',
     dataPath: '/properties/1/type',
-    schemaPath: '#/definitions/properties/items/allOf/1/then/properties/type/errorMessage',
+    schemaPath: '#/definitions/properties/allOf/1/items/allOf/0/then/properties/type/errorMessage',
     params: {
       errors: [
         {
           keyword: 'enum',
           emUsed: true,
           dataPath: '/properties/1/type',
-          schemaPath: '#/definitions/properties/items/allOf/1/then/properties/type/enum',
+          schemaPath: '#/definitions/properties/allOf/1/items/allOf/0/then/properties/type/enum',
           params: {
             'allowedValues': [
               'String',
@@ -54,7 +54,7 @@ export const errors = [
   {
     keyword: 'if',
     dataPath: '/properties/1',
-    schemaPath: '#/definitions/properties/items/allOf/1/if',
+    schemaPath: '#/definitions/properties/allOf/1/items/allOf/0/if',
     params: {
       'failingKeyword': 'then'
     },

--- a/test/fixtures/invalid-version.js
+++ b/test/fixtures/invalid-version.js
@@ -12,7 +12,7 @@ export const errors = [
   {
     keyword: 'type',
     dataPath: '/version',
-    schemaPath: '#/properties/version/type',
+    schemaPath: '#/allOf/0/properties/version/type',
     params: { type: 'number' },
     message: 'should be number'
   },

--- a/test/fixtures/invalid-zeebe-input-type.js
+++ b/test/fixtures/invalid-zeebe-input-type.js
@@ -1,0 +1,80 @@
+export const template = {
+  'name': 'InvalidZeebeInputType',
+  'id': 'com.camunda.example.InvalidZeebeInputType',
+  'appliesTo': [
+    'bpmn:Task'
+  ],
+  'properties': [
+    {
+      'label': 'foo',
+      'type': 'Text',
+      'binding': {
+        'type': 'zeebe:input',
+        'name': 'foo'
+      }
+    },
+    {
+      'label': 'bar',
+      'type': 'Boolean',
+      'binding': {
+        'type': 'zeebe:input',
+        'name': 'bar'
+      }
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'errorMessage',
+    dataPath: '/properties/1/type',
+    schemaPath: '#/definitions/properties/allOf/1/items/allOf/1/then/properties/type/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'enum',
+          emUsed: true,
+          dataPath: '/properties/1/type',
+          schemaPath: '#/definitions/properties/allOf/1/items/allOf/1/then/properties/type/enum',
+          params: {
+            'allowedValues': [
+              'String',
+              'Text',
+              'Hidden',
+              'Dropdown'
+            ]
+          },
+          message: 'should be equal to one of the allowed values'
+        }
+      ]
+    },
+    message: 'invalid property type "Boolean" for binding type "zeebe:input"; must be any of { String, Text, Hidden, Dropdown }'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/1',
+    schemaPath: '#/definitions/properties/allOf/1/items/allOf/1/if',
+    params: {
+      'failingKeyword': 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    dataPath: '',
+    keyword: 'type',
+    message: 'should be array',
+    params: {
+      type: 'array',
+    },
+    schemaPath: '#/oneOf/1/type',
+  },
+  {
+    dataPath: '',
+    keyword: 'oneOf',
+    message: 'should match exactly one schema in oneOf',
+    params: {
+      passingSchemas: null
+    },
+    schemaPath: '#/oneOf'
+  }
+];

--- a/test/fixtures/invalid-zeebe-output-type.js
+++ b/test/fixtures/invalid-zeebe-output-type.js
@@ -1,0 +1,80 @@
+export const template = {
+  'name': 'InvalidZeebeOutputType',
+  'id': 'com.camunda.example.InvalidZeebeOutputType',
+  'appliesTo': [
+    'bpmn:Task'
+  ],
+  'properties': [
+    {
+      'label': 'foo',
+      'type': 'Text',
+      'binding': {
+        'type': 'zeebe:output',
+        'source': 'foo'
+      }
+    },
+    {
+      'label': 'bar',
+      'type': 'Boolean',
+      'binding': {
+        'type': 'zeebe:output',
+        'source': 'bar'
+      }
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'errorMessage',
+    dataPath: '/properties/1/type',
+    schemaPath: '#/definitions/properties/allOf/1/items/allOf/1/then/properties/type/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'enum',
+          emUsed: true,
+          dataPath: '/properties/1/type',
+          schemaPath: '#/definitions/properties/allOf/1/items/allOf/1/then/properties/type/enum',
+          params: {
+            'allowedValues': [
+              'String',
+              'Text',
+              'Hidden',
+              'Dropdown'
+            ]
+          },
+          message: 'should be equal to one of the allowed values'
+        }
+      ]
+    },
+    message: 'invalid property type "Boolean" for binding type "zeebe:output"; must be any of { String, Text, Hidden, Dropdown }'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/1',
+    schemaPath: '#/definitions/properties/allOf/1/items/allOf/1/if',
+    params: {
+      'failingKeyword': 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    dataPath: '',
+    keyword: 'type',
+    message: 'should be array',
+    params: {
+      type: 'array',
+    },
+    schemaPath: '#/oneOf/1/type',
+  },
+  {
+    dataPath: '',
+    keyword: 'oneOf',
+    message: 'should match exactly one schema in oneOf',
+    params: {
+      passingSchemas: null
+    },
+    schemaPath: '#/oneOf'
+  }
+];

--- a/test/fixtures/invalid-zeebe-task-definition-type-type.js
+++ b/test/fixtures/invalid-zeebe-task-definition-type-type.js
@@ -1,0 +1,78 @@
+export const template = {
+  'name': 'InvalidZeebeTaskHeaderType',
+  'id': 'com.camunda.example.InvalidZeebeTaskHeaderType',
+  'appliesTo': [
+    'bpmn:Task'
+  ],
+  'properties': [
+    {
+      'label': 'foo',
+      'type': 'Text',
+      'binding': {
+        'type': 'zeebe:taskDefinition:type'
+      }
+    },
+    {
+      'label': 'bar',
+      'type': 'Boolean',
+      'binding': {
+        'type': 'zeebe:taskDefinition:type'
+      }
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'errorMessage',
+    dataPath: '/properties/1/type',
+    schemaPath: '#/definitions/properties/allOf/1/items/allOf/1/then/properties/type/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'enum',
+          emUsed: true,
+          dataPath: '/properties/1/type',
+          schemaPath: '#/definitions/properties/allOf/1/items/allOf/1/then/properties/type/enum',
+          params: {
+            'allowedValues': [
+              'String',
+              'Text',
+              'Hidden',
+              'Dropdown'
+            ]
+          },
+          message: 'should be equal to one of the allowed values'
+        }
+      ]
+    },
+    message: 'invalid property type "Boolean" for binding type "zeebe:taskDefinition:type"; must be any of { String, Text, Hidden, Dropdown }'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/1',
+    schemaPath: '#/definitions/properties/allOf/1/items/allOf/1/if',
+    params: {
+      'failingKeyword': 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    dataPath: '',
+    keyword: 'type',
+    message: 'should be array',
+    params: {
+      type: 'array',
+    },
+    schemaPath: '#/oneOf/1/type',
+  },
+  {
+    dataPath: '',
+    keyword: 'oneOf',
+    message: 'should match exactly one schema in oneOf',
+    params: {
+      passingSchemas: null
+    },
+    schemaPath: '#/oneOf'
+  }
+];

--- a/test/fixtures/invalid-zeebe-task-header-type.js
+++ b/test/fixtures/invalid-zeebe-task-header-type.js
@@ -1,0 +1,80 @@
+export const template = {
+  'name': 'InvalidZeebeTaskHeaderType',
+  'id': 'com.camunda.example.InvalidZeebeTaskHeaderType',
+  'appliesTo': [
+    'bpmn:Task'
+  ],
+  'properties': [
+    {
+      'label': 'foo',
+      'type': 'Text',
+      'binding': {
+        'type': 'zeebe:taskHeader',
+        'key': 'foo'
+      }
+    },
+    {
+      'label': 'bar',
+      'type': 'Boolean',
+      'binding': {
+        'type': 'zeebe:taskHeader',
+        'key': 'foo'
+      }
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'errorMessage',
+    dataPath: '/properties/1/type',
+    schemaPath: '#/definitions/properties/allOf/1/items/allOf/1/then/properties/type/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'enum',
+          emUsed: true,
+          dataPath: '/properties/1/type',
+          schemaPath: '#/definitions/properties/allOf/1/items/allOf/1/then/properties/type/enum',
+          params: {
+            'allowedValues': [
+              'String',
+              'Text',
+              'Hidden',
+              'Dropdown'
+            ]
+          },
+          message: 'should be equal to one of the allowed values'
+        }
+      ]
+    },
+    message: 'invalid property type "Boolean" for binding type "zeebe:taskHeader"; must be any of { String, Text, Hidden, Dropdown }'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/1',
+    schemaPath: '#/definitions/properties/allOf/1/items/allOf/1/if',
+    params: {
+      'failingKeyword': 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    dataPath: '',
+    keyword: 'type',
+    message: 'should be array',
+    params: {
+      type: 'array',
+    },
+    schemaPath: '#/oneOf/1/type',
+  },
+  {
+    dataPath: '',
+    keyword: 'oneOf',
+    message: 'should match exactly one schema in oneOf',
+    params: {
+      passingSchemas: null
+    },
+    schemaPath: '#/oneOf'
+  }
+];

--- a/test/fixtures/missing-applies-to.js
+++ b/test/fixtures/missing-applies-to.js
@@ -8,13 +8,13 @@ export const errors = [
   {
     keyword: 'errorMessage',
     dataPath: '',
-    schemaPath: '#/errorMessage',
+    schemaPath: '#/allOf/0/errorMessage',
     params: {
       errors: [
         {
           keyword: 'required',
           dataPath: '',
-          schemaPath: '#/required',
+          schemaPath: '#/allOf/0/required',
           params: { missingProperty: 'appliesTo' },
           message: "should have required property 'appliesTo'",
           emUsed: true

--- a/test/fixtures/missing-binding-errorRef.js
+++ b/test/fixtures/missing-binding-errorRef.js
@@ -47,14 +47,14 @@ export const errors = [
   {
     keyword: 'errorMessage',
     dataPath: '/properties/0/binding',
-    schemaPath: '#/definitions/properties/items/properties/binding/allOf/4/then/errorMessage',
+    schemaPath: '#/definitions/properties/allOf/1/items/properties/binding/allOf/4/then/errorMessage',
     params: {
       errors: [
         {
           keyword: 'required',
           emUsed: true,
           dataPath: '/properties/0/binding',
-          schemaPath: '#/definitions/properties/items/properties/binding/allOf/4/then/oneOf/0/required',
+          schemaPath: '#/definitions/properties/allOf/1/items/properties/binding/allOf/4/then/oneOf/0/required',
           params: { missingProperty: 'errorRef' },
           message: "should have required property 'errorRef'"
         },
@@ -62,7 +62,7 @@ export const errors = [
           keyword: 'oneOf',
           emUsed: true,
           dataPath: '/properties/0/binding',
-          schemaPath: '#/definitions/properties/items/properties/binding/allOf/4/then/oneOf',
+          schemaPath: '#/definitions/properties/allOf/1/items/properties/binding/allOf/4/then/oneOf',
           params: { passingSchemas: null },
           message: 'should match exactly one schema in oneOf'
         }
@@ -73,7 +73,7 @@ export const errors = [
   {
     keyword: 'if',
     dataPath: '/properties/0/binding',
-    schemaPath: '#/definitions/properties/items/properties/binding/allOf/4/if',
+    schemaPath: '#/definitions/properties/allOf/1/items/properties/binding/allOf/4/if',
     params: { failingKeyword: 'then' },
     message: 'should match "then" schema'
   },

--- a/test/fixtures/missing-binding-name.js
+++ b/test/fixtures/missing-binding-name.js
@@ -27,14 +27,14 @@ export const errors = [
   {
     keyword: 'errorMessage',
     dataPath: '/properties/1/binding',
-    schemaPath: '#/definitions/properties/items/properties/binding/allOf/0/then/errorMessage',
+    schemaPath: '#/definitions/properties/allOf/1/items/properties/binding/allOf/0/then/errorMessage',
     params: {
       errors: [
         {
           keyword: 'required',
           emUsed: true,
           dataPath: '/properties/1/binding',
-          schemaPath: '#/definitions/properties/items/properties/binding/allOf/0/then/required',
+          schemaPath: '#/definitions/properties/allOf/1/items/properties/binding/allOf/0/then/required',
           params: {
             missingProperty: 'name'
           },
@@ -47,7 +47,7 @@ export const errors = [
   {
     keyword: 'if',
     dataPath: '/properties/1/binding',
-    schemaPath: '#/definitions/properties/items/properties/binding/allOf/0/if',
+    schemaPath: '#/definitions/properties/allOf/1/items/properties/binding/allOf/0/if',
     params: {
       'failingKeyword': 'then'
     },

--- a/test/fixtures/missing-binding-source.js
+++ b/test/fixtures/missing-binding-source.js
@@ -27,14 +27,14 @@ export const errors = [
   {
     keyword: 'errorMessage',
     dataPath: '/properties/1/binding',
-    schemaPath: '#/definitions/properties/items/properties/binding/allOf/1/then/errorMessage',
+    schemaPath: '#/definitions/properties/allOf/1/items/properties/binding/allOf/1/then/errorMessage',
     params: {
       errors: [
         {
           keyword: 'required',
           emUsed: true,
           dataPath: '/properties/1/binding',
-          schemaPath: '#/definitions/properties/items/properties/binding/allOf/1/then/required',
+          schemaPath: '#/definitions/properties/allOf/1/items/properties/binding/allOf/1/then/required',
           params: {
             missingProperty: 'source'
           },
@@ -47,7 +47,7 @@ export const errors = [
   {
     keyword: 'if',
     dataPath: '/properties/1/binding',
-    schemaPath: '#/definitions/properties/items/properties/binding/allOf/1/if',
+    schemaPath: '#/definitions/properties/allOf/1/items/properties/binding/allOf/1/if',
     params: {
       'failingKeyword': 'then'
     },

--- a/test/fixtures/missing-binding-variables-target.js
+++ b/test/fixtures/missing-binding-variables-target.js
@@ -27,13 +27,13 @@ export const errors = [
   {
     'keyword': 'errorMessage',
     'dataPath': '/properties/1/binding',
-    'schemaPath': '#/definitions/properties/items/properties/binding/allOf/2/then/errorMessage',
+    'schemaPath': '#/definitions/properties/allOf/1/items/properties/binding/allOf/2/then/errorMessage',
     'params': {
       'errors': [
         {
           'keyword': 'required',
           'dataPath': '/properties/1/binding',
-          'schemaPath': '#/definitions/properties/items/properties/binding/allOf/2/then/anyOf/0/required',
+          'schemaPath': '#/definitions/properties/allOf/1/items/properties/binding/allOf/2/then/anyOf/0/required',
           'params': {
             'missingProperty': 'variables'
           },
@@ -43,7 +43,7 @@ export const errors = [
         {
           'keyword': 'required',
           'dataPath': '/properties/1/binding',
-          'schemaPath': '#/definitions/properties/items/properties/binding/allOf/2/then/anyOf/1/required',
+          'schemaPath': '#/definitions/properties/allOf/1/items/properties/binding/allOf/2/then/anyOf/1/required',
           'params': {
             'missingProperty': 'target'
           },
@@ -53,7 +53,7 @@ export const errors = [
         {
           'keyword': 'anyOf',
           'dataPath': '/properties/1/binding',
-          'schemaPath': '#/definitions/properties/items/properties/binding/allOf/2/then/anyOf',
+          'schemaPath': '#/definitions/properties/allOf/1/items/properties/binding/allOf/2/then/anyOf',
           'params': {},
           'message': 'should match some schema in anyOf',
           'emUsed': true
@@ -65,7 +65,7 @@ export const errors = [
   {
     'keyword': 'if',
     'dataPath': '/properties/1/binding',
-    'schemaPath': '#/definitions/properties/items/properties/binding/allOf/2/if',
+    'schemaPath': '#/definitions/properties/allOf/1/items/properties/binding/allOf/2/if',
     'params': {
       'failingKeyword': 'then'
     },

--- a/test/fixtures/missing-binding-zeebe-header-key.js
+++ b/test/fixtures/missing-binding-zeebe-header-key.js
@@ -1,0 +1,66 @@
+export const template = {
+  'name': 'MissingBindingKey',
+  'id': 'com.camunda.example.MissingBindingKey',
+  'appliesTo': [
+    'bpmn:Task'
+  ],
+  'properties': [
+    {
+      'label': 'foo',
+      'type': 'String',
+      'binding': {
+        'type': 'zeebe:taskHeader'
+      }
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'errorMessage',
+    dataPath: '/properties/0/binding',
+    schemaPath: '#/definitions/properties/allOf/1/items/properties/binding/allOf/2/then/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'required',
+          emUsed: true,
+          dataPath: '/properties/0/binding',
+          schemaPath: '#/definitions/properties/allOf/1/items/properties/binding/allOf/2/then/required',
+          params: {
+            missingProperty: 'key'
+          },
+          message: "should have required property 'key'"
+        }
+      ]
+    },
+    message: 'property.binding "zeebe:taskHeader" requires key'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/0/binding',
+    schemaPath: '#/definitions/properties/allOf/1/items/properties/binding/allOf/2/if',
+    params: {
+      'failingKeyword': 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    dataPath: '',
+    keyword: 'type',
+    message: 'should be array',
+    params: {
+      type: 'array',
+    },
+    schemaPath: '#/oneOf/1/type',
+  },
+  {
+    dataPath: '',
+    keyword: 'oneOf',
+    message: 'should match exactly one schema in oneOf',
+    params: {
+      passingSchemas: null
+    },
+    schemaPath: '#/oneOf'
+  }
+];

--- a/test/fixtures/missing-binding-zeebe-input-name.js
+++ b/test/fixtures/missing-binding-zeebe-input-name.js
@@ -1,0 +1,66 @@
+export const template = {
+  'name': 'MissingBindingName',
+  'id': 'com.camunda.example.MissingBindingName',
+  'appliesTo': [
+    'bpmn:Task'
+  ],
+  'properties': [
+    {
+      'label': 'foo',
+      'type': 'String',
+      'binding': {
+        'type': 'zeebe:input'
+      }
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'errorMessage',
+    dataPath: '/properties/0/binding',
+    schemaPath: '#/definitions/properties/allOf/1/items/properties/binding/allOf/0/then/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'required',
+          emUsed: true,
+          dataPath: '/properties/0/binding',
+          schemaPath: '#/definitions/properties/allOf/1/items/properties/binding/allOf/0/then/required',
+          params: {
+            missingProperty: 'name'
+          },
+          message: "should have required property 'name'"
+        }
+      ]
+    },
+    message: 'property.binding "zeebe:input" requires name'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/0/binding',
+    schemaPath: '#/definitions/properties/allOf/1/items/properties/binding/allOf/0/if',
+    params: {
+      'failingKeyword': 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    dataPath: '',
+    keyword: 'type',
+    message: 'should be array',
+    params: {
+      type: 'array',
+    },
+    schemaPath: '#/oneOf/1/type',
+  },
+  {
+    dataPath: '',
+    keyword: 'oneOf',
+    message: 'should match exactly one schema in oneOf',
+    params: {
+      passingSchemas: null
+    },
+    schemaPath: '#/oneOf'
+  }
+];

--- a/test/fixtures/missing-binding-zeebe-output-source.js
+++ b/test/fixtures/missing-binding-zeebe-output-source.js
@@ -1,0 +1,74 @@
+export const template = {
+  'name': 'MissingBindingSource',
+  'id': 'com.camunda.example.MissingBindingSource',
+  'appliesTo': [
+    'bpmn:Task'
+  ],
+  'properties': [
+    {
+      'label': 'foo',
+      'type': 'String',
+      'binding': {
+        'type': 'zeebe:output',
+        'source': 'foo'
+      }
+    },
+    {
+      'label': 'foo',
+      'type': 'String',
+      'binding': {
+        'type': 'zeebe:output'
+      }
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'errorMessage',
+    dataPath: '/properties/1/binding',
+    schemaPath: '#/definitions/properties/allOf/1/items/properties/binding/allOf/1/then/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'required',
+          emUsed: true,
+          dataPath: '/properties/1/binding',
+          schemaPath: '#/definitions/properties/allOf/1/items/properties/binding/allOf/1/then/required',
+          params: {
+            missingProperty: 'source'
+          },
+          message: "should have required property 'source'"
+        }
+      ]
+    },
+    message: 'property.binding "zeebe:output" requires source'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/1/binding',
+    schemaPath: '#/definitions/properties/allOf/1/items/properties/binding/allOf/1/if',
+    params: {
+      'failingKeyword': 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    dataPath: '',
+    keyword: 'type',
+    message: 'should be array',
+    params: {
+      type: 'array',
+    },
+    schemaPath: '#/oneOf/1/type',
+  },
+  {
+    dataPath: '',
+    keyword: 'oneOf',
+    message: 'should match exactly one schema in oneOf',
+    params: {
+      passingSchemas: null
+    },
+    schemaPath: '#/oneOf'
+  }
+];

--- a/test/fixtures/missing-binding.js
+++ b/test/fixtures/missing-binding.js
@@ -17,13 +17,13 @@ export const errors = [
   {
     keyword: 'errorMessage',
     dataPath: '/properties/0',
-    schemaPath: '#/definitions/properties/items/errorMessage',
+    schemaPath: '#/definitions/properties/allOf/1/items/errorMessage',
     params: {
       errors: [
         {
           keyword: 'required',
           dataPath: '/properties/0',
-          schemaPath: '#/definitions/properties/items/required',
+          schemaPath: '#/definitions/properties/allOf/1/items/required',
           params: { missingProperty: 'binding' },
           message: "should have required property 'binding'",
           emUsed: true

--- a/test/fixtures/missing-choices.js
+++ b/test/fixtures/missing-choices.js
@@ -21,14 +21,14 @@ export const errors = [
   {
     keyword: 'errorMessage',
     dataPath: '/properties/0',
-    schemaPath: '#/definitions/properties/items/allOf/0/then/errorMessage',
+    schemaPath: '#/definitions/properties/allOf/0/items/allOf/0/then/errorMessage',
     params: {
       errors: [
         {
           keyword: 'required',
           emUsed: true,
           dataPath: '/properties/0',
-          schemaPath: '#/definitions/properties/items/allOf/0/then/required',
+          schemaPath: '#/definitions/properties/allOf/0/items/allOf/0/then/required',
           params: {
             missingProperty: 'choices'
           },
@@ -41,7 +41,7 @@ export const errors = [
   {
     keyword: 'if',
     dataPath: '/properties/0',
-    schemaPath: '#/definitions/properties/items/allOf/0/if',
+    schemaPath: '#/definitions/properties/allOf/0/items/allOf/0/if',
     params: {
       'failingKeyword': 'then'
     },

--- a/test/fixtures/missing-properties.js
+++ b/test/fixtures/missing-properties.js
@@ -8,13 +8,13 @@ export const errors = [
   {
     keyword: 'errorMessage',
     dataPath: '',
-    schemaPath: '#/errorMessage',
+    schemaPath: '#/allOf/0/errorMessage',
     params: {
       errors: [
         {
           keyword: 'required',
           dataPath: '',
-          schemaPath: '#/required',
+          schemaPath: '#/allOf/0/required',
           params: { missingProperty: 'properties' },
           message: "should have required property 'properties'",
           emUsed: true

--- a/test/fixtures/missing-template-id.js
+++ b/test/fixtures/missing-template-id.js
@@ -8,13 +8,13 @@ export const errors = [
   {
     keyword: 'errorMessage',
     dataPath: '',
-    schemaPath: '#/errorMessage',
+    schemaPath: '#/allOf/0/errorMessage',
     params: {
       errors: [
         {
           keyword: 'required',
           dataPath: '',
-          schemaPath: '#/required',
+          schemaPath: '#/allOf/0/required',
           params: { missingProperty: 'id' },
           message: "should have required property 'id'",
           emUsed: true

--- a/test/fixtures/missing-template-name.js
+++ b/test/fixtures/missing-template-name.js
@@ -8,13 +8,13 @@ export const errors = [
   {
     keyword: 'errorMessage',
     dataPath: '',
-    schemaPath: '#/errorMessage',
+    schemaPath: '#/allOf/0/errorMessage',
     params: {
       errors: [
         {
           keyword: 'required',
           dataPath: '',
-          schemaPath: '#/required',
+          schemaPath: '#/allOf/0/required',
           params: { missingProperty: 'name' },
           message: "should have required property 'name'",
           emUsed: true

--- a/test/fixtures/multiple-errors.js
+++ b/test/fixtures/multiple-errors.js
@@ -44,54 +44,17 @@ export const template = {
 export const errors = [
   {
     keyword: 'errorMessage',
-    dataPath: '/properties/0/type',
-    schemaPath: '#/definitions/properties/items/allOf/1/then/properties/type/errorMessage',
-    params: {
-      errors: [
-        {
-          keyword: 'enum',
-          emUsed: true,
-          dataPath: '/properties/0/type',
-          schemaPath: '#/definitions/properties/items/allOf/1/then/properties/type/enum',
-          params: {
-            'allowedValues': [
-              'String',
-              'Text',
-              'Hidden',
-              'Dropdown',
-              'Boolean'
-            ]
-          },
-          message: 'should be equal to one of the allowed values'
-        }
-      ]
-    },
-    message: 'invalid property type "Foo" for binding type "property"; must be any of { String, Text, Hidden, Dropdown, Boolean }'
-  },
-  {
-    dataPath: '/properties/0',
-    keyword: 'if',
-    message: 'should match "then" schema',
-    params: {
-      'failingKeyword': 'then'
-    },
-    schemaPath: '#/definitions/properties/items/allOf/1/if'
-  },
-  {
-    keyword: 'errorMessage',
     dataPath: '/properties/1',
-    schemaPath: '#/definitions/properties/items/allOf/0/then/errorMessage',
+    schemaPath: '#/definitions/properties/allOf/0/items/allOf/0/then/errorMessage',
     params: {
       errors: [
         {
           keyword: 'required',
-          emUsed: true,
           dataPath: '/properties/1',
-          schemaPath: '#/definitions/properties/items/allOf/0/then/required',
-          params: {
-            missingProperty: 'choices'
-          },
-          message: "should have required property 'choices'"
+          schemaPath: '#/definitions/properties/allOf/0/items/allOf/0/then/required',
+          params: { missingProperty: 'choices' },
+          message: "should have required property 'choices'",
+          emUsed: true
         }
       ]
     },
@@ -100,27 +63,50 @@ export const errors = [
   {
     keyword: 'if',
     dataPath: '/properties/1',
-    schemaPath: '#/definitions/properties/items/allOf/0/if',
+    schemaPath: '#/definitions/properties/allOf/0/items/allOf/0/if',
+    params: { failingKeyword: 'then' },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'errorMessage',
+    dataPath: '/properties/0/type',
+    schemaPath: '#/definitions/properties/allOf/1/items/allOf/0/then/properties/type/errorMessage',
     params: {
-      'failingKeyword': 'then'
+      errors: [
+        {
+          keyword: 'enum',
+          dataPath: '/properties/0/type',
+          schemaPath: '#/definitions/properties/allOf/1/items/allOf/0/then/properties/type/enum',
+          params: {
+            allowedValues: [ 'String', 'Text', 'Hidden', 'Dropdown', 'Boolean' ]
+          },
+          message: 'should be equal to one of the allowed values',
+          emUsed: true
+        }
+      ]
     },
+    message: 'invalid property type "Foo" for binding type "property"; must be any of { String, Text, Hidden, Dropdown, Boolean }'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/0',
+    schemaPath: '#/definitions/properties/allOf/1/items/allOf/0/if',
+    params: { failingKeyword: 'then' },
     message: 'should match "then" schema'
   },
   {
     keyword: 'errorMessage',
     dataPath: '/properties/2/binding',
-    schemaPath: '#/definitions/properties/items/properties/binding/allOf/1/then/errorMessage',
+    schemaPath: '#/definitions/properties/allOf/1/items/properties/binding/allOf/1/then/errorMessage',
     params: {
       errors: [
         {
           keyword: 'required',
-          emUsed: true,
           dataPath: '/properties/2/binding',
-          schemaPath: '#/definitions/properties/items/properties/binding/allOf/1/then/required',
-          params: {
-            missingProperty: 'source'
-          },
-          message: "should have required property 'source'"
+          schemaPath: '#/definitions/properties/allOf/1/items/properties/binding/allOf/1/then/required',
+          params: { missingProperty: 'source' },
+          message: "should have required property 'source'",
+          emUsed: true
         }
       ]
     },
@@ -129,27 +115,23 @@ export const errors = [
   {
     keyword: 'if',
     dataPath: '/properties/2/binding',
-    schemaPath: '#/definitions/properties/items/properties/binding/allOf/1/if',
-    params: {
-      'failingKeyword': 'then'
-    },
+    schemaPath: '#/definitions/properties/allOf/1/items/properties/binding/allOf/1/if',
+    params: { failingKeyword: 'then' },
     message: 'should match "then" schema'
   },
   {
     keyword: 'errorMessage',
     dataPath: '/properties/3/binding',
-    schemaPath: '#/definitions/properties/items/properties/binding/allOf/0/then/errorMessage',
+    schemaPath: '#/definitions/properties/allOf/1/items/properties/binding/allOf/0/then/errorMessage',
     params: {
       errors: [
         {
           keyword: 'required',
-          emUsed: true,
           dataPath: '/properties/3/binding',
-          schemaPath: '#/definitions/properties/items/properties/binding/allOf/0/then/required',
-          params: {
-            missingProperty: 'name'
-          },
-          message: "should have required property 'name'"
+          schemaPath: '#/definitions/properties/allOf/1/items/properties/binding/allOf/0/then/required',
+          params: { missingProperty: 'name' },
+          message: "should have required property 'name'",
+          emUsed: true
         }
       ]
     },
@@ -158,28 +140,22 @@ export const errors = [
   {
     keyword: 'if',
     dataPath: '/properties/3/binding',
-    schemaPath: '#/definitions/properties/items/properties/binding/allOf/0/if',
-    params: {
-      'failingKeyword': 'then'
-    },
+    schemaPath: '#/definitions/properties/allOf/1/items/properties/binding/allOf/0/if',
+    params: { failingKeyword: 'then' },
     message: 'should match "then" schema'
   },
   {
-    dataPath: '',
     keyword: 'type',
-    message: 'should be array',
-    params: {
-      type: 'array',
-    },
+    dataPath: '',
     schemaPath: '#/oneOf/1/type',
+    params: { type: 'array' },
+    message: 'should be array'
   },
   {
-    dataPath: '',
     keyword: 'oneOf',
-    message: 'should match exactly one schema in oneOf',
-    params: {
-      passingSchemas: null
-    },
-    schemaPath: '#/oneOf'
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: { passingSchemas: null },
+    message: 'should match exactly one schema in oneOf'
   }
 ];

--- a/test/fixtures/number-value.js
+++ b/test/fixtures/number-value.js
@@ -21,7 +21,7 @@ export const errors = [
   {
     keyword: 'type',
     dataPath: '/properties/0/value',
-    schemaPath: '#/definitions/properties/items/properties/value/type',
+    schemaPath: '#/definitions/properties/allOf/0/items/properties/value/type',
     params: {
       type: [
         'string',

--- a/test/fixtures/pattern-string.js
+++ b/test/fixtures/pattern-string.js
@@ -10,7 +10,7 @@ export const template = {
       'description': 'Must match /A+B/',
       'type': 'String',
       'binding': {
-        'type': 'camunda:property',
+        'type': 'property',
         'name': 'prop'
       },
       'constraints': {

--- a/test/fixtures/scope-connector-legacy.js
+++ b/test/fixtures/scope-connector-legacy.js
@@ -54,7 +54,7 @@ export const errors = [
   {
     keyword: 'type',
     dataPath: '/scopes',
-    schemaPath: '#/type',
+    schemaPath: '#/properties/scopes/type',
     params: { type: 'array' },
     message: 'should be array'
   },

--- a/test/fixtures/scope-connector-missing-binding-legacy.js
+++ b/test/fixtures/scope-connector-missing-binding-legacy.js
@@ -22,7 +22,7 @@ export const errors = [
   {
     keyword: 'type',
     dataPath: '/scopes',
-    schemaPath: '#/type',
+    schemaPath: '#/properties/scopes/type',
     params: { type: 'array' },
     message: 'should be array'
   },

--- a/test/fixtures/scope-invalid-legacy.js
+++ b/test/fixtures/scope-invalid-legacy.js
@@ -16,7 +16,7 @@ export const errors = [
   {
     keyword: 'type',
     dataPath: '/scopes',
-    schemaPath: '#/type',
+    schemaPath: '#/properties/scopes/type',
     params: { type: 'array' },
     message: 'should be array'
   },

--- a/test/fixtures/scope-invalid-type.js
+++ b/test/fixtures/scope-invalid-type.js
@@ -17,13 +17,13 @@ export const errors = [
   {
     keyword: 'errorMessage',
     dataPath: '/scopes/0/type',
-    schemaPath: '#/items/properties/type/errorMessage',
+    schemaPath: '#/properties/scopes/items/properties/type/errorMessage',
     params: {
       errors: [
         {
           keyword: 'enum',
           dataPath: '/scopes/0/type',
-          schemaPath: '#/items/properties/type/enum',
+          schemaPath: '#/properties/scopes/items/properties/type/enum',
           emUsed: true,
           params: { allowedValues: [ 'camunda:Connector', 'bpmn:Error' ] },
           message: 'should be equal to one of the allowed values'

--- a/test/fixtures/scope-missing-binding.js
+++ b/test/fixtures/scope-missing-binding.js
@@ -23,13 +23,13 @@ export const errors = [
   {
     keyword: 'errorMessage',
     dataPath: '/scopes/0/properties/0',
-    schemaPath: '#/definitions/properties/items/errorMessage',
+    schemaPath: '#/definitions/properties/allOf/1/items/errorMessage',
     params: {
       errors: [
         {
           keyword: 'required',
           dataPath: '/scopes/0/properties/0',
-          schemaPath: '#/definitions/properties/items/required',
+          schemaPath: '#/definitions/properties/allOf/1/items/required',
           params: { missingProperty: 'binding' },
           message: "should have required property 'binding'",
           emUsed: true

--- a/test/fixtures/scope-missing-error-id.js
+++ b/test/fixtures/scope-missing-error-id.js
@@ -47,13 +47,13 @@ export const errors = [
   {
     keyword: 'errorMessage',
     dataPath: '/scopes/0',
-    schemaPath: '#/items/allOf/0/then/errorMessage',
+    schemaPath: '#/properties/scopes/items/allOf/0/then/errorMessage',
     params: {
       errors: [
         {
           keyword: 'required',
           dataPath: '/scopes/0',
-          schemaPath: '#/items/allOf/0/then/required',
+          schemaPath: '#/properties/scopes/items/allOf/0/then/required',
           params: { missingProperty: 'id' },
           emUsed: true,
           message: "should have required property 'id'"
@@ -65,7 +65,7 @@ export const errors = [
   {
     keyword: 'if',
     dataPath: '/scopes/0',
-    schemaPath: '#/items/allOf/0/if',
+    schemaPath: '#/properties/scopes/items/allOf/0/if',
     params: { failingKeyword: 'then' },
     message: 'should match "then" schema'
   },

--- a/test/fixtures/scope-missing-properties.js
+++ b/test/fixtures/scope-missing-properties.js
@@ -16,13 +16,13 @@ export const errors = [
   {
     keyword: 'errorMessage',
     dataPath: '/scopes/0',
-    schemaPath: '#/items/errorMessage',
+    schemaPath: '#/properties/scopes/items/errorMessage',
     params: {
       errors: [
         {
           keyword: 'required',
           dataPath: '/scopes/0',
-          schemaPath: '#/items/required',
+          schemaPath: '#/properties/scopes/items/required',
           params: { missingProperty: 'properties' },
           message: "should have required property 'properties'",
           emUsed: true

--- a/test/fixtures/scope-missing-type.js
+++ b/test/fixtures/scope-missing-type.js
@@ -16,13 +16,13 @@ export const errors = [
   {
     keyword: 'errorMessage',
     dataPath: '/scopes/0',
-    schemaPath: '#/items/errorMessage',
+    schemaPath: '#/properties/scopes/items/errorMessage',
     params: {
       errors: [
         {
           keyword: 'required',
           dataPath: '/scopes/0',
-          schemaPath: '#/items/required',
+          schemaPath: '#/properties/scopes/items/required',
           params: { missingProperty: 'type' },
           message: "should have required property 'type'",
           emUsed: true

--- a/test/spec/cloud.validationSpec.js
+++ b/test/spec/cloud.validationSpec.js
@@ -1,0 +1,185 @@
+import { expect } from 'chai';
+
+import util from 'util';
+
+import schema from '../../resources/cloud.json';
+
+import {
+  createValidator
+} from '../helpers';
+
+const validator = createValidator(schema);
+
+
+describe('validation - cloud', function() {
+
+  function validateTemplate(template) {
+
+    const valid = validator(template);
+
+    const errors = validator.errors;
+
+    return {
+      valid,
+      errors
+    };
+  }
+
+  function testTemplate(name, file, only = false) {
+
+    if (!file) {
+      file = `../fixtures/${name}.js`;
+    }
+
+    (only ? it.only : it)('should validate template - ' + name, function() {
+
+      // given
+      const testDefinition = require(file);
+
+      const {
+        errors: expectedErrors,
+        template
+      } = testDefinition;
+
+      // when
+      const {
+        errors
+      } = validateTemplate(template);
+
+      // then
+      expect(errors).to.eql(expectedErrors);
+    });
+  }
+
+  // eslint-disable-next-line no-unused-vars
+  function testOnly(name, file) {
+    return testTemplate(name, file, true);
+  }
+
+
+  describe('single template', function() {
+
+    testTemplate('cloud-rest-connector');
+
+
+    testTemplate('missing-type');
+
+
+    testTemplate('missing-applies-to');
+
+
+    testTemplate('missing-template-name');
+
+
+    testTemplate('missing-template-id');
+
+
+    testTemplate('missing-properties');
+
+
+    testTemplate('missing-binding');
+
+
+    testTemplate('applies-to-single');
+
+
+    testTemplate('number-value');
+
+
+    testTemplate('additional-property');
+
+
+    testTemplate('invalid-binding-type-cloud');
+
+
+    testTemplate('choices-missing-value');
+
+
+    testTemplate('choices-missing-name');
+
+
+    testTemplate('missing-choices');
+
+
+    testTemplate('missing-binding-zeebe-output-source');
+
+
+    testTemplate('missing-binding-zeebe-input-name');
+
+
+    testTemplate('missing-binding-zeebe-header-key');
+
+
+    testTemplate('with-version');
+
+
+    testTemplate('invalid-version');
+
+
+    testTemplate('constraints');
+
+
+    testTemplate('invalid-constraints');
+
+
+    testTemplate('invalid-applies-to');
+
+
+    testTemplate('entries-visible-boolean');
+
+
+    testTemplate('pattern-string');
+
+
+    testTemplate('cloud-optional-inputs-outputs');
+
+
+    testTemplate('cloud-optional-invalid-type');
+
+
+    describe('property type - binding type', function() {
+
+      testTemplate('invalid-property-type');
+
+
+      testTemplate('invalid-zeebe-input-type');
+
+
+      testTemplate('invalid-zeebe-output-type');
+
+
+      testTemplate('invalid-zeebe-task-header-type');
+
+
+      testTemplate('invalid-zeebe-task-definition-type-type');
+
+    });
+
+
+    describe('grouping', function() {
+
+      testTemplate('groups');
+
+
+      testTemplate('groups-missing-id');
+
+
+      testTemplate('groups-missing-label');
+
+    });
+
+  });
+
+});
+
+
+// helpers /////////////////
+
+// eslint-disable-next-line no-unused-vars
+function printNested(object) {
+  console.log(util.inspect(object, {
+    showHidden: false,
+    depth: null,
+    colors: true
+  }));
+}

--- a/test/spec/cloud.validationSpec.js
+++ b/test/spec/cloud.validationSpec.js
@@ -137,6 +137,9 @@ describe('validation - cloud', function() {
     testTemplate('cloud-optional-invalid-type');
 
 
+    testTemplate('cloud-optional-invalid-not-empty');
+
+
     describe('property type - binding type', function() {
 
       testTemplate('invalid-property-type');

--- a/test/spec/platform.validationSpec.js
+++ b/test/spec/platform.validationSpec.js
@@ -11,7 +11,7 @@ import {
 const validator = createValidator(schema);
 
 
-describe('validation', function() {
+describe('validation - platform', function() {
 
   function validateTemplate(template) {
 

--- a/test/spec/schemaSpec.js
+++ b/test/spec/schemaSpec.js
@@ -2,6 +2,7 @@ import Ajv from 'ajv';
 import { expect } from 'chai';
 
 import platformSchema from '../../resources/schema.json';
+import cloudSchema from '../../resources/cloud.json';
 
 
 describe('schema validation', function() {
@@ -13,6 +14,20 @@ describe('schema validation', function() {
 
     // when
     const valid = ajv.validateSchema(platformSchema);
+
+    // then
+    expect(valid).to.be.true;
+    expect(valid.errors).to.not.exist;
+  });
+
+
+  it('should be valid (cloud)', function() {
+
+    // given
+    const ajv = new Ajv();
+
+    // when
+    const valid = ajv.validateSchema(cloudSchema);
 
     // then
     expect(valid).to.be.true;

--- a/test/spec/schemaSpec.js
+++ b/test/spec/schemaSpec.js
@@ -1,17 +1,18 @@
 import Ajv from 'ajv';
 import { expect } from 'chai';
 
-import schema from '../../resources/schema.json';
+import platformSchema from '../../resources/schema.json';
+
 
 describe('schema validation', function() {
 
-  it('should be valid', function() {
+  it('should be valid (platform)', function() {
 
     // given
     const ajv = new Ajv();
 
     // when
-    const valid = ajv.validateSchema(schema);
+    const valid = ajv.validateSchema(platformSchema);
 
     // then
     expect(valid).to.be.true;


### PR DESCRIPTION
Related to bpmn-io/bpmn-js-properties-panel#561

This demonstrates how to split up the existing [JSON Schema](https://github.com/camunda/element-templates-json-schema/blob/master/resources/schema.json) into smaller chunks (`src/defs`) and generate it back to the exporting schema as `build` step.

Furthermore, it's adding support for the new C8 templates bindings on top:
- `zeebe:taskDefinition:type`
- `zeebe:taskHeader` (`binding.key` is required)
- `zeebe:input` (`binding.name` is required)
- `zeebe:output ` (`binding.source` is required)
- `optional` for inputs and outputs
- do not allow `optional` for `constraints.notEmpty = true`

Things to clarify in kick off (can still be changed later)
* how to name exports (`resources/*.json`)? schema / platform / cloud vs. C7 / C8?
* multi-package? use the same version for both?