### PR TITLE
feat: support zeebe:taskDefinition:retries

### DIFF
--- a/packages/zeebe-element-templates-json-schema/resources/schema.json
+++ b/packages/zeebe-element-templates-json-schema/resources/schema.json
@@ -297,6 +297,7 @@
                             "zeebe:output",
                             "zeebe:property",
                             "zeebe:taskHeader",
+                            "zeebe:taskDefinition:retries",
                             "zeebe:taskDefinition:type"
                           ]
                         }
@@ -514,6 +515,9 @@
                         "name": "property"
                       },
                       {
+                        "type": "zeebe:taskDefinition:retries"
+                      },
+                      {
                         "type": "zeebe:taskDefinition:type"
                       },
                       {
@@ -531,6 +535,7 @@
                     "enum": [
                       "property",
                       "zeebe:taskDefinition:type",
+                      "zeebe:taskDefinition:retries",
                       "zeebe:input",
                       "zeebe:output",
                       "zeebe:property",

--- a/packages/zeebe-element-templates-json-schema/src/defs/examples.json
+++ b/packages/zeebe-element-templates-json-schema/src/defs/examples.json
@@ -18,6 +18,9 @@
         "name": "property"
       },
       {
+        "type": "zeebe:taskDefinition:retries"
+      },
+      {
         "type": "zeebe:taskDefinition:type"
       },
       {

--- a/packages/zeebe-element-templates-json-schema/src/defs/properties.json
+++ b/packages/zeebe-element-templates-json-schema/src/defs/properties.json
@@ -52,6 +52,7 @@
                     "zeebe:output",
                     "zeebe:property",
                     "zeebe:taskHeader",
+                    "zeebe:taskDefinition:retries",
                     "zeebe:taskDefinition:type"
                   ]
                 }
@@ -262,6 +263,7 @@
             "enum": [
               "property",
               "zeebe:taskDefinition:type",
+              "zeebe:taskDefinition:retries",
               "zeebe:input",
               "zeebe:output",
               "zeebe:property",

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/cloud-rest-connector.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/cloud-rest-connector.js
@@ -14,6 +14,13 @@ export const template = {
       }
     },
     {
+      'type': 'Hidden',
+      'value': '5',
+      'binding': {
+        'type': 'zeebe:taskDefinition:retries'
+      }
+    },
+    {
       'label': 'REST Endpoint URL',
       'description': 'Specify the url of the REST API to talk to.',
       'type': 'String',

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/invalid-binding-type.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/invalid-binding-type.js
@@ -40,6 +40,7 @@ export const errors = [
             allowedValues: [
               'property',
               'zeebe:taskDefinition:type',
+              'zeebe:taskDefinition:retries',
               'zeebe:input',
               'zeebe:output',
               'zeebe:property',

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/invalid-zeebe-task-definition-retries-type.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/invalid-zeebe-task-definition-retries-type.js
@@ -1,0 +1,78 @@
+export const template = {
+  'name': 'InvalidZeebeTaskHeaderType',
+  'id': 'com.camunda.example.InvalidZeebeTaskHeaderType',
+  'appliesTo': [
+    'bpmn:Task'
+  ],
+  'properties': [
+    {
+      'label': 'foo',
+      'type': 'Text',
+      'binding': {
+        'type': 'zeebe:taskDefinition:retries'
+      }
+    },
+    {
+      'label': 'bar',
+      'type': 'Boolean',
+      'binding': {
+        'type': 'zeebe:taskDefinition:retries'
+      }
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'errorMessage',
+    dataPath: '/properties/1/type',
+    schemaPath: '#/definitions/properties/allOf/1/items/allOf/1/then/properties/type/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'enum',
+          emUsed: true,
+          dataPath: '/properties/1/type',
+          schemaPath: '#/definitions/properties/allOf/1/items/allOf/1/then/properties/type/enum',
+          params: {
+            'allowedValues': [
+              'String',
+              'Text',
+              'Hidden',
+              'Dropdown'
+            ]
+          },
+          message: 'should be equal to one of the allowed values'
+        }
+      ]
+    },
+    message: 'invalid property type "Boolean" for binding type "zeebe:taskDefinition:retries"; must be any of { String, Text, Hidden, Dropdown }'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/1',
+    schemaPath: '#/definitions/properties/allOf/1/items/allOf/1/if',
+    params: {
+      'failingKeyword': 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    dataPath: '',
+    keyword: 'type',
+    message: 'should be array',
+    params: {
+      type: 'array',
+    },
+    schemaPath: '#/oneOf/1/type',
+  },
+  {
+    dataPath: '',
+    keyword: 'oneOf',
+    message: 'should match exactly one schema in oneOf',
+    params: {
+      passingSchemas: null
+    },
+    schemaPath: '#/oneOf'
+  }
+];

--- a/packages/zeebe-element-templates-json-schema/test/spec/validationSpec.js
+++ b/packages/zeebe-element-templates-json-schema/test/spec/validationSpec.js
@@ -180,6 +180,9 @@ describe('validation', function() {
       testTemplate('invalid-zeebe-task-header-type');
 
 
+      testTemplate('invalid-zeebe-task-definition-retries-type');
+
+
       testTemplate('invalid-zeebe-task-definition-type-type');
 
     });


### PR DESCRIPTION
For https://github.com/camunda/camunda-modeler/issues/2936, start by defining `zeebe:taskDefinition:retries` in the schema.

@nikku you probably have a lot to say about this. I mostly duplicated behaviour of `zeebe:taskDefinition:type`. There is no special type (its value should be limited to positive integer) but I had no idea how to do that.