### PR TITLE
feat: add `type` binding

### DIFF
--- a/packages/element-templates-json-schema-shared/src/defs/base.json
+++ b/packages/element-templates-json-schema-shared/src/defs/base.json
@@ -50,6 +50,27 @@
         ]
       }
     },
+    "elementType": {
+      "$id": "#/elementType",
+      "type": "object",
+      "description": "The BPMN type the element will be transformed into.",
+      "default": {},
+      "properties": {
+        "value": {
+          "$id": "#/elementType/value",
+          "type": "string",
+          "pattern": "^(.*?:)",
+          "errorMessage": {
+            "pattern": "invalid item for \"elementType\", should contain namespaced property, example: \"bpmn:Task\""
+          },
+          "allOf": [
+            {
+              "$ref": "examples.json#/elementType"
+            }
+          ]
+        }
+      }
+    },
     "metadata": {
       "$id": "#/metadata",
       "type": "object",

--- a/packages/element-templates-json-schema-shared/src/defs/base.json
+++ b/packages/element-templates-json-schema-shared/src/defs/base.json
@@ -39,7 +39,7 @@
       "items": {
         "$id": "#/appliesTo/items",
         "type": "string",
-        "pattern": "^(.*?:)",
+        "pattern": "^[\\w\\d]+:[\\w\\d]+$",
         "errorMessage": {
           "pattern": "invalid item for \"appliesTo\", should contain namespaced property, example: \"bpmn:Task\""
         },
@@ -59,7 +59,7 @@
         "value": {
           "$id": "#/elementType/value",
           "type": "string",
-          "pattern": "^(.*?:)",
+          "pattern": "^[\\w\\d]+:[\\w\\d]+$",
           "errorMessage": {
             "pattern": "invalid item for \"elementType\", should contain namespaced property, example: \"bpmn:Task\""
           },

--- a/packages/element-templates-json-schema-shared/src/defs/examples.json
+++ b/packages/element-templates-json-schema-shared/src/defs/examples.json
@@ -38,12 +38,11 @@
   },
   "elementType": {
     "examples": [
-      "bpmn:Task",
       "bpmn:ServiceTask",
-      "bpmn:SequenceFlow",
-      "bpmn:Process",
+      "bpmn:UserTask",
       "bpmn:StartEvent",
-      "bpmn:Gateway"
+      "bpmn:ExclusiveGateway",
+      "bpmn:ParallelGateway"
     ]
   }
 }

--- a/packages/element-templates-json-schema-shared/src/defs/examples.json
+++ b/packages/element-templates-json-schema-shared/src/defs/examples.json
@@ -35,5 +35,15 @@
         "notEmpty": true
       }
     ]
+  },
+  "elementType": {
+    "examples": [
+      "bpmn:Task",
+      "bpmn:ServiceTask",
+      "bpmn:SequenceFlow",
+      "bpmn:Process",
+      "bpmn:StartEvent",
+      "bpmn:Gateway"
+    ]
   }
 }

--- a/packages/element-templates-json-schema/resources/schema.json
+++ b/packages/element-templates-json-schema/resources/schema.json
@@ -677,7 +677,7 @@
               "items": {
                 "$id": "#/appliesTo/items",
                 "type": "string",
-                "pattern": "^(.*?:)",
+                "pattern": "^[\\w\\d]+:[\\w\\d]+$",
                 "errorMessage": {
                   "pattern": "invalid item for \"appliesTo\", should contain namespaced property, example: \"bpmn:Task\""
                 },
@@ -704,7 +704,7 @@
                 "value": {
                   "$id": "#/elementType/value",
                   "type": "string",
-                  "pattern": "^(.*?:)",
+                  "pattern": "^[\\w\\d]+:[\\w\\d]+$",
                   "errorMessage": {
                     "pattern": "invalid item for \"elementType\", should contain namespaced property, example: \"bpmn:Task\""
                   },

--- a/packages/element-templates-json-schema/resources/schema.json
+++ b/packages/element-templates-json-schema/resources/schema.json
@@ -711,12 +711,11 @@
                   "allOf": [
                     {
                       "examples": [
-                        "bpmn:Task",
                         "bpmn:ServiceTask",
-                        "bpmn:SequenceFlow",
-                        "bpmn:Process",
+                        "bpmn:UserTask",
                         "bpmn:StartEvent",
-                        "bpmn:Gateway"
+                        "bpmn:ExclusiveGateway",
+                        "bpmn:ParallelGateway"
                       ]
                     }
                   ]

--- a/packages/element-templates-json-schema/resources/schema.json
+++ b/packages/element-templates-json-schema/resources/schema.json
@@ -695,6 +695,34 @@
                 ]
               }
             },
