### PR TITLE
Support property condition: `simple`

### DIFF
--- a/packages/element-templates-json-schema-shared/src/defs/base-properties.json
+++ b/packages/element-templates-json-schema-shared/src/defs/base-properties.json
@@ -3,7 +3,7 @@
   "description": "List of properties of the element template.",
   "allOf": [
     { "$ref": "examples.json#/properties" }
-  ],  
+  ],
   "items": {
     "type": "object",
     "default": {},
@@ -28,6 +28,10 @@
       }
     ],
     "properties": {
+      "id": {
+        "type": "string",
+        "description": "Unique identifier of the property."
+      },
       "value": {
         "$id": "#/properties/property/value",
         "type": [
@@ -138,6 +142,9 @@
         "$id": "#/properties/property/group",
         "type": "string",
         "description": "The custom group of a control field."
+      },
+      "condition": {
+        "$ref": "condition.json"
       }
     }
   }

--- a/packages/element-templates-json-schema-shared/src/defs/condition.json
+++ b/packages/element-templates-json-schema-shared/src/defs/condition.json
@@ -1,0 +1,63 @@
+{
+  "$id": "#/condition",
+  "type": "object",
+  "description": "Condition to activate the binding.",
+  "allOf": [
+    {
+      "$ref": "examples.json#/condition"
+    }
+  ],
+  "required": [
+    "property"
+  ],
+  "errorMessage": {
+    "required": {
+      "property": "missing property name for condition"
+    }
+  },
+  "properties": {
+    "type": {
+      "$id": "#/condition/type",
+      "const": "simple",
+      "description": "The type of the condition.",
+      "default": "simple"
+    },
+    "property": {
+      "$id": "#/condition/property",
+      "type": "string",
+      "description": "The id of the property to check."
+    }
+  },
+  "oneOf": [
+    {
+      "properties": {
+        "equals": {
+          "type": [
+            "string",
+            "number",
+            "boolean"
+          ]
+        }
+      },
+      "required": [
+        "equals"
+      ]
+    },
+    {
+      "properties": {
+        "oneOf": {
+          "type": "array",
+          "items": {
+            "type": [
+              "string",
+              "number"
+            ]
+          }
+        }
+      },
+      "required": [
+        "oneOf"
+      ]
+    }
+  ]
+}

--- a/packages/element-templates-json-schema-shared/src/defs/examples.json
+++ b/packages/element-templates-json-schema-shared/src/defs/examples.json
@@ -44,5 +44,19 @@
       "bpmn:ExclusiveGateway",
       "bpmn:ParallelGateway"
     ]
+  },
+  "condition": {
+    "examples": [
+      {
+        "type": "simple",
+        "property": "httpMethod",
+        "equals": "GET"
+      },
+      {
+        "type": "simple",
+        "property": "httpMethod",
+        "oneOf": [ "POST", "PUT", "DELETE" ]
+      }
+    ]
   }
 }

