### PR TITLE
chore: add alpha release task

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,21 @@ Run tests in individual [packages](./packages):
 npm run dev -- @camunda/zeebe-element-templates-json-schema
 ```
 
+## Release
+
+We use [`lerna`](https://github.com/lerna/lerna) to publish releases. All [packages](./packages/) can be released independently (lerna will take care of this).
+
+```sh
+# release stable version
+npm run release
+
+# release alpha version
+npm run release:alpha
+
+# execute dry run
+npm run release:dry
+```
+
 ## License
 
 MIT

--- a/package.json
+++ b/package.json
@@ -12,8 +12,10 @@
     "build:zeebe": "lerna run build --scope @camunda/zeebe-element-templates-json-schema",
     "all": "run-s build lint test",
     "lerna-publish": "lerna publish",
+    "lerna-publish:alpha": "lerna publish --dist-tag next",
     "lerna-publish:dry": "lerna version --no-git-tag-version --no-push",
     "release": "run-s build test lerna-publish",
+    "release:alpha": "run-s build test lerna-publish:alpha",
     "release:dry": "run-s build test lerna-publish:dry",
     "postinstall": "lerna bootstrap --hoist"
   },


### PR DESCRIPTION
Adds an `npm run release:alpha` script to publish alpha releases.

Context: https://camunda.slack.com/archives/GP70M0J6M/p1653920841326989
Context: https://github.com/lerna/lerna/blob/main/commands/publish/README.md#--dist-tag-tag