+            "elementType": {
+              "$id": "#/elementType",
+              "type": "object",
+              "description": "The BPMN type the element will be transformed into.",
+              "default": {},
+              "properties": {
+                "value": {
+                  "$id": "#/elementType/value",
+                  "type": "string",
+                  "pattern": "^(.*?:)",
+                  "errorMessage": {
+                    "pattern": "invalid item for \"elementType\", should contain namespaced property, example: \"bpmn:Task\""
+                  },
+                  "allOf": [
+                    {
+                      "examples": [
+                        "bpmn:Task",
+                        "bpmn:ServiceTask",
+                        "bpmn:SequenceFlow",
+                        "bpmn:Process",
+                        "bpmn:StartEvent",
+                        "bpmn:Gateway"
+                      ]
+                    }
+                  ]
+                }
+              }
+            },
             "metadata": {
               "$id": "#/metadata",
               "type": "object",

--- a/packages/element-templates-json-schema/test/fixtures/element-type-invalid.js
+++ b/packages/element-templates-json-schema/test/fixtures/element-type-invalid.js
@@ -22,9 +22,9 @@ export const errors = [
           dataPath: '/elementType/value',
           schemaPath: '#/allOf/0/properties/elementType/properties/value/pattern',
           params: {
-            pattern: '^(.*?:)'
+            pattern: '^[\\w\\d]+:[\\w\\d]+$'
           },
-          message: 'should match pattern "^(.*?:)"',
+          message: 'should match pattern "^[\\w\\d]+:[\\w\\d]+$"',
           emUsed: true
         }
       ]

--- a/packages/element-templates-json-schema/test/fixtures/element-type-invalid.js
+++ b/packages/element-templates-json-schema/test/fixtures/element-type-invalid.js
@@ -1,0 +1,52 @@
+export const template = {
+  'name': 'Binding Type Template (invalid value)',
+  'id': 'com.example.BindingTemplate-invalid-value',
+  'appliesTo': [
+    'bpmn:Task'
+  ],
+  'elementType': {
+    'value': 'foobar'
+  },
+  'properties': [],
+};
+
+export const errors = [
+  {
+    keyword: 'errorMessage',
+    dataPath: '/elementType/value',
+    schemaPath: '#/allOf/0/properties/elementType/properties/value/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'pattern',
+          dataPath: '/elementType/value',
+          schemaPath: '#/allOf/0/properties/elementType/properties/value/pattern',
+          params: {
+            pattern: '^(.*?:)'
+          },
+          message: 'should match pattern "^(.*?:)"',
+          emUsed: true
+        }
+      ]
+    },
+    message: 'invalid item for "elementType", should contain namespaced property, example: "bpmn:Task"'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: {
+      type: 'array'
+    },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: {
+      passingSchemas: null
+    },
+    message: 'should match exactly one schema in oneOf'
+  }
+];

