### PR TITLE
fix: required `value` for element type property

### DIFF
--- a/packages/element-templates-json-schema-shared/src/defs/base.json
+++ b/packages/element-templates-json-schema-shared/src/defs/base.json
@@ -55,6 +55,14 @@
       "type": "object",
       "description": "The BPMN type the element will be transformed into.",
       "default": {},
+      "required": [
+        "value"
+      ],
+      "errorMessage": {
+        "required": {
+          "value": "missing elementType value"
+        }
+      },
       "properties": {
         "value": {
           "$id": "#/elementType/value",

--- a/packages/element-templates-json-schema/resources/schema.json
+++ b/packages/element-templates-json-schema/resources/schema.json
@@ -700,6 +700,14 @@
               "type": "object",
               "description": "The BPMN type the element will be transformed into.",
               "default": {},
+              "required": [
+                "value"
+              ],
+              "errorMessage": {
+                "required": {
+                  "value": "missing elementType value"
+                }
+              },
               "properties": {
                 "value": {
                   "$id": "#/elementType/value",

--- a/packages/element-templates-json-schema/test/fixtures/element-type-no-value.js
+++ b/packages/element-templates-json-schema/test/fixtures/element-type-no-value.js
@@ -1,0 +1,44 @@
+export const template = {
+  'name': 'Binding Type Template (no value)',
+  'id': 'com.example.BindingTemplate-no-value',
+  'appliesTo': [
+    'bpmn:Task'
+  ],
+  'elementType': { },
+  'properties': [],
+};
+
+export const errors = [
+  {
+    keyword: 'errorMessage',
+    dataPath: '/elementType',
+    schemaPath: '#/allOf/0/properties/elementType/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'required',
+          dataPath: '/elementType',
+          schemaPath: '#/allOf/0/properties/elementType/required',
+          params: { missingProperty: 'value' },
+          message: "should have required property 'value'",
+          emUsed: true
+        }
+      ]
+    },
+    message: 'missing elementType value'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: { type: 'array' },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: { passingSchemas: null },
+    message: 'should match exactly one schema in oneOf'
+  }
+];

--- a/packages/element-templates-json-schema/test/spec/validationSpec.js
+++ b/packages/element-templates-json-schema/test/spec/validationSpec.js
@@ -185,6 +185,9 @@ describe('validation', function() {
     testTemplate('element-type');
 
 
+    testTemplate('element-type-no-value');
+
+
     testTemplate('element-type-invalid');
 
 

--- a/packages/zeebe-element-templates-json-schema/resources/schema.json
+++ b/packages/zeebe-element-templates-json-schema/resources/schema.json
@@ -549,6 +549,14 @@
               "type": "object",
               "description": "The BPMN type the element will be transformed into.",
               "default": {},
+              "required": [
+                "value"
+              ],
+              "errorMessage": {
+                "required": {
+                  "value": "missing elementType value"
+                }
+              },
               "properties": {
                 "value": {
                   "$id": "#/elementType/value",

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/element-type-no-value.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/element-type-no-value.js
@@ -1,0 +1,44 @@
+export const template = {
+  'name': 'Binding Type Template (no value)',
+  'id': 'com.example.BindingTemplate-no-value',
+  'appliesTo': [
+    'bpmn:Task'
+  ],
+  'elementType': { },
+  'properties': [],
+};
+
+export const errors = [
+  {
+    keyword: 'errorMessage',
+    dataPath: '/elementType',
+    schemaPath: '#/allOf/0/properties/elementType/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'required',
+          dataPath: '/elementType',
+          schemaPath: '#/allOf/0/properties/elementType/required',
+          params: { missingProperty: 'value' },
+          message: "should have required property 'value'",
+          emUsed: true
+        }
+      ]
+    },
+    message: 'missing elementType value'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: { type: 'array' },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: { passingSchemas: null },
+    message: 'should match exactly one schema in oneOf'
+  }
+];

--- a/packages/zeebe-element-templates-json-schema/test/spec/validationSpec.js
+++ b/packages/zeebe-element-templates-json-schema/test/spec/validationSpec.js
@@ -155,6 +155,9 @@ describe('validation', function() {
     testTemplate('element-type');
 
 
+    testTemplate('element-type-no-value');
+
+
     testTemplate('element-type-invalid');
 
 


### PR DESCRIPTION
related to https://github.com/bpmn-io/bpmn-js-properties-panel/pull/648#discussion_r839540764

This PR ensures that a template with `elementType` but no value is invalid