### PR TITLE
Provide better editor annotations

### DIFF
--- a/packages/element-templates-json-schema-shared/src/defs/base-properties.json
+++ b/packages/element-templates-json-schema-shared/src/defs/base-properties.json
@@ -1,12 +1,11 @@
 {
   "type": "array",
-  "title": "element template properties",
-  "description": "The properties of the element template",
-  "default": [],
+  "description": "List of properties of the element template.",
+  "allOf": [
+    { "$ref": "examples.json#/properties" }
+  ],  
   "items": {
     "type": "object",
-    "title": "element template property",
-    "description": "A property defined for the element template",
     "default": {},
     "allOf": [
       {
@@ -35,53 +34,47 @@
           "string",
           "boolean"
         ],
-        "title": "property value",
-        "description": "The value of the control field for the property"
+        "description": "The value of a control field."
       },
       "description": {
         "$id": "#/properties/property/description",
         "type": "string",
-        "title": "property description",
-        "description": "The description of the control field"
+        "description": "The description of a control field."
       },
       "label": {
         "$id": "#/properties/property/label",
         "type": "string",
-        "title": "property label",
-        "description": "The label of the control field for the property"
+        "description": "The label of a control field."
       },
       "type": {
         "$id": "#/properties/property/type",
         "type": "string",
-        "title": "property type",
-        "description": "The type of the control field"
+        "description": "The type of a control field."
       },
       "editable": {
         "$id": "#/properties/property/editable",
         "type": "boolean",
-        "title": "property editable",
-        "description": "Indicates whether the property is editable or not"
+        "description": "Indicates whether a control field is editable or not."
       },
       "choices": {
         "$id": "#/properties/property/choices",
         "type": "array",
-        "title": "property choices",
-        "description": "The choices for dropdown properties",
+        "description": "The choices for dropdown fields.",
+        "default": [],
         "items": {
           "$id": "#/properties/property/choices/item",
           "type": "object",
+          "default": {},
           "properties": {
             "name": {
               "$id": "#/properties/property/choices/item/name",
               "type": "string",
-              "title": "choice name",
-              "description": "The name of the choice"
+              "description": "The name of a choice."
             },
             "value": {
               "$id": "#/properties/property/choices/item/value",
               "type": "string",
-              "title": "choice value",
-              "description": "The value of the choice"
+              "description": "The value of a choice."
             }
           },
           "required": [
@@ -94,46 +87,43 @@
       "constraints": {
         "$id": "#/properties/property/constraints",
         "type": "object",
-        "title": "property constraints",
-        "description": "The validation constraints",
+        "description": "The validation constraints of a control field.",
+        "allOf": [
+          { "$ref": "examples.json#/constraints" }
+        ],
         "properties": {
           "notEmpty": {
             "$id": "#/properties/property/constraints/notEmpty",
             "type": "boolean",
-            "title": "property constraints not empty",
-            "description": "The control field must not be empty"
+            "description": "The control field must not be empty."
           },
           "minLength": {
             "$id": "#/properties/property/constraints/minLength",
             "type": "number",
-            "title": "property constraints min length",
-            "description": "The minimal length for the control field value"
+            "description": "The minimal length of a control field value."
           },
           "maxLength": {
             "$id": "#/properties/property/constraints/maxLength",
             "type": "number",
-            "title": "property constraints max length",
-            "description": "The maximal length for the control field value"
+            "description": "The maximal length for a control field value."
           },
           "pattern": {
             "$id": "#/properties/property/constraints/pattern",
-            "title": "property constraints pattern",
-            "description": "A regular expression pattern for the constraints",
+            "description": "A regular expression pattern for a constraint.",
             "oneOf": [
               {
                 "type": "object",
+                "default": {},
                 "properties": {
                   "value": {
                     "$id": "#/properties/property/constraints/pattern/value",
                     "type": "string",
-                    "title": "property constraints pattern value",
-                    "description": "The regular expression of the pattern constraint"
+                    "description": "The regular expression of a pattern."
                   },
                   "message": {
                     "$id": "#/properties/property/constraints/pattern/message",
                     "type": "string",
-                    "title": "property constraints pattern message",
-                    "description": "The validation message of the pattern constraint"
+                    "description": "The validation message of a pattern."
                   }
                 }
               },
@@ -147,8 +137,7 @@
       "group": {
         "$id": "#/properties/property/group",
         "type": "string",
-        "title": "property group",
-        "description": "The custom group of the control field for the property"
+        "description": "The custom group of a control field."
       }
     }
   }

--- a/packages/element-templates-json-schema-shared/src/defs/base.json
+++ b/packages/element-templates-json-schema-shared/src/defs/base.json
@@ -9,38 +9,32 @@
     "name": {
       "$id": "#/name",
       "type": "string",
-      "title": "element template name",
-      "description": "The name of the element template"
+      "description": "The name of the element template."
     },
     "id": {
       "$id": "#/id",
       "type": "string",
-      "title": "element template id",
-      "description": "The identifier of the element template"
+      "description": "The identifier of the element template."
     },
     "description": {
       "$id": "#/description",
       "type": "string",
-      "title": "element template description",
-      "description": "The description of the element template"
+      "description": "The description of the element template."
     },
     "version": {
       "$id": "#/version",
       "type": "number",
-      "title": "element template version",
-      "description": "The version of the element template"
+      "description": "Optional version of the template. If you add a version to a template it will be considered unique based on its ID and version. Two templates can have the same ID if their version is different."
     },
     "isDefault": {
       "$id": "#/isDefault",
       "type": "boolean",
-      "title": "element template is default",
-      "description": "Indicates whether the element template is a default template"
+      "description": "Indicates whether the element template is a default template."
     },
     "appliesTo": {
       "$id": "#/appliesTo",
       "type": "array",
-      "title": "element template applies to",
-      "description": "The definition for which element types the element template can be applied",
+      "description": "List of BPMN types the template can be applied to.",
       "default": [],
       "items": {
         "$id": "#/appliesTo/items",
@@ -48,20 +42,24 @@
         "pattern": "^(.*?:)",
         "errorMessage": {
           "pattern": "invalid item for \"appliesTo\", should contain namespaced property, example: \"bpmn:Task\""
-        }
+        },
+        "allOf": [
+          {
+            "$ref": "examples.json#/appliesTo"
+          }
+        ]
       }
     },
     "metadata": {
       "$id": "#/metadata",
       "type": "object",
-      "title": "element template metadata",
-      "description": "Some metadata for further configuration"
+      "description": "Some custom properties for further configuration.",
+      "default": {}
     },
     "entriesVisible": {
       "$id": "#/entriesVisible",
       "type": "boolean",
-      "title": "element template entries visible",
-      "description": "Select whether non-template entries are visible in the properties panel"
+      "description": "Select whether non-template entries are visible in the properties panel."
     },
     "groups": {
       "$ref": "groups.json"

--- a/packages/element-templates-json-schema-shared/src/defs/examples.json
+++ b/packages/element-templates-json-schema-shared/src/defs/examples.json
@@ -1,0 +1,39 @@
+{
+  "appliesTo": {
+    "examples": [
+      "bpmn:Task",
+      "bpmn:ServiceTask",
+      "bpmn:SequenceFlow",
+      "bpmn:Process",
+      "bpmn:StartEvent",
+      "bpmn:Gateway"
+    ]
+  },
+  "properties": {
+    "examples": [ [
+      {
+        "label": "Name",
+        "type": "String",
+        "binding": {
+          "type": "property",
+          "name": "name"
+        }
+      }
+    ] ]
+  },
+  "groups": {
+    "examples": [ [
+      {
+        "id": "group-1",
+        "label": "My Group"
+      }
+    ] ]
+  },
+  "constraints": {
+    "examples": [
+      {
+        "notEmpty": true
+      }
+    ]
+  }
+}

--- a/packages/element-templates-json-schema-shared/src/defs/groups.json
+++ b/packages/element-templates-json-schema-shared/src/defs/groups.json
@@ -1,14 +1,15 @@
 {
   "$id": "#/groups",
   "type": "array",
-  "title": "element template properties groups",
-  "description": "The custom defined groups of the element template",
-  "default": [],
+  "description": "Custom fields can be ordered together via groups.",
+  "allOf": [
+    {
+      "$ref": "examples.json#/groups"
+    }
+  ],
   "items": {
     "$id": "#/groups/group",
     "type": "object",
-    "title": "element template group",
-    "description": "A custom defined group for the element template",
     "default": {},
     "required": [
       "id",
@@ -24,13 +25,11 @@
       "id": {
         "$id": "#/groups/group/id",
         "type": "string",
-        "title": "group id",
         "description": "The id of the custom group"
       },
       "label": {
         "$id": "#/groups/group/label",
         "type": "string",
-        "title": "group label",
         "description": "The label of the custom group"
       }
     }

--- a/packages/element-templates-json-schema/resources/schema.json
+++ b/packages/element-templates-json-schema/resources/schema.json
@@ -2,19 +2,30 @@
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id": "http://camunda.org/schema/element-templates/1.0",
   "title": "Element Template Schema",
-  "description": "A single element template configuration or an array of element template configurations",
   "definitions": {
     "properties": {
       "allOf": [
         {
           "type": "array",
-          "title": "element template properties",
-          "description": "The properties of the element template",
-          "default": [],
+          "description": "List of properties of the element template.",
+          "allOf": [
+            {
+              "examples": [
+                [
+                  {
+                    "label": "Name",
+                    "type": "String",
+                    "binding": {
+                      "type": "property",
+                      "name": "name"
+                    }
+                  }
+                ]
+              ]
+            }
+          ],
           "items": {
             "type": "object",
-            "title": "element template property",
-            "description": "A property defined for the element template",
             "default": {},
             "allOf": [
               {
@@ -43,53 +54,47 @@
                   "string",
                   "boolean"
                 ],
-                "title": "property value",
-                "description": "The value of the control field for the property"
+                "description": "The value of a control field."
               },
               "description": {
                 "$id": "#/properties/property/description",
                 "type": "string",
-                "title": "property description",
-                "description": "The description of the control field"
+                "description": "The description of a control field."
               },
               "label": {
                 "$id": "#/properties/property/label",
                 "type": "string",
-                "title": "property label",
-                "description": "The label of the control field for the property"
+                "description": "The label of a control field."
               },
               "type": {
                 "$id": "#/properties/property/type",
                 "type": "string",
-                "title": "property type",
-                "description": "The type of the control field"
+                "description": "The type of a control field."
               },
               "editable": {
                 "$id": "#/properties/property/editable",
                 "type": "boolean",
-                "title": "property editable",
-                "description": "Indicates whether the property is editable or not"
+                "description": "Indicates whether a control field is editable or not."
               },
               "choices": {
                 "$id": "#/properties/property/choices",
                 "type": "array",
-                "title": "property choices",
-                "description": "The choices for dropdown properties",
+                "description": "The choices for dropdown fields.",
+                "default": [],
                 "items": {
                   "$id": "#/properties/property/choices/item",
                   "type": "object",
+                  "default": {},
                   "properties": {
                     "name": {
                       "$id": "#/properties/property/choices/item/name",
                       "type": "string",
-                      "title": "choice name",
-                      "description": "The name of the choice"
+                      "description": "The name of a choice."
                     },
                     "value": {
                       "$id": "#/properties/property/choices/item/value",
                       "type": "string",
-                      "title": "choice value",
-                      "description": "The value of the choice"
+                      "description": "The value of a choice."
                     }
                   },
                   "required": [
@@ -102,46 +107,49 @@
               "constraints": {
                 "$id": "#/properties/property/constraints",
                 "type": "object",
-                "title": "property constraints",
-                "description": "The validation constraints",
+                "description": "The validation constraints of a control field.",
+                "allOf": [
+                  {
+                    "examples": [
+                      {
+                        "notEmpty": true
+                      }
+                    ]
+                  }
+                ],
                 "properties": {
                   "notEmpty": {
                     "$id": "#/properties/property/constraints/notEmpty",
                     "type": "boolean",
-                    "title": "property constraints not empty",
-                    "description": "The control field must not be empty"
+                    "description": "The control field must not be empty."
                   },
                   "minLength": {
                     "$id": "#/properties/property/constraints/minLength",
                     "type": "number",
-                    "title": "property constraints min length",
-                    "description": "The minimal length for the control field value"
+                    "description": "The minimal length of a control field value."
                   },
                   "maxLength": {
                     "$id": "#/properties/property/constraints/maxLength",
                     "type": "number",
-                    "title": "property constraints max length",
-                    "description": "The maximal length for the control field value"
+                    "description": "The maximal length for a control field value."
                   },
                   "pattern": {
                     "$id": "#/properties/property/constraints/pattern",
-                    "title": "property constraints pattern",
-                    "description": "A regular expression pattern for the constraints",
+                    "description": "A regular expression pattern for a constraint.",
                     "oneOf": [
                       {
                         "type": "object",
+                        "default": {},
                         "properties": {
                           "value": {
                             "$id": "#/properties/property/constraints/pattern/value",
                             "type": "string",
-                            "title": "property constraints pattern value",
-                            "description": "The regular expression of the pattern constraint"
+                            "description": "The regular expression of a pattern."
                           },
                           "message": {
                             "$id": "#/properties/property/constraints/pattern/message",
                             "type": "string",
-                            "title": "property constraints pattern message",
-                            "description": "The validation message of the pattern constraint"
+                            "description": "The validation message of a pattern."
                           }
                         }
                       },
@@ -155,8 +163,7 @@
               "group": {
                 "$id": "#/properties/property/group",
                 "type": "string",
-                "title": "property group",
-                "description": "The custom group of the control field for the property"
+                "description": "The custom group of a control field."
               }
             }
           }
@@ -164,13 +171,9 @@
         {
           "$schema": "http://json-schema.org/draft-07/schema",
           "type": "array",
-          "title": "element template properties",
-          "description": "The properties of the element template",
-          "default": [],
+          "description": "List of properties of the element template.",
           "items": {
             "type": "object",
-            "title": "element template property",
-            "description": "A property defined for the element template",
             "default": {},
             "required": [
               "binding"
@@ -321,8 +324,7 @@
               "binding": {
                 "$id": "#/properties/property/binding",
                 "type": "object",
-                "title": "property binding",
-                "description": "A binding to a BPMN 2.0 property",
+                "description": "Specifying how the property is mapped to BPMN or Camunda extension elements and attributes.",
                 "required": [
                   "type"
                 ],
@@ -512,13 +514,59 @@
                       ],
                       "errorMessage": "property.binding ${0/type} requires errorRef"
                     }
+                  },
+                  {
+                    "examples": [
+                      {
+                        "type": "property",
+                        "name": "name"
+                      },
+                      {
+                        "type": "camunda:property",
+                        "name": "property"
+                      },
+                      {
+                        "type": "camunda:inputParameter",
+                        "name": "input"
+                      },
+                      {
+                        "type": "camunda:outputParameter",
+                        "source": "output"
+                      },
+                      {
+                        "type": "camunda:in",
+                        "target": "target"
+                      },
+                      {
+                        "type": "camunda:in:businessKey"
+                      },
+                      {
+                        "type": "camunda:out",
+                        "source": "output"
+                      },
+                      {
+                        "type": "camunda:executionListener",
+                        "event": "start"
+                      },
+                      {
+                        "type": "camunda:field",
+                        "name": "field"
+                      },
+                      {
+                        "type": "camunda:errorEventDefinition",
+                        "errorRef": "error"
+                      },
+                      {
+                        "type": "camunda:errorEventDefinition",
+                        "errorRef": "error"
+                      }
+                    ]
                   }
                 ],
                 "properties": {
                   "type": {
                     "$id": "#/properties/property/binding/type",
                     "type": "string",
-                    "title": "property binding type",
                     "enum": [
                       "property",
                       "camunda:property",
@@ -532,59 +580,51 @@
                       "camunda:errorEventDefinition"
                     ],
                     "errorMessage": "invalid property.binding type ${0}; must be any of { property, camunda:property, camunda:inputParameter, camunda:outputParameter, camunda:in, camunda:out, camunda:in:businessKey, camunda:executionListener, camunda:field, camunda:errorEventDefinition }",
-                    "description": "The type of the property binding"
+                    "description": "The type of a property binding."
                   },
                   "name": {
                     "$id": "#/properties/property/binding/name",
                     "type": "string",
-                    "title": "property binding name",
-                    "description": "The name of binding xml property"
+                    "description": "The name of a property binding."
                   },
                   "event": {
                     "$id": "#/properties/property/binding/event",
                     "type": "string",
-                    "title": "property binding event",
-                    "description": "The event type of an execution listener binding"
+                    "description": "The event type of a property binding (camunda:executionListener)."
                   },
                   "scriptFormat": {
                     "$id": "#/properties/property/binding/scriptFormat",
                     "type": "string",
-                    "title": "property binding script format",
-                    "description": "The format of a script property binding (camunda:outputParameter, camunda:inputParameter)"
+                    "description": "The script format of a property binding (camunda:outputParameter, camunda:inputParameter)."
                   },
                   "source": {
                     "$id": "#/properties/property/binding/source",
                     "type": "string",
-                    "title": "property binding source",
-                    "description": "The source value of a property binding (camunda:outputParameter, camunda:out)"
+                    "description": "The source value of a property binding (camunda:outputParameter, camunda:out)."
                   },
                   "target": {
                     "$id": "#/properties/property/binding/target",
                     "type": "string",
-                    "title": "property binding target",
-                    "description": "The target value to be mapped to (camunda:in)"
+                    "description": "The target value of a property binding (camunda:in)."
                   },
                   "expression": {
                     "$id": "#/properties/property/binding/expression",
                     "type": "boolean",
-                    "title": "property binding expression",
-                    "description": "True indicates that the control field value is an expression (camunda:in, camunda:field)"
+                    "description": "Indicates whether the control field value is an expression (camunda:in, camunda:field)."
                   },
                   "variables": {
                     "$id": "#/properties/property/binding/variables",
                     "type": "string",
-                    "title": "property binding variables",
                     "enum": [
                       "all",
                       "local"
                     ],
-                    "description": "Either all or local indicating the variable mapping (camunda:in)"
+                    "description": "The variable mapping of a property binding (camunda:in)."
                   },
                   "sourceExpression": {
                     "$id": "#/properties/property/binding/sourceExpression",
                     "type": "string",
-                    "title": "property binding source expression",
-                    "description": "The string containing the expression for the source attribute (camunda:out)"
+                    "description": "The string containing the expression for the source attribute (camunda:out)."
                   }
                 }
               }
@@ -607,38 +647,32 @@
             "name": {
               "$id": "#/name",
               "type": "string",
-              "title": "element template name",
-              "description": "The name of the element template"
+              "description": "The name of the element template."
             },
             "id": {
               "$id": "#/id",
               "type": "string",
-              "title": "element template id",
-              "description": "The identifier of the element template"
+              "description": "The identifier of the element template."
             },
             "description": {
               "$id": "#/description",
               "type": "string",
-              "title": "element template description",
-              "description": "The description of the element template"
+              "description": "The description of the element template."
             },
             "version": {
               "$id": "#/version",
               "type": "number",
-              "title": "element template version",
-              "description": "The version of the element template"
+              "description": "Optional version of the template. If you add a version to a template it will be considered unique based on its ID and version. Two templates can have the same ID if their version is different."
             },
             "isDefault": {
               "$id": "#/isDefault",
               "type": "boolean",
-              "title": "element template is default",
-              "description": "Indicates whether the element template is a default template"
+              "description": "Indicates whether the element template is a default template."
             },
             "appliesTo": {
               "$id": "#/appliesTo",
               "type": "array",
-              "title": "element template applies to",
-              "description": "The definition for which element types the element template can be applied",
+              "description": "List of BPMN types the template can be applied to.",
               "default": [],
               "items": {
                 "$id": "#/appliesTo/items",
@@ -646,32 +680,51 @@
                 "pattern": "^(.*?:)",
                 "errorMessage": {
                   "pattern": "invalid item for \"appliesTo\", should contain namespaced property, example: \"bpmn:Task\""
-                }
+                },
+                "allOf": [
+                  {
+                    "examples": [
+                      "bpmn:Task",
+                      "bpmn:ServiceTask",
+                      "bpmn:SequenceFlow",
+                      "bpmn:Process",
+                      "bpmn:StartEvent",
+                      "bpmn:Gateway"
+                    ]
+                  }
+                ]
               }
             },
             "metadata": {
               "$id": "#/metadata",
               "type": "object",
-              "title": "element template metadata",
-              "description": "Some metadata for further configuration"
+              "description": "Some custom properties for further configuration.",
+              "default": {}
             },
             "entriesVisible": {
               "$id": "#/entriesVisible",
               "type": "boolean",
-              "title": "element template entries visible",
-              "description": "Select whether non-template entries are visible in the properties panel"
+              "description": "Select whether non-template entries are visible in the properties panel."
             },
             "groups": {
               "$id": "#/groups",
               "type": "array",
-              "title": "element template properties groups",
-              "description": "The custom defined groups of the element template",
-              "default": [],
+              "description": "Custom fields can be ordered together via groups.",
+              "allOf": [
+                {
+                  "examples": [
+                    [
+                      {
+                        "id": "group-1",
+                        "label": "My Group"
+                      }
+                    ]
+                  ]
+                }
+              ],
               "items": {
                 "$id": "#/groups/group",
                 "type": "object",
-                "title": "element template group",
-                "description": "A custom defined group for the element template",
                 "default": {},
                 "required": [
                   "id",
@@ -687,13 +740,11 @@
                   "id": {
                     "$id": "#/groups/group/id",
                     "type": "string",
-                    "title": "group id",
                     "description": "The id of the custom group"
                   },
                   "label": {
                     "$id": "#/groups/group/label",
                     "type": "string",
-                    "title": "group label",
                     "description": "The label of the custom group"
                   }
                 }
@@ -718,17 +769,51 @@
         "scopes": {
           "$id": "#/scopes",
           "type": "array",
-          "title": "element template scope",
-          "description": "Special scoped bindings that allow you to configure nested elements",
+          "description": "Special scoped bindings that allow you to configure nested elements.",
+          "allOf": [
+            {
+              "examples": [
+                [
+                  {
+                    "type": "bpmn:Error",
+                    "id": "Error_1",
+                    "properties": [
+                      {
+                        "value": "error-code",
+                        "binding": {
+                          "type": "property",
+                          "name": "errorCode"
+                        }
+                      },
+                      {
+                        "value": "error-message",
+                        "binding": {
+                          "type": "property",
+                          "name": "camunda:errorMessage"
+                        }
+                      },
+                      {
+                        "value": "error-name",
+                        "binding": {
+                          "type": "property",
+                          "name": "name"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              ]
+            }
+          ],
           "items": {
             "$id": "#/scopes/item",
             "type": "object",
-            "title": "element template scope item",
-            "description": "Scoped binding to configure nested elements",
+            "default": {},
             "properties": {
               "type": {
                 "$id": "#scopes/item/type",
                 "type": "string",
+                "description": "The type of a scope.",
                 "enum": [
                   "camunda:Connector",
                   "bpmn:Error"
@@ -737,6 +822,8 @@
               },
               "properties": {
                 "$id": "#/scopes/properties",
+                "description": "List of properties of a scope.",
+                "default": [],
                 "allOf": [
                   {
                     "$ref": "#/definitions/properties/allOf/0"
@@ -786,10 +873,12 @@
   },
   "oneOf": [
     {
+      "description": "An element template configuration.",
       "$ref": "#/definitions/template"
     },
     {
       "type": "array",
+      "description": "A list of element template configurations.",
       "items": {
         "$ref": "#/definitions/template"
       }

--- a/packages/element-templates-json-schema/src/defs/examples.json
+++ b/packages/element-templates-json-schema/src/defs/examples.json
@@ -1,0 +1,80 @@
+{
+  "binding": {
+    "examples": [
+      {
+        "type": "property",
+        "name": "name"
+      },
+      {
+        "type": "camunda:property",
+        "name": "property"
+      },
+      {
+        "type": "camunda:inputParameter",
+        "name": "input"
+      },
+      {
+        "type": "camunda:outputParameter",
+        "source": "output"
+      },
+      {
+        "type": "camunda:in",
+        "target": "target"
+      },
+      {
+        "type": "camunda:in:businessKey"
+      },
+      {
+        "type": "camunda:out",
+        "source": "output"
+      },
+      {
+        "type": "camunda:executionListener",
+        "event": "start"
+      },
+      {
+        "type": "camunda:field",
+        "name": "field"
+      },
+      {
+        "type": "camunda:errorEventDefinition",
+        "errorRef": "error"
+      },
+      {
+        "type": "camunda:errorEventDefinition",
+        "errorRef": "error"
+      }
+    ]
+  },
+  "scopes": {
+    "examples": [ [
+      {
+        "type": "bpmn:Error",
+        "id": "Error_1",
+        "properties": [
+          {
+            "value": "error-code",
+            "binding": {
+              "type": "property",
+              "name": "errorCode"
+            }
+          },
+          {
+            "value": "error-message",
+            "binding": {
+              "type": "property",
+              "name": "camunda:errorMessage"
+            }
+          },
+          {
+            "value": "error-name",
+            "binding": {
+              "type": "property",
+              "name": "name"
+            }
+          }
+        ]
+      }
+    ] ]
+  }
+}

--- a/packages/element-templates-json-schema/src/defs/properties.json
+++ b/packages/element-templates-json-schema/src/defs/properties.json
@@ -1,13 +1,9 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "type": "array",
-  "title": "element template properties",
-  "description": "The properties of the element template",
-  "default": [],
+  "description": "List of properties of the element template.",
   "items": {
     "type": "object",
-    "title": "element template property",
-    "description": "A property defined for the element template",
     "default": {},
     "required": [
       "binding"
@@ -158,8 +154,7 @@
       "binding": {
         "$id": "#/properties/property/binding",
         "type": "object",
-        "title": "property binding",
-        "description": "A binding to a BPMN 2.0 property",
+        "description": "Specifying how the property is mapped to BPMN or Camunda extension elements and attributes.",
         "required": [
           "type"
         ],
@@ -349,13 +344,15 @@
               ],
               "errorMessage": "property.binding ${0/type} requires errorRef"
             }
+          },
+          {
+            "$ref": "examples.json#/binding"
           }
         ],
         "properties": {
           "type": {
             "$id": "#/properties/property/binding/type",
             "type": "string",
-            "title": "property binding type",
             "enum": [
               "property",
               "camunda:property",
@@ -369,59 +366,51 @@
               "camunda:errorEventDefinition"
             ],
             "errorMessage": "invalid property.binding type ${0}; must be any of { property, camunda:property, camunda:inputParameter, camunda:outputParameter, camunda:in, camunda:out, camunda:in:businessKey, camunda:executionListener, camunda:field, camunda:errorEventDefinition }",
-            "description": "The type of the property binding"
+            "description": "The type of a property binding."
           },
           "name": {
             "$id": "#/properties/property/binding/name",
             "type": "string",
-            "title": "property binding name",
-            "description": "The name of binding xml property"
+            "description": "The name of a property binding."
           },
           "event": {
             "$id": "#/properties/property/binding/event",
             "type": "string",
-            "title": "property binding event",
-            "description": "The event type of an execution listener binding"
+            "description": "The event type of a property binding (camunda:executionListener)."
           },
           "scriptFormat": {
             "$id": "#/properties/property/binding/scriptFormat",
             "type": "string",
-            "title": "property binding script format",
-            "description": "The format of a script property binding (camunda:outputParameter, camunda:inputParameter)"
+            "description": "The script format of a property binding (camunda:outputParameter, camunda:inputParameter)."
           },
           "source": {
             "$id": "#/properties/property/binding/source",
             "type": "string",
-            "title": "property binding source",
-            "description": "The source value of a property binding (camunda:outputParameter, camunda:out)"
+            "description": "The source value of a property binding (camunda:outputParameter, camunda:out)."
           },
           "target": {
             "$id": "#/properties/property/binding/target",
             "type": "string",
-            "title": "property binding target",
-            "description": "The target value to be mapped to (camunda:in)"
+            "description": "The target value of a property binding (camunda:in)."
           },
           "expression": {
             "$id": "#/properties/property/binding/expression",
             "type": "boolean",
-            "title": "property binding expression",
-            "description": "True indicates that the control field value is an expression (camunda:in, camunda:field)"
+            "description": "Indicates whether the control field value is an expression (camunda:in, camunda:field)."
           },
           "variables": {
             "$id": "#/properties/property/binding/variables",
             "type": "string",
-            "title": "property binding variables",
             "enum": [
               "all",
               "local"
             ],
-            "description": "Either all or local indicating the variable mapping (camunda:in)"
+            "description": "The variable mapping of a property binding (camunda:in)."
           },
           "sourceExpression": {
             "$id": "#/properties/property/binding/sourceExpression",
             "type": "string",
-            "title": "property binding source expression",
-            "description": "The string containing the expression for the source attribute (camunda:out)"
+            "description": "The string containing the expression for the source attribute (camunda:out)."
           }
         }
       }

--- a/packages/element-templates-json-schema/src/defs/scopes.json
+++ b/packages/element-templates-json-schema/src/defs/scopes.json
@@ -1,17 +1,19 @@
 {
   "$id": "#/scopes",
   "type": "array",
-  "title": "element template scope",
-  "description": "Special scoped bindings that allow you to configure nested elements",
+  "description": "Special scoped bindings that allow you to configure nested elements.",
+  "allOf": [
+    { "$ref": "examples.json#/scopes" }
+  ],
   "items": {
     "$id": "#/scopes/item",
     "type": "object",
-    "title": "element template scope item",
-    "description": "Scoped binding to configure nested elements",
+    "default": {},
     "properties": {
       "type": {
         "$id": "#scopes/item/type",
         "type": "string",
+        "description": "The type of a scope.",
         "enum": [
           "camunda:Connector",
           "bpmn:Error"
@@ -20,6 +22,8 @@
       },
       "properties": {
         "$id": "#/scopes/properties",
+        "description": "List of properties of a scope.",
+        "default": [],
         "allOf": [
           {
             "$ref": "../../../../packages/element-templates-json-schema-shared/src/defs/base-properties.json"

--- a/packages/element-templates-json-schema/src/schema.json
+++ b/packages/element-templates-json-schema/src/schema.json
@@ -2,7 +2,6 @@
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id": "http://camunda.org/schema/element-templates/1.0",
   "title": "Element Template Schema",
-  "description": "A single element template configuration or an array of element template configurations",
   "definitions": {
     "properties": {
       "allOf": [
@@ -35,10 +34,12 @@
   },
   "oneOf": [
     {
+      "description": "An element template configuration.",
       "$ref": "#/definitions/template"
     },
     {
       "type": "array",
+      "description": "A list of element template configurations.",
       "items": {
         "$ref": "#/definitions/template"
       }

--- a/packages/zeebe-element-templates-json-schema/resources/schema.json
+++ b/packages/zeebe-element-templates-json-schema/resources/schema.json
@@ -2,19 +2,30 @@
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id": "http://camunda.org/schema/zeebe-element-templates/1.0",
   "title": "Element Template Schema",
-  "description": "A single element template configuration or an array of element template configurations",
   "definitions": {
     "properties": {
       "allOf": [
         {
           "type": "array",
-          "title": "element template properties",
-          "description": "The properties of the element template",
-          "default": [],
+          "description": "List of properties of the element template.",
+          "allOf": [
+            {
+              "examples": [
+                [
+                  {
+                    "label": "Name",
+                    "type": "String",
+                    "binding": {
+                      "type": "property",
+                      "name": "name"
+                    }
+                  }
+                ]
+              ]
+            }
+          ],
           "items": {
             "type": "object",
-            "title": "element template property",
-            "description": "A property defined for the element template",
             "default": {},
             "allOf": [
               {
@@ -43,53 +54,47 @@
                   "string",
                   "boolean"
                 ],
-                "title": "property value",
-                "description": "The value of the control field for the property"
+                "description": "The value of a control field."
               },
               "description": {
                 "$id": "#/properties/property/description",
                 "type": "string",
-                "title": "property description",
-                "description": "The description of the control field"
+                "description": "The description of a control field."
               },
               "label": {
                 "$id": "#/properties/property/label",
                 "type": "string",
-                "title": "property label",
-                "description": "The label of the control field for the property"
+                "description": "The label of a control field."
               },
               "type": {
                 "$id": "#/properties/property/type",
                 "type": "string",
-                "title": "property type",
-                "description": "The type of the control field"
+                "description": "The type of a control field."
               },
               "editable": {
                 "$id": "#/properties/property/editable",
                 "type": "boolean",
-                "title": "property editable",
-                "description": "Indicates whether the property is editable or not"
+                "description": "Indicates whether a control field is editable or not."
               },
               "choices": {
                 "$id": "#/properties/property/choices",
                 "type": "array",
-                "title": "property choices",
-                "description": "The choices for dropdown properties",
+                "description": "The choices for dropdown fields.",
+                "default": [],
                 "items": {
                   "$id": "#/properties/property/choices/item",
                   "type": "object",
+                  "default": {},
                   "properties": {
                     "name": {
                       "$id": "#/properties/property/choices/item/name",
                       "type": "string",
-                      "title": "choice name",
-                      "description": "The name of the choice"
+                      "description": "The name of a choice."
                     },
                     "value": {
                       "$id": "#/properties/property/choices/item/value",
                       "type": "string",
-                      "title": "choice value",
-                      "description": "The value of the choice"
+                      "description": "The value of a choice."
                     }
                   },
                   "required": [
@@ -102,46 +107,49 @@
               "constraints": {
                 "$id": "#/properties/property/constraints",
                 "type": "object",
-                "title": "property constraints",
-                "description": "The validation constraints",
+                "description": "The validation constraints of a control field.",
+                "allOf": [
+                  {
+                    "examples": [
+                      {
+                        "notEmpty": true
+                      }
+                    ]
+                  }
+                ],
                 "properties": {
                   "notEmpty": {
                     "$id": "#/properties/property/constraints/notEmpty",
                     "type": "boolean",
-                    "title": "property constraints not empty",
-                    "description": "The control field must not be empty"
+                    "description": "The control field must not be empty."
                   },
                   "minLength": {
                     "$id": "#/properties/property/constraints/minLength",
                     "type": "number",
-                    "title": "property constraints min length",
-                    "description": "The minimal length for the control field value"
+                    "description": "The minimal length of a control field value."
                   },
                   "maxLength": {
                     "$id": "#/properties/property/constraints/maxLength",
                     "type": "number",
-                    "title": "property constraints max length",
-                    "description": "The maximal length for the control field value"
+                    "description": "The maximal length for a control field value."
                   },
                   "pattern": {
                     "$id": "#/properties/property/constraints/pattern",
-                    "title": "property constraints pattern",
-                    "description": "A regular expression pattern for the constraints",
+                    "description": "A regular expression pattern for a constraint.",
                     "oneOf": [
                       {
                         "type": "object",
+                        "default": {},
                         "properties": {
                           "value": {
                             "$id": "#/properties/property/constraints/pattern/value",
                             "type": "string",
-                            "title": "property constraints pattern value",
-                            "description": "The regular expression of the pattern constraint"
+                            "description": "The regular expression of a pattern."
                           },
                           "message": {
                             "$id": "#/properties/property/constraints/pattern/message",
                             "type": "string",
-                            "title": "property constraints pattern message",
-                            "description": "The validation message of the pattern constraint"
+                            "description": "The validation message of a pattern."
                           }
                         }
                       },
@@ -155,8 +163,7 @@
               "group": {
                 "$id": "#/properties/property/group",
                 "type": "string",
-                "title": "property group",
-                "description": "The custom group of the control field for the property"
+                "description": "The custom group of a control field."
               }
             }
           }
@@ -164,13 +171,9 @@
         {
           "$schema": "http://json-schema.org/draft-07/schema",
           "type": "array",
-          "title": "element template properties",
-          "description": "The properties of the element template",
-          "default": [],
+          "description": "List of properties of the element template.",
           "items": {
             "type": "object",
-            "title": "element template property",
-            "description": "A property defined for the element template",
             "default": {},
             "required": [
               "binding"
@@ -313,8 +316,7 @@
               "binding": {
                 "$id": "#/properties/property/binding",
                 "type": "object",
-                "title": "property binding",
-                "description": "A binding to a BPMN 2.0 property",
+                "description": "Specifying how the property is mapped to BPMN or Zeebe extension elements and attributes.",
                 "required": [
                   "type"
                 ],
@@ -375,13 +377,36 @@
                       ],
                       "errorMessage": "property.binding ${0/type} requires key"
                     }
+                  },
+                  {
+                    "examples": [
+                      {
+                        "type": "property",
+                        "name": "name"
+                      },
+                      {
+                        "type": "zeebe:input",
+                        "name": "input"
+                      },
+                      {
+                        "type": "zeebe:output",
+                        "source": "output"
+                      },
+                      {
+                        "type": "zeebe:taskDefinition:type"
+                      },
+                      {
+                        "type": "zeebe:taskHeader",
+                        "key": "key"
+                      }
+                    ]
                   }
                 ],
                 "properties": {
                   "type": {
                     "$id": "#/properties/property/binding/type",
                     "type": "string",
-                    "title": "property binding type",
+                    "description": "The type of a property binding.",
                     "enum": [
                       "property",
                       "zeebe:taskDefinition:type",
@@ -389,34 +414,29 @@
                       "zeebe:output",
                       "zeebe:taskHeader"
                     ],
-                    "errorMessage": "invalid property.binding type ${0}; must be any of { property, zeebe:taskDefinition:type, zeebe:input, zeebe:output, zeebe:taskHeader }",
-                    "description": "The type of the property binding"
+                    "errorMessage": "invalid property.binding type ${0}; must be any of { property, zeebe:taskDefinition:type, zeebe:input, zeebe:output, zeebe:taskHeader }"
                   },
                   "name": {
                     "$id": "#/properties/property/binding/name",
                     "type": "string",
-                    "title": "property binding name",
-                    "description": "The name of binding xml property"
+                    "description": "The name of a property binding."
                   },
                   "source": {
                     "$id": "#/properties/property/binding/source",
                     "type": "string",
-                    "title": "property binding source",
-                    "description": "The source value of a property binding (zeebe:output)"
+                    "description": "The source value of a property binding (zeebe:output)."
                   },
                   "key": {
                     "$id": "#/properties/property/binding/key",
                     "type": "string",
-                    "title": "property binding key",
-                    "description": "The key value of a property binding (zeebe:taskHeader)"
+                    "description": "The key value of a property binding (zeebe:taskHeader)."
                   }
                 }
               },
               "optional": {
                 "$id": "#/optional",
                 "type": "boolean",
-                "title": "element template optional",
-                "description": "Indicates whether a property is optional"
+                "description": "Indicates whether a property is optional. Optional bindings do not persist empty values in the underlying BPMN 2.0 XML."
               }
             }
           }
@@ -437,38 +457,32 @@
             "name": {
               "$id": "#/name",
               "type": "string",
-              "title": "element template name",
-              "description": "The name of the element template"
+              "description": "The name of the element template."
             },
             "id": {
               "$id": "#/id",
               "type": "string",
-              "title": "element template id",
-              "description": "The identifier of the element template"
+              "description": "The identifier of the element template."
             },
             "description": {
               "$id": "#/description",
               "type": "string",
-              "title": "element template description",
-              "description": "The description of the element template"
+              "description": "The description of the element template."
             },
             "version": {
               "$id": "#/version",
               "type": "number",
-              "title": "element template version",
-              "description": "The version of the element template"
+              "description": "Optional version of the template. If you add a version to a template it will be considered unique based on its ID and version. Two templates can have the same ID if their version is different."
             },
             "isDefault": {
               "$id": "#/isDefault",
               "type": "boolean",
-              "title": "element template is default",
-              "description": "Indicates whether the element template is a default template"
+              "description": "Indicates whether the element template is a default template."
             },
             "appliesTo": {
               "$id": "#/appliesTo",
               "type": "array",
-              "title": "element template applies to",
-              "description": "The definition for which element types the element template can be applied",
+              "description": "List of BPMN types the template can be applied to.",
               "default": [],
               "items": {
                 "$id": "#/appliesTo/items",
@@ -476,32 +490,51 @@
                 "pattern": "^(.*?:)",
                 "errorMessage": {
                   "pattern": "invalid item for \"appliesTo\", should contain namespaced property, example: \"bpmn:Task\""
-                }
+                },
+                "allOf": [
+                  {
+                    "examples": [
+                      "bpmn:Task",
+                      "bpmn:ServiceTask",
+                      "bpmn:SequenceFlow",
+                      "bpmn:Process",
+                      "bpmn:StartEvent",
+                      "bpmn:Gateway"
+                    ]
+                  }
+                ]
               }
             },
             "metadata": {
               "$id": "#/metadata",
               "type": "object",
-              "title": "element template metadata",
-              "description": "Some metadata for further configuration"
+              "description": "Some custom properties for further configuration.",
+              "default": {}
             },
             "entriesVisible": {
               "$id": "#/entriesVisible",
               "type": "boolean",
-              "title": "element template entries visible",
-              "description": "Select whether non-template entries are visible in the properties panel"
+              "description": "Select whether non-template entries are visible in the properties panel."
             },
             "groups": {
               "$id": "#/groups",
               "type": "array",
-              "title": "element template properties groups",
-              "description": "The custom defined groups of the element template",
-              "default": [],
+              "description": "Custom fields can be ordered together via groups.",
+              "allOf": [
+                {
+                  "examples": [
+                    [
+                      {
+                        "id": "group-1",
+                        "label": "My Group"
+                      }
+                    ]
+                  ]
+                }
+              ],
               "items": {
                 "$id": "#/groups/group",
                 "type": "object",
-                "title": "element template group",
-                "description": "A custom defined group for the element template",
                 "default": {},
                 "required": [
                   "id",
@@ -517,13 +550,11 @@
                   "id": {
                     "$id": "#/groups/group/id",
                     "type": "string",
-                    "title": "group id",
                     "description": "The id of the custom group"
                   },
                   "label": {
                     "$id": "#/groups/group/label",
                     "type": "string",
-                    "title": "group label",
                     "description": "The label of the custom group"
                   }
                 }
@@ -550,10 +581,12 @@
   },
   "oneOf": [
     {
+      "description": "An element template configuration.",
       "$ref": "#/definitions/template"
     },
     {
       "type": "array",
+      "description": "A list of element template configurations.",
       "items": {
         "$ref": "#/definitions/template"
       }

--- a/packages/zeebe-element-templates-json-schema/src/defs/examples.json
+++ b/packages/zeebe-element-templates-json-schema/src/defs/examples.json
@@ -1,0 +1,25 @@
+{
+  "binding": {
+    "examples": [
+      {
+        "type": "property",
+        "name": "name"
+      },
+      {
+        "type": "zeebe:input",
+        "name": "input"
+      },
+      {
+        "type": "zeebe:output",
+        "source": "output"
+      },
+      {
+        "type": "zeebe:taskDefinition:type"
+      },
+      {
+        "type": "zeebe:taskHeader",
+        "key": "key"
+      }
+    ]
+  }
+}

--- a/packages/zeebe-element-templates-json-schema/src/defs/properties.json
+++ b/packages/zeebe-element-templates-json-schema/src/defs/properties.json
@@ -1,13 +1,9 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "type": "array",
-  "title": "element template properties",
-  "description": "The properties of the element template",
-  "default": [],
+  "description": "List of properties of the element template.",
   "items": {
     "type": "object",
-    "title": "element template property",
-    "description": "A property defined for the element template",
     "default": {},
     "required": [
       "binding"
@@ -150,8 +146,7 @@
       "binding": {
         "$id": "#/properties/property/binding",
         "type": "object",
-        "title": "property binding",
-        "description": "A binding to a BPMN 2.0 property",
+        "description": "Specifying how the property is mapped to BPMN or Zeebe extension elements and attributes.",
         "required": [
           "type"
         ],
@@ -212,13 +207,16 @@
               ],
               "errorMessage": "property.binding ${0/type} requires key"
             }
+          },
+          {
+            "$ref": "examples.json#/binding"
           }
         ],
         "properties": {
           "type": {
             "$id": "#/properties/property/binding/type",
             "type": "string",
-            "title": "property binding type",
+            "description": "The type of a property binding.",
             "enum": [
               "property",
               "zeebe:taskDefinition:type",
@@ -226,34 +224,29 @@
               "zeebe:output",
               "zeebe:taskHeader"
             ],
-            "errorMessage": "invalid property.binding type ${0}; must be any of { property, zeebe:taskDefinition:type, zeebe:input, zeebe:output, zeebe:taskHeader }",
-            "description": "The type of the property binding"
+            "errorMessage": "invalid property.binding type ${0}; must be any of { property, zeebe:taskDefinition:type, zeebe:input, zeebe:output, zeebe:taskHeader }"
           },
           "name": {
             "$id": "#/properties/property/binding/name",
             "type": "string",
-            "title": "property binding name",
-            "description": "The name of binding xml property"
+            "description": "The name of a property binding."
           },
           "source": {
             "$id": "#/properties/property/binding/source",
             "type": "string",
-            "title": "property binding source",
-            "description": "The source value of a property binding (zeebe:output)"
+            "description": "The source value of a property binding (zeebe:output)."
           },
           "key": {
             "$id": "#/properties/property/binding/key",
             "type": "string",
-            "title": "property binding key",
-            "description": "The key value of a property binding (zeebe:taskHeader)"
+            "description": "The key value of a property binding (zeebe:taskHeader)."
           }
         }
       },
       "optional": {
         "$id": "#/optional",
         "type": "boolean",
-        "title": "element template optional",
-        "description": "Indicates whether a property is optional"
+        "description": "Indicates whether a property is optional. Optional bindings do not persist empty values in the underlying BPMN 2.0 XML."
       }
     }
   }

--- a/packages/zeebe-element-templates-json-schema/src/schema.json
+++ b/packages/zeebe-element-templates-json-schema/src/schema.json
@@ -2,7 +2,6 @@
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id": "http://camunda.org/schema/zeebe-element-templates/1.0",
   "title": "Element Template Schema",
-  "description": "A single element template configuration or an array of element template configurations",
   "definitions": {
     "properties": {
       "allOf": [
@@ -31,10 +30,12 @@
   },
   "oneOf": [
     {
+      "description": "An element template configuration.",
       "$ref": "#/definitions/template"
     },
     {
       "type": "array",
+      "description": "A list of element template configurations.",
       "items": {
         "$ref": "#/definitions/template"
       }


### PR DESCRIPTION
This provides better programming editor support by
* cleaning up descriptions
* removing unnecessary titles
* add examples
* add default values were examples are not applicable

Context: [Annotations docs](http://json-schema.org/understanding-json-schema/reference/generic.html#id2)

![Kapture 2022-03-04 at 13 31 53](https://user-images.githubusercontent.com/9433996/156779347-4e99f837-158b-46c2-b70a-24bad0f2122a.gif)

