### PR TITLE
feat: support `language` on `Text` elements

### DIFF
--- a/packages/zeebe-element-templates-json-schema/resources/error-messages.json
+++ b/packages/zeebe-element-templates-json-schema/resources/error-messages.json
@@ -248,6 +248,21 @@
       "allOf",
       1,
       "items",
+      "allOf",
+      5,
+      "then",
+      "properties",
+      "type"
+    ],
+    "errorMessage": "language is only supported for \"Text\" type"
+  },
+  {
+    "path": [
+      "definitions",
+      "properties",
+      "allOf",
+      1,
+      "items",
       "properties",
       "binding",
       "allOf",

--- a/packages/zeebe-element-templates-json-schema/resources/schema.json
+++ b/packages/zeebe-element-templates-json-schema/resources/schema.json
@@ -406,6 +406,29 @@
                     "type"
                   ]
                 }
+              },
+              {
+                "if": {
+                  "properties": {
+                    "language": {
+                      "not": {
+                        "const": null
+                      }
+                    }
+                  },
+                  "required": [
+                    "language"
+                  ]
+                },
+                "then": {
+                  "properties": {
+                    "type": {
+                      "enum": [
+                        "Text"
+                      ]
+                    }
+                  }
+                }
               }
             ],
             "properties": {
@@ -546,6 +569,11 @@
                   "optional",
                   "required"
                 ]
+              },
+              "language": {
+                "$id": "#/properties/property/language",
+                "type": "string",
+                "description": "Indicates that the field is a custom language editor"
               }
             }
           }

--- a/packages/zeebe-element-templates-json-schema/src/defs/properties.json
+++ b/packages/zeebe-element-templates-json-schema/src/defs/properties.json
@@ -161,6 +161,29 @@
             "type"
           ]
         }
+      },
+      {
+        "if": {
+          "properties": {
+            "language": {
+              "not": {
+                "const": null
+              }
+            }
+          },
+          "required": [
+            "language"
+          ]
+        },
+        "then": {
+          "properties": {
+            "type": {
+              "enum": [
+                "Text"
+              ]
+            }
+          }
+        }
       }
     ],
     "properties": {
@@ -277,6 +300,11 @@
           "optional",
           "required"
         ]
+      },
+      "language": {
+        "$id": "#/properties/property/language",
+        "type": "string",
+        "description": "Indicates that the field is a custom language editor"
       }
     }
   }

--- a/packages/zeebe-element-templates-json-schema/src/error-messages.json
+++ b/packages/zeebe-element-templates-json-schema/src/error-messages.json
@@ -99,6 +99,21 @@
       "allOf",
       1,
       "items",
+      "allOf",
+      5,
+      "then",
+      "properties",
+      "type"
+    ],
+    "errorMessage": "language is only supported for \"Text\" type"
+  },
+  {
+    "path": [
+      "definitions",
+      "properties",
+      "allOf",
+      1,
+      "items",
       "properties",
       "binding",
       "allOf",

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/language.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/language.js
@@ -1,0 +1,129 @@
+export const template = {
+  name: 'Pattern Template',
+  id: 'com.example.PatternTemplate',
+  appliesTo: [
+    'bpmn:Task'
+  ],
+  properties: [
+    {
+      label: 'Language (valid on <Text>)',
+      type: 'Text',
+      language: 'GraphQL',
+      binding: {
+        type: 'property',
+        name: 'prop'
+      }
+    },
+    {
+      label: 'Language (invalid on <String>)',
+      type: 'String',
+      language: 'GraphQL',
+      binding: {
+        type: 'property',
+        name: 'prop'
+      }
+    },
+    {
+      label: 'Language (invalid type)',
+      type: 'String',
+      language: 1,
+      binding: {
+        type: 'property',
+        name: 'prop'
+      }
+    }
+  ]
+};
+
+
+export const errors = [
+  {
+    keyword: 'errorMessage',
+    dataPath: '/properties/1/type',
+    schemaPath: '#/definitions/properties/allOf/1/items/allOf/5/then/properties/type/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'enum',
+          dataPath: '/properties/1/type',
+          schemaPath: '#/definitions/properties/allOf/1/items/allOf/5/then/properties/type/enum',
+          params: {
+            allowedValues: [
+              'Text'
+            ]
+          },
+          message: 'should be equal to one of the allowed values',
+          emUsed: true
+        }
+      ]
+    },
+    message: 'language is only supported for "Text" type'
+  },
+  {
+    dataPath: '/properties/1',
+    keyword: 'if',
+    message: 'should match "then" schema',
+    params: {
+      failingKeyword: 'then'
+    },
+    schemaPath: '#/definitions/properties/allOf/1/items/allOf/5/if',
+  },
+  {
+    keyword: 'errorMessage',
+    dataPath: '/properties/2/type',
+    schemaPath: '#/definitions/properties/allOf/1/items/allOf/5/then/properties/type/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'enum',
+          dataPath: '/properties/2/type',
+          schemaPath: '#/definitions/properties/allOf/1/items/allOf/5/then/properties/type/enum',
+          params: {
+            allowedValues: [
+              'Text'
+            ]
+          },
+          message: 'should be equal to one of the allowed values',
+          emUsed: true
+        }
+      ]
+    },
+    message: 'language is only supported for "Text" type'
+  },
+  {
+    dataPath: '/properties/2',
+    keyword: 'if' ,
+    message: 'should match "then" schema',
+    params: {
+      failingKeyword: 'then'
+    },
+    schemaPath: '#/definitions/properties/allOf/1/items/allOf/5/if'
+  },
+  {
+    dataPath: '/properties/2/language',
+    keyword: 'type',
+    message: 'should be string',
+    params: {
+      type: 'string'
+    },
+    schemaPath: '#/definitions/properties/allOf/1/items/properties/language/type'
+  },
+  {
+    dataPath: '',
+    keyword: 'type',
+    message: 'should be array',
+    params: {
+      type: 'array'
+    },
+    schemaPath: '#/oneOf/1/type'
+  },
+  {
+    dataPath: '',
+    keyword: 'oneOf',
+    message: 'should match exactly one schema in oneOf',
+    params: {
+      passingSchemas: null
+    },
+    schemaPath: '#/oneOf'
+  }
+];

--- a/packages/zeebe-element-templates-json-schema/test/spec/validationSpec.js
+++ b/packages/zeebe-element-templates-json-schema/test/spec/validationSpec.js
@@ -136,6 +136,9 @@ describe('validation', function() {
     testTemplate('feel-type-mismatch');
 
 
+    testTemplate('language');
+
+
     testTemplate('pattern-string');
 
 


### PR DESCRIPTION
Allows users to pass a `language` meta-data with `Text` elements:

```json
{
  "name": "My special Template
  ...
  "properties: [
    {
      "label": "Query/Mutation",
      "type": "Text",
      "language": "graphql",
      "binding": {
        "type": "zeebe:input",
        "name": "graphql.query"
      }
    }
  ],
  ...
}
```
Related to https://github.com/bpmn-io/bpmn-js-properties-panel/issues/858