### PR TITLE
fix: build schemas for `36645d3` change

### DIFF
--- a/packages/element-templates-json-schema/resources/schema.json
+++ b/packages/element-templates-json-schema/resources/schema.json
@@ -192,8 +192,8 @@
                         "allMatch": [
                           {
                             "type": "simple",
-                            "property": "httpMethod",
-                            "equals": "GET"
+                            "property": "authType",
+                            "equals": "Basic"
                           },
                           {
                             "type": "simple",

--- a/packages/zeebe-element-templates-json-schema/resources/schema.json
+++ b/packages/zeebe-element-templates-json-schema/resources/schema.json
@@ -192,8 +192,8 @@
                         "allMatch": [
                           {
                             "type": "simple",
-                            "property": "httpMethod",
-                            "equals": "GET"
+                            "property": "authType",
+                            "equals": "Basic"
                           },
                           {
                             "type": "simple",


### PR DESCRIPTION
Related to https://github.com/camunda/element-templates-json-schema/commit/36645d3bc421f422537e7b45c45f234dd64eae35 - we didn't run `npm build` after changing the example