### PR TITLE
feat(zeebe): add `groups/openByDefault` property

### DIFF
--- a/packages/zeebe-element-templates-json-schema/src/defs/groups.json
+++ b/packages/zeebe-element-templates-json-schema/src/defs/groups.json
@@ -4,6 +4,12 @@
       "tooltip": {
         "$id": "#/groups/group/tooltip",
         "type": "string"
+      },
+      "openByDefault": {
+        "$id": "#/groups/group/openByDefault",
+        "type": "boolean",
+        "description": "Specifies whether the Group should be opened when first viewed. Defaults to true.",
+        "default": true
       }
     }
   }

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/groups-wrong-open-state.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/groups-wrong-open-state.js
@@ -1,0 +1,45 @@
+export const template = {
+  'name': 'Grouping',
+  'id': 'example.com.missingGroupId',
+  'appliesTo': [
+    'bpmn:ServiceTask'
+  ],
+  'properties': [],
+  'groups': [
+    {
+      'id': 'one',
+      'label': 'Group one',
+      'openByDefault': 'true'
+    }
+  ]
+};
+
+export const errors = [
+  {
+    'dataPath': '/groups/0/openByDefault',
+    'keyword': 'type',
+    'message': 'should be boolean',
+    'params': {
+      'type': 'boolean'
+    },
+    'schemaPath': '#/properties/groups/items/properties/openByDefault/type'
+  },
+  {
+    'dataPath': '',
+    'keyword': 'type',
+    'message': 'should be array',
+    'params': {
+      'type': 'array'
+    },
+    'schemaPath': '#/oneOf/1/type'
+  },
+  {
+    'dataPath': '',
+    'keyword': 'oneOf',
+    'message': 'should match exactly one schema in oneOf',
+    'params': {
+      'passingSchemas': null
+    },
+    'schemaPath': '#/oneOf'
+  }
+];

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/groups.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/groups.js
@@ -53,11 +53,13 @@ export const template = {
   'groups': [
     {
       'id': 'one',
-      'label': 'Group one'
+      'label': 'Group one',
+      'openByDefault': true
     },
     {
       'id': 'two',
-      'label': 'Group two'
+      'label': 'Group two',
+      'openByDefault': false
     },
     {
       'id': 'three',

--- a/packages/zeebe-element-templates-json-schema/test/spec/validationSpec.js
+++ b/packages/zeebe-element-templates-json-schema/test/spec/validationSpec.js
@@ -228,6 +228,9 @@ describe('validation', function() {
 
       testTemplate('groups-missing-label');
 
+
+      testTemplate('groups-wrong-open-state');
+
     });
 
 


### PR DESCRIPTION
related to https://github.com/camunda/camunda-modeler/issues/3807

integration into element-templates: https://github.com/bpmn-io/bpmn-js-element-templates/pull/18