--- a/packages/element-templates-json-schema/resources/schema.json
+++ b/packages/element-templates-json-schema/resources/schema.json
@@ -48,6 +48,10 @@
               }
             ],
             "properties": {
+              "id": {
+                "type": "string",
+                "description": "Unique identifier of the property."
+              },
               "value": {
                 "$id": "#/properties/property/value",
                 "type": [
@@ -164,6 +168,84 @@
                 "$id": "#/properties/property/group",
                 "type": "string",
                 "description": "The custom group of a control field."
+              },
+              "condition": {
+                "$id": "#/condition",
+                "type": "object",
+                "description": "Condition to activate the binding.",
+                "allOf": [
+                  {
+                    "examples": [
+                      {
+                        "type": "simple",
+                        "property": "httpMethod",
+                        "equals": "GET"
+                      },
+                      {
+                        "type": "simple",
+                        "property": "httpMethod",
+                        "oneOf": [
+                          "POST",
+                          "PUT",
+                          "DELETE"
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "required": [
+                  "property"
+                ],
+                "errorMessage": {
+                  "required": {
+                    "property": "missing property name for condition"
+                  }
+                },
+                "properties": {
+                  "type": {
+                    "$id": "#/condition/type",
+                    "const": "simple",
+                    "description": "The type of the condition.",
+                    "default": "simple"
+                  },
+                  "property": {
+                    "$id": "#/condition/property",
+                    "type": "string",
+                    "description": "The id of the property to check."
+                  }
+                },
+                "oneOf": [
+                  {
+                    "properties": {
+                      "equals": {
+                        "type": [
+                          "string",
+                          "number",
+                          "boolean"
+                        ]
+                      }
+                    },
+                    "required": [
+                      "equals"
+                    ]
+                  },
+                  {
+                    "properties": {
+                      "oneOf": {
+                        "type": "array",
+                        "items": {
+                          "type": [
+                            "string",
+                            "number"
+                          ]
+                        }
+                      }
+                    },
+                    "required": [
+                      "oneOf"
+                    ]
+                  }
+                ]
               }
             }
           }

--- a/packages/element-templates-json-schema/test/fixtures/condition-default-type.js
+++ b/packages/element-templates-json-schema/test/fixtures/condition-default-type.js
@@ -1,0 +1,67 @@
+export const template = {
+  'name': 'Condition',
+  'id': 'example.com.condition',
+  'appliesTo': [
+    'bpmn:ServiceTask'
+  ],
+  'properties': [
+    {
+      'id': 'myId',
+      'label': 'input 1',
+      'type': 'String',
+      'binding': {
+        'type': 'property',
+        'name': 'input1'
+      }
+    },
+    {
+      'label': 'input 2',
+      'type': 'String',
+      'condition': {
+        'property': 'myId'
+      },
+      'binding': {
+        'type': 'property',
+        'name': 'input2'
+      }
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'required',
+    dataPath: '/properties/1/condition',
+    schemaPath: '#/definitions/properties/allOf/0/items/properties/condition/oneOf/0/required',
+    params: { missingProperty: 'equals' },
+    message: "should have required property 'equals'"
+  },
+  {
+    keyword: 'required',
+    dataPath: '/properties/1/condition',
+    schemaPath: '#/definitions/properties/allOf/0/items/properties/condition/oneOf/1/required',
+    params: { missingProperty: 'oneOf' },
+    message: "should have required property 'oneOf'"
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '/properties/1/condition',
+    schemaPath: '#/definitions/properties/allOf/0/items/properties/condition/oneOf',
+    params: { passingSchemas: null },
+    message: 'should match exactly one schema in oneOf'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: { type: 'array' },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: { passingSchemas: null },
+    message: 'should match exactly one schema in oneOf'
+  }
+];

--- a/packages/element-templates-json-schema/test/fixtures/condition-missing-condition-keyword.js
+++ b/packages/element-templates-json-schema/test/fixtures/condition-missing-condition-keyword.js
@@ -1,0 +1,68 @@
+export const template = {
+  'name': 'Condition',
+  'id': 'example.com.condition',
+  'appliesTo': [
+    'bpmn:ServiceTask'
+  ],
+  'properties': [
+    {
+      'id': 'myId',
+      'label': 'input 1',
+      'type': 'String',
+      'binding': {
+        'type': 'property',
+        'name': 'input1'
+      }
+    },
+    {
+      'label': 'input 2',
+      'type': 'String',
+      'condition': {
+        'type': 'simple',
+        'property': 'myId'
+      },
+      'binding': {
+        'type': 'property',
+        'name': 'input2'
+      }
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'required',
+    dataPath: '/properties/1/condition',
+    schemaPath: '#/definitions/properties/allOf/0/items/properties/condition/oneOf/0/required',
+    params: { missingProperty: 'equals' },
+    message: "should have required property 'equals'"
+  },
+  {
+    keyword: 'required',
+    dataPath: '/properties/1/condition',
+    schemaPath: '#/definitions/properties/allOf/0/items/properties/condition/oneOf/1/required',
+    params: { missingProperty: 'oneOf' },
+    message: "should have required property 'oneOf'"
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '/properties/1/condition',
+    schemaPath: '#/definitions/properties/allOf/0/items/properties/condition/oneOf',
+    params: { passingSchemas: null },
+    message: 'should match exactly one schema in oneOf'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: { type: 'array' },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: { passingSchemas: null },
+    message: 'should match exactly one schema in oneOf'
+  }
+];

--- a/packages/element-templates-json-schema/test/fixtures/condition-missing-property.js
+++ b/packages/element-templates-json-schema/test/fixtures/condition-missing-property.js
@@ -1,0 +1,65 @@
+export const template = {
+  'name': 'Condition',
+  'id': 'example.com.condition',
+  'appliesTo': [
+    'bpmn:ServiceTask'
+  ],
+  'properties': [
+    {
+      'id': 'myId',
+      'label': 'input 1',
+      'type': 'String',
+      'binding': {
+        'type': 'property',
+        'name': 'input1'
+      }
+    },
+    {
+      'label': 'input 2',
+      'type': 'String',
+      'condition': {
+        'type': 'simple',
+        equals: 'text'
+      },
+      'binding': {
+        'type': 'property',
+        'name': 'input2'
+      }
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'errorMessage',
+    dataPath: '/properties/1/condition',
+    schemaPath: '#/definitions/properties/allOf/0/items/properties/condition/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'required',
+          dataPath: '/properties/1/condition',
+          schemaPath: '#/definitions/properties/allOf/0/items/properties/condition/required',
+          params: { missingProperty: 'property' },
+          message: "should have required property 'property'",
+          emUsed: true
+        }
+      ]
+    },
+    message: 'missing property name for condition'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: { type: 'array' },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: { passingSchemas: null },
+    message: 'should match exactly one schema in oneOf'
+  }
+];

--- a/packages/element-templates-json-schema/test/fixtures/condition-wrong-type.js
+++ b/packages/element-templates-json-schema/test/fixtures/condition-wrong-type.js
@@ -1,0 +1,61 @@
+export const template = {
+  'name': 'Condition',
+  'id': 'example.com.condition',
+  'appliesTo': [
+    'bpmn:ServiceTask'
+  ],
+  'properties': [
+    {
+      'id': 'myId',
+      'label': 'input 1',
+      'type': 'String',
+      'binding': {
+        'type': 'property',
+        'name': 'input1'
+      }
+    },
+    {
+      'label': 'input 2',
+      'type': 'String',
+      'condition': {
+        'type': 'made-up',
+        'property': 'myId',
+        'equals': 'foo'
+      },
+      'binding': {
+        'type': 'property',
+        'name': 'input2'
+      }
+    }
+  ]
+};
+
+export const errors = [
+  {
+    'dataPath': '/properties/1/condition/type',
+    'keyword': 'const',
+    'message': 'should be equal to constant',
+    'params': {
+      'allowedValue': 'simple'
+    },
+    'schemaPath': '#/definitions/properties/allOf/0/items/properties/condition/properties/type/const'
+  },
+  {
+    'dataPath': '',
+    'keyword': 'type',
+    'message': 'should be array',
+    'params': {
+      'type': 'array',
+    },
+    'schemaPath': '#/oneOf/1/type'
+  },
+  {
+    'dataPath': '',
+    'keyword': 'oneOf',
+    'message': 'should match exactly one schema in oneOf',
+    'params': {
+      'passingSchemas': null
+    },
+    'schemaPath': '#/oneOf'
+  }
+];

--- a/packages/element-templates-json-schema/test/fixtures/condition-wrong-types.js
+++ b/packages/element-templates-json-schema/test/fixtures/condition-wrong-types.js
@@ -1,0 +1,110 @@
+export const template = {
+  'name': 'Condition',
+  'id': 'example.com.condition',
+  'appliesTo': [
+    'bpmn:ServiceTask'
+  ],
+  'properties': [
+    {
+      'id': 'myId',
+      'label': 'input 1',
+      'type': 'String',
+      'binding': {
+        'type': 'property',
+        'name': 'input1'
+      }
+    },
+    {
+      'label': 'equals array',
+      'type': 'String',
+      'condition': {
+        'type': 'simple',
+        'property': 'myId',
+        equals: [ 'text', 'text2' ]
+      },
+      'binding': {
+        'type': 'property',
+        'name': 'input2'
+      }
+    },
+    {
+      'label': 'array of booleans',
+      'type': 'String',
+      'condition': {
+        'type': 'simple',
+        'property': 'myId',
+        oneOf: [ true, false ]
+      },
+      'binding': {
+        'type': 'property',
+        'name': 'input2'
+      }
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'type',
+    dataPath: '/properties/1/condition/equals',
+    schemaPath: '#/definitions/properties/allOf/0/items/properties/condition/oneOf/0/properties/equals/type',
+    params: { type: [ 'string', 'number', 'boolean' ] },
+    message: 'should be string,number,boolean'
+  },
+  {
+    keyword: 'required',
+    dataPath: '/properties/1/condition',
+    schemaPath: '#/definitions/properties/allOf/0/items/properties/condition/oneOf/1/required',
+    params: { missingProperty: 'oneOf' },
+    message: "should have required property 'oneOf'"
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '/properties/1/condition',
+    schemaPath: '#/definitions/properties/allOf/0/items/properties/condition/oneOf',
+    params: { passingSchemas: null },
+    message: 'should match exactly one schema in oneOf'
+  },
+  {
+    keyword: 'required',
+    dataPath: '/properties/2/condition',
+    schemaPath: '#/definitions/properties/allOf/0/items/properties/condition/oneOf/0/required',
+    params: { missingProperty: 'equals' },
+    message: "should have required property 'equals'"
+  },
+  {
+    keyword: 'type',
+    dataPath: '/properties/2/condition/oneOf/0',
+    schemaPath: '#/definitions/properties/allOf/0/items/properties/condition/oneOf/1/properties/oneOf/items/type',
+    params: { type: [ 'string', 'number' ] },
+    message: 'should be string,number'
+  },
+  {
+    keyword: 'type',
+    dataPath: '/properties/2/condition/oneOf/1',
+    schemaPath: '#/definitions/properties/allOf/0/items/properties/condition/oneOf/1/properties/oneOf/items/type',
+    params: { type: [ 'string', 'number' ] },
+    message: 'should be string,number'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '/properties/2/condition',
+    schemaPath: '#/definitions/properties/allOf/0/items/properties/condition/oneOf',
+    params: { passingSchemas: null },
+    message: 'should match exactly one schema in oneOf'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: { type: 'array' },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: { passingSchemas: null },
+    message: 'should match exactly one schema in oneOf'
+  }
+];

--- a/packages/element-templates-json-schema/test/fixtures/condition.js
+++ b/packages/element-templates-json-schema/test/fixtures/condition.js
@@ -1,0 +1,97 @@
+export const template = {
+  'name': 'Condition',
+  'id': 'example.com.condition',
+  'appliesTo': [
+    'bpmn:ServiceTask'
+  ],
+  'properties': [
+    {
+      'id': 'myId',
+      'label': 'input 1',
+      'type': 'String',
+      'binding': {
+        'type': 'property',
+        'name': 'input1'
+      }
+    },
+    {
+      'label': 'equals (string)',
+      'type': 'String',
+      'condition': {
+        'type': 'simple',
+        property: 'myId',
+        equals: 'text'
+      },
+      'binding': {
+        'type': 'property',
+        'name': 'input2'
+      }
+    },
+    {
+      'label': 'equals (number)',
+      'type': 'String',
+      'condition': {
+        'type': 'simple',
+        property: 'myId',
+        equals: 11
+      },
+      'binding': {
+        'type': 'property',
+        'name': 'input3'
+      }
+    },
+    {
+      'label': 'equals (boolean)',
+      'type': 'String',
+      'condition': {
+        'type': 'simple',
+        property: 'myId',
+        equals: true
+      },
+      'binding': {
+        'type': 'property',
+        'name': 'input4'
+      }
+    },
+    {
+      'label': 'one of (string)',
+      'type': 'String',
+      'condition': {
+        'type': 'simple',
+        property: 'myId',
+        oneOf: [ 'text', 'another text' ]
+      },
+      'binding': {
+        'type': 'property',
+        'name': 'input4'
+      }
+    },
+    {
+      'label': 'one of (number)',
+      'type': 'String',
+      'condition': {
+        'type': 'simple',
+        property: 'myId',
+        oneOf: [ 2, 5 ]
+      },
+      'binding': {
+        'type': 'property',
+        'name': 'input4'
+      }
+    },
+    {
+      'label': 'default condition type',
+      'type': 'String',
+      'condition': {
+        property: 'myId',
+        oneOf: [ 2, 5 ]
+      },
+      'binding': {
+        'type': 'property',
+        'name': 'input4'
+      }
+    }
+  ]
+};
+
+export const errors = null;

--- a/packages/element-templates-json-schema/test/spec/validationSpec.js
+++ b/packages/element-templates-json-schema/test/spec/validationSpec.js
@@ -271,6 +271,27 @@ describe('validation', function() {
 
     });
 
+
+    describe('condition', function() {
+
+      testTemplate('condition');
+
+
+      testTemplate('condition-missing-property');
+
+
+      testTemplate('condition-missing-condition-keyword');
+
+
+      testTemplate('condition-wrong-types');
+
+
+      testTemplate('condition-default-type');
+
+
+      testTemplate('condition-wrong-type');
+    });
+
   });
 
 

--- a/packages/zeebe-element-templates-json-schema/resources/schema.json
+++ b/packages/zeebe-element-templates-json-schema/resources/schema.json
@@ -48,6 +48,10 @@
               }
             ],
             "properties": {
+              "id": {
+                "type": "string",
+                "description": "Unique identifier of the property."
+              },
               "value": {
                 "$id": "#/properties/property/value",
                 "type": [
@@ -164,6 +168,84 @@
                 "$id": "#/properties/property/group",
                 "type": "string",
                 "description": "The custom group of a control field."
+              },
+              "condition": {
+                "$id": "#/condition",
+                "type": "object",
+                "description": "Condition to activate the binding.",
+                "allOf": [
+                  {
+                    "examples": [
+                      {
+                        "type": "simple",
+                        "property": "httpMethod",
+                        "equals": "GET"
+                      },
+                      {
+                        "type": "simple",
+                        "property": "httpMethod",
+                        "oneOf": [
+                          "POST",
+                          "PUT",
+                          "DELETE"
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "required": [
+                  "property"
+                ],
+                "errorMessage": {
+                  "required": {
+                    "property": "missing property name for condition"
+                  }
+                },
+                "properties": {
+                  "type": {
+                    "$id": "#/condition/type",
+                    "const": "simple",
+                    "description": "The type of the condition.",
+                    "default": "simple"
+                  },
+                  "property": {
+                    "$id": "#/condition/property",
+                    "type": "string",
+                    "description": "The id of the property to check."
+                  }
+                },
+                "oneOf": [
+                  {
+                    "properties": {
+                      "equals": {
+                        "type": [
+                          "string",
+                          "number",
+                          "boolean"
+                        ]
+                      }
+                    },
+                    "required": [
+                      "equals"
+                    ]
+                  },
+                  {
+                    "properties": {
+                      "oneOf": {
+                        "type": "array",
+                        "items": {
+                          "type": [
+                            "string",
+                            "number"
+                          ]
+                        }
+                      }
+                    },
+                    "required": [
+                      "oneOf"
+                    ]
+                  }
+                ]
               }
             }
           }

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/condition-default-type.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/condition-default-type.js
@@ -1,0 +1,67 @@
+export const template = {
+  'name': 'Condition',
+  'id': 'example.com.condition',
+  'appliesTo': [
+    'bpmn:ServiceTask'
+  ],
+  'properties': [
+    {
+      'id': 'myId',
+      'label': 'input 1',
+      'type': 'String',
+      'binding': {
+        'type': 'property',
+        'name': 'input1'
+      }
+    },
+    {
+      'label': 'input 2',
+      'type': 'String',
+      'condition': {
+        'property': 'myId'
+      },
+      'binding': {
+        'type': 'property',
+        'name': 'input2'
+      }
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'required',
+    dataPath: '/properties/1/condition',
+    schemaPath: '#/definitions/properties/allOf/0/items/properties/condition/oneOf/0/required',
+    params: { missingProperty: 'equals' },
+    message: "should have required property 'equals'"
+  },
+  {
+    keyword: 'required',
+    dataPath: '/properties/1/condition',
+    schemaPath: '#/definitions/properties/allOf/0/items/properties/condition/oneOf/1/required',
+    params: { missingProperty: 'oneOf' },
+    message: "should have required property 'oneOf'"
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '/properties/1/condition',
+    schemaPath: '#/definitions/properties/allOf/0/items/properties/condition/oneOf',
+    params: { passingSchemas: null },
+    message: 'should match exactly one schema in oneOf'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: { type: 'array' },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: { passingSchemas: null },
+    message: 'should match exactly one schema in oneOf'
+  }
+];

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/condition-missing-condition-keyword.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/condition-missing-condition-keyword.js
@@ -1,0 +1,68 @@
+export const template = {
+  'name': 'Condition',
+  'id': 'example.com.condition',
+  'appliesTo': [
+    'bpmn:ServiceTask'
+  ],
+  'properties': [
+    {
+      'id': 'myId',
+      'label': 'input 1',
+      'type': 'String',
+      'binding': {
+        'type': 'property',
+        'name': 'input1'
+      }
+    },
+    {
+      'label': 'input 2',
+      'type': 'String',
+      'condition': {
+        'type': 'simple',
+        'property': 'myId'
+      },
+      'binding': {
+        'type': 'property',
+        'name': 'input2'
+      }
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'required',
+    dataPath: '/properties/1/condition',
+    schemaPath: '#/definitions/properties/allOf/0/items/properties/condition/oneOf/0/required',
+    params: { missingProperty: 'equals' },
+    message: "should have required property 'equals'"
+  },
+  {
+    keyword: 'required',
+    dataPath: '/properties/1/condition',
+    schemaPath: '#/definitions/properties/allOf/0/items/properties/condition/oneOf/1/required',
+    params: { missingProperty: 'oneOf' },
+    message: "should have required property 'oneOf'"
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '/properties/1/condition',
+    schemaPath: '#/definitions/properties/allOf/0/items/properties/condition/oneOf',
+    params: { passingSchemas: null },
+    message: 'should match exactly one schema in oneOf'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: { type: 'array' },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: { passingSchemas: null },
+    message: 'should match exactly one schema in oneOf'
+  }
+];

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/condition-missing-property.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/condition-missing-property.js
@@ -1,0 +1,65 @@
+export const template = {
+  'name': 'Condition',
+  'id': 'example.com.condition',
+  'appliesTo': [
+    'bpmn:ServiceTask'
+  ],
+  'properties': [
+    {
+      'id': 'myId',
+      'label': 'input 1',
+      'type': 'String',
+      'binding': {
+        'type': 'property',
+        'name': 'input1'
+      }
+    },
+    {
+      'label': 'input 2',
+      'type': 'String',
+      'condition': {
+        'type': 'simple',
+        equals: 'text'
+      },
+      'binding': {
+        'type': 'property',
+        'name': 'input2'
+      }
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'errorMessage',
+    dataPath: '/properties/1/condition',
+    schemaPath: '#/definitions/properties/allOf/0/items/properties/condition/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'required',
+          dataPath: '/properties/1/condition',
+          schemaPath: '#/definitions/properties/allOf/0/items/properties/condition/required',
+          params: { missingProperty: 'property' },
+          message: "should have required property 'property'",
+          emUsed: true
+        }
+      ]
+    },
+    message: 'missing property name for condition'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: { type: 'array' },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: { passingSchemas: null },
+    message: 'should match exactly one schema in oneOf'
+  }
+];

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/condition-wrong-type.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/condition-wrong-type.js
@@ -1,0 +1,61 @@
+export const template = {
+  'name': 'Condition',
+  'id': 'example.com.condition',
+  'appliesTo': [
+    'bpmn:ServiceTask'
+  ],
+  'properties': [
+    {
+      'id': 'myId',
+      'label': 'input 1',
+      'type': 'String',
+      'binding': {
+        'type': 'property',
+        'name': 'input1'
+      }
+    },
+    {
+      'label': 'input 2',
+      'type': 'String',
+      'condition': {
+        'type': 'made-up',
+        'property': 'myId',
+        'equals': 'foo'
+      },
+      'binding': {
+        'type': 'property',
+        'name': 'input2'
+      }
+    }
+  ]
+};
+
+export const errors = [
+  {
+    'dataPath': '/properties/1/condition/type',
+    'keyword': 'const',
+    'message': 'should be equal to constant',
+    'params': {
+      'allowedValue': 'simple'
+    },
+    'schemaPath': '#/definitions/properties/allOf/0/items/properties/condition/properties/type/const'
+  },
+  {
+    'dataPath': '',
+    'keyword': 'type',
+    'message': 'should be array',
+    'params': {
+      'type': 'array',
+    },
+    'schemaPath': '#/oneOf/1/type'
+  },
+  {
+    'dataPath': '',
+    'keyword': 'oneOf',
+    'message': 'should match exactly one schema in oneOf',
+    'params': {
+      'passingSchemas': null
+    },
+    'schemaPath': '#/oneOf'
+  }
+];

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/condition-wrong-types.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/condition-wrong-types.js
@@ -1,0 +1,110 @@
+export const template = {
+  'name': 'Condition',
+  'id': 'example.com.condition',
+  'appliesTo': [
+    'bpmn:ServiceTask'
+  ],
+  'properties': [
+    {
+      'id': 'myId',
+      'label': 'input 1',
+      'type': 'String',
+      'binding': {
+        'type': 'property',
+        'name': 'input1'
+      }
+    },
+    {
+      'label': 'equals array',
+      'type': 'String',
+      'condition': {
+        'type': 'simple',
+        'property': 'myId',
+        equals: [ 'text', 'text2' ]
+      },
+      'binding': {
+        'type': 'property',
+        'name': 'input2'
+      }
+    },
+    {
+      'label': 'array of booleans',
+      'type': 'String',
+      'condition': {
+        'type': 'simple',
+        'property': 'myId',
+        oneOf: [ true, false ]
+      },
+      'binding': {
+        'type': 'property',
+        'name': 'input2'
+      }
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'type',
+    dataPath: '/properties/1/condition/equals',
+    schemaPath: '#/definitions/properties/allOf/0/items/properties/condition/oneOf/0/properties/equals/type',
+    params: { type: [ 'string', 'number', 'boolean' ] },
+    message: 'should be string,number,boolean'
+  },
+  {
+    keyword: 'required',
+    dataPath: '/properties/1/condition',
+    schemaPath: '#/definitions/properties/allOf/0/items/properties/condition/oneOf/1/required',
+    params: { missingProperty: 'oneOf' },
+    message: "should have required property 'oneOf'"
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '/properties/1/condition',
+    schemaPath: '#/definitions/properties/allOf/0/items/properties/condition/oneOf',
+    params: { passingSchemas: null },
+    message: 'should match exactly one schema in oneOf'
+  },
+  {
+    keyword: 'required',
+    dataPath: '/properties/2/condition',
+    schemaPath: '#/definitions/properties/allOf/0/items/properties/condition/oneOf/0/required',
+    params: { missingProperty: 'equals' },
+    message: "should have required property 'equals'"
+  },
+  {
+    keyword: 'type',
+    dataPath: '/properties/2/condition/oneOf/0',
+    schemaPath: '#/definitions/properties/allOf/0/items/properties/condition/oneOf/1/properties/oneOf/items/type',
+    params: { type: [ 'string', 'number' ] },
+    message: 'should be string,number'
+  },
+  {
+    keyword: 'type',
+    dataPath: '/properties/2/condition/oneOf/1',
+    schemaPath: '#/definitions/properties/allOf/0/items/properties/condition/oneOf/1/properties/oneOf/items/type',
+    params: { type: [ 'string', 'number' ] },
+    message: 'should be string,number'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '/properties/2/condition',
+    schemaPath: '#/definitions/properties/allOf/0/items/properties/condition/oneOf',
+    params: { passingSchemas: null },
+    message: 'should match exactly one schema in oneOf'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: { type: 'array' },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: { passingSchemas: null },
+    message: 'should match exactly one schema in oneOf'
+  }
+];

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/condition.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/condition.js
@@ -1,0 +1,97 @@
+export const template = {
+  'name': 'Condition',
+  'id': 'example.com.condition',
+  'appliesTo': [
+    'bpmn:ServiceTask'
+  ],
+  'properties': [
+    {
+      'id': 'myId',
+      'label': 'input 1',
+      'type': 'String',
+      'binding': {
+        'type': 'property',
+        'name': 'input1'
+      }
+    },
+    {
+      'label': 'equals (string)',
+      'type': 'String',
+      'condition': {
+        'type': 'simple',
+        property: 'myId',
+        equals: 'text'
+      },
+      'binding': {
+        'type': 'property',
+        'name': 'input2'
+      }
+    },
+    {
+      'label': 'equals (number)',
+      'type': 'String',
+      'condition': {
+        'type': 'simple',
+        property: 'myId',
+        equals: 11
+      },
+      'binding': {
+        'type': 'property',
+        'name': 'input3'
+      }
+    },
+    {
+      'label': 'equals (boolean)',
+      'type': 'String',
+      'condition': {
+        'type': 'simple',
+        property: 'myId',
+        equals: true
+      },
+      'binding': {
+        'type': 'property',
+        'name': 'input4'
+      }
+    },
+    {
+      'label': 'one of (string)',
+      'type': 'String',
+      'condition': {
+        'type': 'simple',
+        property: 'myId',
+        oneOf: [ 'text', 'another text' ]
+      },
+      'binding': {
+        'type': 'property',
+        'name': 'input4'
+      }
+    },
+    {
+      'label': 'one of (number)',
+      'type': 'String',
+      'condition': {
+        'type': 'simple',
+        property: 'myId',
+        oneOf: [ 2, 5 ]
+      },
+      'binding': {
+        'type': 'property',
+        'name': 'input4'
+      }
+    },
+    {
+      'label': 'default condition type',
+      'type': 'String',
+      'condition': {
+        property: 'myId',
+        oneOf: [ 2, 5 ]
+      },
+      'binding': {
+        'type': 'property',
+        'name': 'input4'
+      }
+    }
+  ]
+};
+
+export const errors = null;

--- a/packages/zeebe-element-templates-json-schema/test/spec/validationSpec.js
+++ b/packages/zeebe-element-templates-json-schema/test/spec/validationSpec.js
@@ -214,6 +214,27 @@ describe('validation', function() {
 
     });
 
+
+    describe('condition', function() {
+
+      testTemplate('condition');
+
+
+      testTemplate('condition-missing-property');
+
+
+      testTemplate('condition-missing-condition-keyword');
+
+
+      testTemplate('condition-wrong-types');
+
+
+      testTemplate('condition-default-type');
+
+
+      testTemplate('condition-wrong-type');
+    });
+
   });
 
 });


### PR DESCRIPTION
```json
"condition": {
  "examples": [
    {
      "type": "simple",
      "property": "httpMethod",
      "equals": "GET"
    },
    {
      "type": "simple",
      "property": "httpMethod",
      "oneOf": [ "POST", "PUT", "DELETE" ]
    }
  ]
}
```

Closes #54