--- a/packages/element-templates-json-schema/test/fixtures/element-type.js
+++ b/packages/element-templates-json-schema/test/fixtures/element-type.js
@@ -1,0 +1,14 @@
+export const template = {
+  'name': 'Pattern Template',
+  'id': 'com.example.BindingTemplate',
+  'appliesTo': [
+    'bpmn:Task',
+    'bpmn:ServiceTask'
+  ],
+  'elementType': {
+    'value': 'bpmn:Task'
+  },
+  'properties': [ ]
+};
+
+export const errors = null;

--- a/packages/element-templates-json-schema/test/fixtures/invalid-applies-to.js
+++ b/packages/element-templates-json-schema/test/fixtures/invalid-applies-to.js
@@ -16,8 +16,8 @@ export const errors = [
           keyword: 'pattern',
           dataPath: '/appliesTo/0',
           schemaPath: '#/allOf/0/properties/appliesTo/items/pattern',
-          params: { pattern: '^(.*?:)' },
-          message: 'should match pattern "^(.*?:)"',
+          params: { pattern: '^[\\w\\d]+:[\\w\\d]+$' },
+          message: 'should match pattern "^[\\w\\d]+:[\\w\\d]+$"',
           emUsed: true
         }
       ]

--- a/packages/element-templates-json-schema/test/spec/validationSpec.js
+++ b/packages/element-templates-json-schema/test/spec/validationSpec.js
@@ -182,6 +182,12 @@ describe('validation', function() {
     testTemplate('invalid-documentation-ref');
 
 
+    testTemplate('element-type');
+
+
+    testTemplate('element-type-invalid');
+
+
     describe('property type - binding type', function() {
 
       testTemplate('invalid-property-type');

--- a/packages/zeebe-element-templates-json-schema/resources/schema.json
+++ b/packages/zeebe-element-templates-json-schema/resources/schema.json
@@ -560,12 +560,11 @@
                   "allOf": [
                     {
                       "examples": [
-                        "bpmn:Task",
                         "bpmn:ServiceTask",
-                        "bpmn:SequenceFlow",
-                        "bpmn:Process",
+                        "bpmn:UserTask",
                         "bpmn:StartEvent",
-                        "bpmn:Gateway"
+                        "bpmn:ExclusiveGateway",
+                        "bpmn:ParallelGateway"
                       ]
                     }
                   ]

--- a/packages/zeebe-element-templates-json-schema/resources/schema.json
+++ b/packages/zeebe-element-templates-json-schema/resources/schema.json
@@ -544,6 +544,34 @@
                 ]
               }
             },
+            "elementType": {
+              "$id": "#/elementType",
+              "type": "object",
+              "description": "The BPMN type the element will be transformed into.",
+              "default": {},
+              "properties": {
+                "value": {
+                  "$id": "#/elementType/value",
+                  "type": "string",
+                  "pattern": "^(.*?:)",
+                  "errorMessage": {
+                    "pattern": "invalid item for \"elementType\", should contain namespaced property, example: \"bpmn:Task\""
+                  },
+                  "allOf": [
+                    {
+                      "examples": [
+                        "bpmn:Task",
+                        "bpmn:ServiceTask",
+                        "bpmn:SequenceFlow",
+                        "bpmn:Process",
+                        "bpmn:StartEvent",
+                        "bpmn:Gateway"
+                      ]
+                    }
+                  ]
+                }
+              }
+            },
             "metadata": {
               "$id": "#/metadata",
               "type": "object",

--- a/packages/zeebe-element-templates-json-schema/resources/schema.json
+++ b/packages/zeebe-element-templates-json-schema/resources/schema.json
@@ -526,7 +526,7 @@
               "items": {
                 "$id": "#/appliesTo/items",
                 "type": "string",
-                "pattern": "^(.*?:)",
+                "pattern": "^[\\w\\d]+:[\\w\\d]+$",
                 "errorMessage": {
                   "pattern": "invalid item for \"appliesTo\", should contain namespaced property, example: \"bpmn:Task\""
                 },
@@ -553,7 +553,7 @@
                 "value": {
                   "$id": "#/elementType/value",
                   "type": "string",
-                  "pattern": "^(.*?:)",
+                  "pattern": "^[\\w\\d]+:[\\w\\d]+$",
                   "errorMessage": {
                     "pattern": "invalid item for \"elementType\", should contain namespaced property, example: \"bpmn:Task\""
                   },

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/element-type-invalid.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/element-type-invalid.js
@@ -22,9 +22,9 @@ export const errors = [
           dataPath: '/elementType/value',
           schemaPath: '#/allOf/0/properties/elementType/properties/value/pattern',
           params: {
-            pattern: '^(.*?:)'
+            pattern: '^[\\w\\d]+:[\\w\\d]+$'
           },
-          message: 'should match pattern "^(.*?:)"',
+          message: 'should match pattern "^[\\w\\d]+:[\\w\\d]+$"',
           emUsed: true
         }
       ]

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/element-type-invalid.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/element-type-invalid.js
@@ -1,0 +1,52 @@
+export const template = {
+  'name': 'Binding Type Template (invalid value)',
+  'id': 'com.example.BindingTemplate-invalid-value',
+  'appliesTo': [
+    'bpmn:Task'
+  ],
+  'elementType': {
+    'value': 'foobar'
+  },
+  'properties': [],
+};
+
+export const errors = [
+  {
+    keyword: 'errorMessage',
+    dataPath: '/elementType/value',
+    schemaPath: '#/allOf/0/properties/elementType/properties/value/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'pattern',
+          dataPath: '/elementType/value',
+          schemaPath: '#/allOf/0/properties/elementType/properties/value/pattern',
+          params: {
+            pattern: '^(.*?:)'
+          },
+          message: 'should match pattern "^(.*?:)"',
+          emUsed: true
+        }
+      ]
+    },
+    message: 'invalid item for "elementType", should contain namespaced property, example: "bpmn:Task"'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: {
+      type: 'array'
+    },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: {
+      passingSchemas: null
+    },
+    message: 'should match exactly one schema in oneOf'
+  }
+];

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/element-type.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/element-type.js
@@ -1,0 +1,14 @@
+export const template = {
+  'name': 'Pattern Template',
+  'id': 'com.example.BindingTemplate',
+  'appliesTo': [
+    'bpmn:Task',
+    'bpmn:ServiceTask'
+  ],
+  'elementType': {
+    'value': 'bpmn:Task'
+  },
+  'properties': [ ]
+};
+
+export const errors = null;

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/invalid-applies-to.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/invalid-applies-to.js
@@ -16,8 +16,8 @@ export const errors = [
           keyword: 'pattern',
           dataPath: '/appliesTo/0',
           schemaPath: '#/allOf/0/properties/appliesTo/items/pattern',
-          params: { pattern: '^(.*?:)' },
-          message: 'should match pattern "^(.*?:)"',
+          params: { pattern: '^[\\w\\d]+:[\\w\\d]+$' },
+          message: 'should match pattern "^[\\w\\d]+:[\\w\\d]+$"',
           emUsed: true
         }
       ]

--- a/packages/zeebe-element-templates-json-schema/test/spec/validationSpec.js
+++ b/packages/zeebe-element-templates-json-schema/test/spec/validationSpec.js
@@ -152,6 +152,12 @@ describe('validation', function() {
     testTemplate('invalid-documentation-ref');
 
 
+    testTemplate('element-type');
+
+
+    testTemplate('element-type-invalid');
+
+
     describe('property type - binding type', function() {
 
       testTemplate('invalid-property-type');


### PR DESCRIPTION
related to https://github.com/bpmn-io/bpmn-js-properties-panel/issues/572

AFAIK there are certain thinks we can't verify in the schema, like
- there can only be one `type` property
- the property value has to be part of `appliesTo`

Therefore, we just validate that
- it is of type `hidden`
- has a value that is of type `bpmn:someTask` (same validation we have for `appliesTo`)

The other options have to be checked during runtime.