### PR TITLE
feat: disallow condition depending on the containing property

### DIFF
--- a/packages/element-templates-json-schema-shared/src/base-error-messages.json
+++ b/packages/element-templates-json-schema-shared/src/base-error-messages.json
@@ -149,5 +149,35 @@
         "property": "missing property name for condition"
       }
     }
+  },
+  {
+    "path": [
+      "definitions",
+      "properties",
+      "allOf",
+      0,
+      "items",
+      "allOf",
+      1,
+      "allOf",
+      0,
+      "then"
+    ],
+    "errorMessage": "Invalid condition.property, must be different than property.id"
+  },
+  {
+    "path": [
+      "definitions",
+      "properties",
+      "allOf",
+      0,
+      "items",
+      "allOf",
+      1,
+      "allOf",
+      1,
+      "then"
+    ],
+    "errorMessage": "Invalid condition.property, must be different than property.id"
   }
 ]

--- a/packages/element-templates-json-schema-shared/src/base-error-messages.json
+++ b/packages/element-templates-json-schema-shared/src/base-error-messages.json
@@ -139,8 +139,8 @@
       "allOf",
       0,
       "items",
-      "properties",
-      "condition",
+      "allOf",
+      1,
       "definitions",
       "condition"
     ],

--- a/packages/element-templates-json-schema-shared/src/defs/base-properties.json
+++ b/packages/element-templates-json-schema-shared/src/defs/base-properties.json
@@ -24,13 +24,12 @@
             "choices"
           ]
         }
+      },
+      {
+        "$ref": "condition.json"
       }
     ],
     "properties": {
-      "id": {
-        "type": "string",
-        "description": "Unique identifier of the property."
-      },
       "value": {
         "$id": "#/properties/property/value",
         "type": [
@@ -80,7 +79,7 @@
               "description": "The value of a choice."
             },
             "condition": {
-              "$ref": "condition.json"
+              "$ref": "condition.json#/properties/condition"
             }
           },
           "required": [
@@ -143,9 +142,6 @@
         "$id": "#/properties/property/group",
         "type": "string",
         "description": "The custom group of a control field."
-      },
-      "condition": {
-        "$ref": "condition.json"
       }
     }
   }

--- a/packages/element-templates-json-schema-shared/src/defs/condition.json
+++ b/packages/element-templates-json-schema-shared/src/defs/condition.json
@@ -61,8 +61,86 @@
           ]
         }
       ]
+    },
+    "conditionDependingOnId": {
+      "anyOf": [
+        {
+          "required": [
+            "property"
+          ],
+          "properties": {
+            "property": {
+              "const": {
+                "$data": "2/id"
+              }
+            }
+          }
+        },
+        {
+          "required": [
+            "allMatch"
+          ],
+          "allMatch": {
+            "contains": {
+              "properties": {
+                "property": {
+                  "const": {
+                    "$data": "2/id"
+                  }
+                }
+              }
+            }
+          }
+        }
+      ]
     }
   },
+  "allOf": [
+    {
+      "$comment": "property#condition should not depend on property#id",
+      "if": {
+        "required": [
+          "id",
+          "condition"
+        ],
+        "properties": {
+          "condition": {
+            "$ref": "#/definitions/conditionDependingOnId"
+          }
+        }
+      },
+      "then": {
+        "not": {
+          "required": [ "condition" ]
+        }
+      }
+    },
+    {
+      "$comment": "property#condition should not depend on property#id",
+      "if": {
+        "required": [
+          "id",
+          "choices"
+        ],
+        "properties": {
+          "choices": {
+            "contains": {
+              "properties": {
+                "condition": {
+                  "$ref": "#/definitions/conditionDependingOnId"
+                }
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "not": {
+          "required": [ "choices" ]
+        }
+      }
+    }
+  ],
   "properties": {
     "id": {
       "type": "string",

--- a/packages/element-templates-json-schema-shared/src/defs/condition.json
+++ b/packages/element-templates-json-schema-shared/src/defs/condition.json
@@ -1,12 +1,4 @@
 {
-  "$id": "#/condition",
-  "type": "object",
-  "description": "Condition(s) to activate the binding.",
-  "allOf": [
-    {
-      "$ref": "examples.json#/condition"
-    }
-  ],
   "definitions": {
     "condition": {
       "type": "object",
@@ -71,24 +63,39 @@
       ]
     }
   },
-  "oneOf": [
-    {
-      "$ref": "#/definitions/condition"
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "Unique identifier of the property."
     },
-    {
-      "properties": {
-        "allMatch": {
-          "$id": "#/allMatch",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/condition"
-          },
-          "minItems": 1
+    "condition": {
+      "type": "object",
+      "description": "Condition(s) to activate the binding.",
+      "allOf": [
+        {
+          "$ref": "examples.json#/condition"
         }
-      },
-      "required": [
-        "allMatch"
+      ],
+      "oneOf": [
+        {
+          "$ref": "#/definitions/condition"
+        },
+        {
+          "properties": {
+            "allMatch": {
+              "$id": "#/allMatch",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/condition"
+              },
+              "minItems": 1
+            }
+          },
+          "required": [
+            "allMatch"
+          ]
+        }
       ]
     }
-  ]
+  }
 }

--- a/packages/element-templates-json-schema-shared/test/helpers/index.js
+++ b/packages/element-templates-json-schema-shared/test/helpers/index.js
@@ -15,7 +15,8 @@ function createValidator(schema, errors) {
 
   const ajv = new Ajv({
     allErrors: true,
-    strict: false
+    strict: false,
+    $data: true
   });
 
   AjvErrors(ajv);

--- a/packages/element-templates-json-schema/test/fixtures/condition-default-type.js
+++ b/packages/element-templates-json-schema/test/fixtures/condition-default-type.js
@@ -32,44 +32,42 @@ export const errors = [
   {
     keyword: 'required',
     dataPath: '/properties/1/condition',
-    schemaPath: '#/definitions/properties/allOf/0/items/properties/condition/definitions/condition/oneOf/0/required',
+    schemaPath: '#/definitions/properties/allOf/0/items/allOf/1/definitions/condition/oneOf/0/required',
     params: { missingProperty: 'equals' },
     message: "should have required property 'equals'"
   },
   {
     keyword: 'required',
     dataPath: '/properties/1/condition',
-    schemaPath: '#/definitions/properties/allOf/0/items/properties/condition/definitions/condition/oneOf/1/required',
+    schemaPath: '#/definitions/properties/allOf/0/items/allOf/1/definitions/condition/oneOf/1/required',
     params: { missingProperty: 'oneOf' },
     message: "should have required property 'oneOf'"
   },
   {
-    dataPath: '/properties/1/condition',
     keyword: 'required',
-    message: "should have required property 'isActive'",
-    params: {
-      missingProperty: 'isActive'
-    },
-    schemaPath: '#/definitions/properties/allOf/0/items/properties/condition/definitions/condition/oneOf/2/required'
+    dataPath: '/properties/1/condition',
+    schemaPath: '#/definitions/properties/allOf/0/items/allOf/1/definitions/condition/oneOf/2/required',
+    params: { missingProperty: 'isActive' },
+    message: "should have required property 'isActive'"
   },
   {
     keyword: 'oneOf',
     dataPath: '/properties/1/condition',
-    schemaPath: '#/definitions/properties/allOf/0/items/properties/condition/definitions/condition/oneOf',
+    schemaPath: '#/definitions/properties/allOf/0/items/allOf/1/definitions/condition/oneOf',
     params: { passingSchemas: null },
     message: 'should match exactly one schema in oneOf'
   },
   {
     keyword: 'required',
     dataPath: '/properties/1/condition',
-    schemaPath: '#/allOf/0/items/properties/condition/oneOf/1/required',
+    schemaPath: '#/allOf/0/items/allOf/1/properties/condition/oneOf/1/required',
     params: { missingProperty: 'allMatch' },
     message: "should have required property 'allMatch'"
   },
   {
     keyword: 'oneOf',
     dataPath: '/properties/1/condition',
-    schemaPath: '#/allOf/0/items/properties/condition/oneOf',
+    schemaPath: '#/allOf/0/items/allOf/1/properties/condition/oneOf',
     params: { passingSchemas: null },
     message: 'should match exactly one schema in oneOf'
   },

--- a/packages/element-templates-json-schema/test/fixtures/condition-missing-condition-keyword.js
+++ b/packages/element-templates-json-schema/test/fixtures/condition-missing-condition-keyword.js
@@ -33,44 +33,42 @@ export const errors = [
   {
     keyword: 'required',
     dataPath: '/properties/1/condition',
-    schemaPath: '#/definitions/properties/allOf/0/items/properties/condition/definitions/condition/oneOf/0/required',
+    schemaPath: '#/definitions/properties/allOf/0/items/allOf/1/definitions/condition/oneOf/0/required',
     params: { missingProperty: 'equals' },
     message: "should have required property 'equals'"
   },
   {
     keyword: 'required',
     dataPath: '/properties/1/condition',
-    schemaPath: '#/definitions/properties/allOf/0/items/properties/condition/definitions/condition/oneOf/1/required',
+    schemaPath: '#/definitions/properties/allOf/0/items/allOf/1/definitions/condition/oneOf/1/required',
     params: { missingProperty: 'oneOf' },
     message: "should have required property 'oneOf'"
   },
   {
-    dataPath: '/properties/1/condition',
     keyword: 'required',
-    message: "should have required property 'isActive'",
-    params: {
-      missingProperty: 'isActive'
-    },
-    schemaPath: '#/definitions/properties/allOf/0/items/properties/condition/definitions/condition/oneOf/2/required'
+    dataPath: '/properties/1/condition',
+    schemaPath: '#/definitions/properties/allOf/0/items/allOf/1/definitions/condition/oneOf/2/required',
+    params: { missingProperty: 'isActive' },
+    message: "should have required property 'isActive'"
   },
   {
     keyword: 'oneOf',
     dataPath: '/properties/1/condition',
-    schemaPath: '#/definitions/properties/allOf/0/items/properties/condition/definitions/condition/oneOf',
+    schemaPath: '#/definitions/properties/allOf/0/items/allOf/1/definitions/condition/oneOf',
     params: { passingSchemas: null },
     message: 'should match exactly one schema in oneOf'
   },
   {
     keyword: 'required',
     dataPath: '/properties/1/condition',
-    schemaPath: '#/allOf/0/items/properties/condition/oneOf/1/required',
+    schemaPath: '#/allOf/0/items/allOf/1/properties/condition/oneOf/1/required',
     params: { missingProperty: 'allMatch' },
     message: "should have required property 'allMatch'"
   },
   {
     keyword: 'oneOf',
     dataPath: '/properties/1/condition',
-    schemaPath: '#/allOf/0/items/properties/condition/oneOf',
+    schemaPath: '#/allOf/0/items/allOf/1/properties/condition/oneOf',
     params: { passingSchemas: null },
     message: 'should match exactly one schema in oneOf'
   },

--- a/packages/element-templates-json-schema/test/fixtures/condition-missing-property.js
+++ b/packages/element-templates-json-schema/test/fixtures/condition-missing-property.js
@@ -33,13 +33,13 @@ export const errors = [
   {
     keyword: 'errorMessage',
     dataPath: '/properties/1/condition',
-    schemaPath: '#/definitions/properties/allOf/0/items/properties/condition/definitions/condition/errorMessage',
+    schemaPath: '#/definitions/properties/allOf/0/items/allOf/1/definitions/condition/errorMessage',
     params: {
       errors: [
         {
           keyword: 'required',
           dataPath: '/properties/1/condition',
-          schemaPath: '#/definitions/properties/allOf/0/items/properties/condition/definitions/condition/required',
+          schemaPath: '#/definitions/properties/allOf/0/items/allOf/1/definitions/condition/required',
           params: { missingProperty: 'property' },
           message: "should have required property 'property'",
           emUsed: true
@@ -51,14 +51,14 @@ export const errors = [
   {
     keyword: 'required',
     dataPath: '/properties/1/condition',
-    schemaPath: '#/allOf/0/items/properties/condition/oneOf/1/required',
+    schemaPath: '#/allOf/0/items/allOf/1/properties/condition/oneOf/1/required',
     params: { missingProperty: 'allMatch' },
     message: "should have required property 'allMatch'"
   },
   {
     keyword: 'oneOf',
     dataPath: '/properties/1/condition',
-    schemaPath: '#/allOf/0/items/properties/condition/oneOf',
+    schemaPath: '#/allOf/0/items/allOf/1/properties/condition/oneOf',
     params: { passingSchemas: null },
     message: 'should match exactly one schema in oneOf'
   },

--- a/packages/element-templates-json-schema/test/fixtures/condition-wrong-type.js
+++ b/packages/element-templates-json-schema/test/fixtures/condition-wrong-type.js
@@ -32,48 +32,38 @@ export const template = {
 
 export const errors = [
   {
-    'dataPath': '/properties/1/condition/type',
-    'keyword': 'const',
-    'message': 'should be equal to constant',
-    'params': {
-      'allowedValue': 'simple'
-    },
-    'schemaPath': '#/definitions/properties/allOf/0/items/properties/condition/definitions/condition/properties/type/const'
+    keyword: 'const',
+    dataPath: '/properties/1/condition/type',
+    schemaPath: '#/definitions/properties/allOf/0/items/allOf/1/definitions/condition/properties/type/const',
+    params: { allowedValue: 'simple' },
+    message: 'should be equal to constant'
   },
   {
-    'keyword': 'required',
-    'dataPath': '/properties/1/condition',
-    'schemaPath': '#/allOf/0/items/properties/condition/oneOf/1/required',
-    'params': {
-      'missingProperty': 'allMatch'
-    },
-    'message': "should have required property 'allMatch'"
+    keyword: 'required',
+    dataPath: '/properties/1/condition',
+    schemaPath: '#/allOf/0/items/allOf/1/properties/condition/oneOf/1/required',
+    params: { missingProperty: 'allMatch' },
+    message: "should have required property 'allMatch'"
   },
   {
-    'keyword': 'oneOf',
-    'dataPath': '/properties/1/condition',
-    'schemaPath': '#/allOf/0/items/properties/condition/oneOf',
-    'params': {
-      'passingSchemas': null
-    },
-    'message': 'should match exactly one schema in oneOf'
+    keyword: 'oneOf',
+    dataPath: '/properties/1/condition',
+    schemaPath: '#/allOf/0/items/allOf/1/properties/condition/oneOf',
+    params: { passingSchemas: null },
+    message: 'should match exactly one schema in oneOf'
   },
   {
-    'dataPath': '',
-    'keyword': 'type',
-    'message': 'should be array',
-    'params': {
-      'type': 'array',
-    },
-    'schemaPath': '#/oneOf/1/type'
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: { type: 'array' },
+    message: 'should be array'
   },
   {
-    'dataPath': '',
-    'keyword': 'oneOf',
-    'message': 'should match exactly one schema in oneOf',
-    'params': {
-      'passingSchemas': null
-    },
-    'schemaPath': '#/oneOf'
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: { passingSchemas: null },
+    message: 'should match exactly one schema in oneOf'
   }
 ];

--- a/packages/element-templates-json-schema/test/fixtures/condition-wrong-types.js
+++ b/packages/element-templates-json-schema/test/fixtures/condition-wrong-types.js
@@ -47,95 +47,91 @@ export const errors = [
   {
     keyword: 'type',
     dataPath: '/properties/1/condition/equals',
-    schemaPath: '#/definitions/properties/allOf/0/items/properties/condition/definitions/condition/oneOf/0/properties/equals/type',
+    schemaPath: '#/definitions/properties/allOf/0/items/allOf/1/definitions/condition/oneOf/0/properties/equals/type',
     params: { type: [ 'string', 'number', 'boolean' ] },
     message: 'should be string,number,boolean'
   },
   {
     keyword: 'required',
     dataPath: '/properties/1/condition',
-    schemaPath: '#/definitions/properties/allOf/0/items/properties/condition/definitions/condition/oneOf/1/required',
+    schemaPath: '#/definitions/properties/allOf/0/items/allOf/1/definitions/condition/oneOf/1/required',
     params: { missingProperty: 'oneOf' },
     message: "should have required property 'oneOf'"
   },
   {
-    dataPath: '/properties/1/condition',
     keyword: 'required',
-    message: "should have required property 'isActive'",
-    params: {
-      missingProperty: 'isActive'
-    },
-    schemaPath: '#/definitions/properties/allOf/0/items/properties/condition/definitions/condition/oneOf/2/required'
+    dataPath: '/properties/1/condition',
+    schemaPath: '#/definitions/properties/allOf/0/items/allOf/1/definitions/condition/oneOf/2/required',
+    params: { missingProperty: 'isActive' },
+    message: "should have required property 'isActive'"
   },
   {
     keyword: 'oneOf',
     dataPath: '/properties/1/condition',
-    schemaPath: '#/definitions/properties/allOf/0/items/properties/condition/definitions/condition/oneOf',
+    schemaPath: '#/definitions/properties/allOf/0/items/allOf/1/definitions/condition/oneOf',
     params: { passingSchemas: null },
     message: 'should match exactly one schema in oneOf'
   },
   {
     keyword: 'required',
     dataPath: '/properties/1/condition',
-    schemaPath: '#/allOf/0/items/properties/condition/oneOf/1/required',
+    schemaPath: '#/allOf/0/items/allOf/1/properties/condition/oneOf/1/required',
     params: { missingProperty: 'allMatch' },
     message: "should have required property 'allMatch'"
   },
   {
     keyword: 'oneOf',
     dataPath: '/properties/1/condition',
-    schemaPath: '#/allOf/0/items/properties/condition/oneOf',
+    schemaPath: '#/allOf/0/items/allOf/1/properties/condition/oneOf',
     params: { passingSchemas: null },
     message: 'should match exactly one schema in oneOf'
   },
   {
     keyword: 'required',
     dataPath: '/properties/2/condition',
-    schemaPath: '#/definitions/properties/allOf/0/items/properties/condition/definitions/condition/oneOf/0/required',
+    schemaPath: '#/definitions/properties/allOf/0/items/allOf/1/definitions/condition/oneOf/0/required',
     params: { missingProperty: 'equals' },
     message: "should have required property 'equals'"
   },
   {
     keyword: 'type',
     dataPath: '/properties/2/condition/oneOf/0',
-    schemaPath: '#/definitions/properties/allOf/0/items/properties/condition/definitions/condition/oneOf/1/properties/oneOf/items/type',
+    schemaPath: '#/definitions/properties/allOf/0/items/allOf/1/definitions/condition/oneOf/1/properties/oneOf/items/type',
     params: { type: [ 'string', 'number' ] },
     message: 'should be string,number'
   },
   {
     keyword: 'type',
     dataPath: '/properties/2/condition/oneOf/1',
-    schemaPath: '#/definitions/properties/allOf/0/items/properties/condition/definitions/condition/oneOf/1/properties/oneOf/items/type',
+    schemaPath: '#/definitions/properties/allOf/0/items/allOf/1/definitions/condition/oneOf/1/properties/oneOf/items/type',
     params: { type: [ 'string', 'number' ] },
     message: 'should be string,number'
   },
   {
-    dataPath: '/properties/2/condition',
     keyword: 'required',
-    message: "should have required property 'isActive'",
-    params: {
-      missingProperty: 'isActive'
-    },
-    schemaPath: '#/definitions/properties/allOf/0/items/properties/condition/definitions/condition/oneOf/2/required'
+    dataPath: '/properties/2/condition',
+    schemaPath: '#/definitions/properties/allOf/0/items/allOf/1/definitions/condition/oneOf/2/required',
+    params: { missingProperty: 'isActive' },
+    message: "should have required property 'isActive'"
   },
   {
     keyword: 'oneOf',
     dataPath: '/properties/2/condition',
-    schemaPath: '#/definitions/properties/allOf/0/items/properties/condition/definitions/condition/oneOf',
+    schemaPath: '#/definitions/properties/allOf/0/items/allOf/1/definitions/condition/oneOf',
     params: { passingSchemas: null },
     message: 'should match exactly one schema in oneOf'
   },
   {
     keyword: 'required',
     dataPath: '/properties/2/condition',
-    schemaPath: '#/allOf/0/items/properties/condition/oneOf/1/required',
+    schemaPath: '#/allOf/0/items/allOf/1/properties/condition/oneOf/1/required',
     params: { missingProperty: 'allMatch' },
     message: "should have required property 'allMatch'"
   },
   {
     keyword: 'oneOf',
     dataPath: '/properties/2/condition',
-    schemaPath: '#/allOf/0/items/properties/condition/oneOf',
+    schemaPath: '#/allOf/0/items/allOf/1/properties/condition/oneOf',
     params: { passingSchemas: null },
     message: 'should match exactly one schema in oneOf'
   },

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/condition-default-type.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/condition-default-type.js
@@ -32,44 +32,42 @@ export const errors = [
   {
     keyword: 'required',
     dataPath: '/properties/1/condition',
-    schemaPath: '#/definitions/properties/allOf/0/items/properties/condition/definitions/condition/oneOf/0/required',
+    schemaPath: '#/definitions/properties/allOf/0/items/allOf/1/definitions/condition/oneOf/0/required',
     params: { missingProperty: 'equals' },
     message: "should have required property 'equals'"
   },
   {
     keyword: 'required',
     dataPath: '/properties/1/condition',
-    schemaPath: '#/definitions/properties/allOf/0/items/properties/condition/definitions/condition/oneOf/1/required',
+    schemaPath: '#/definitions/properties/allOf/0/items/allOf/1/definitions/condition/oneOf/1/required',
     params: { missingProperty: 'oneOf' },
     message: "should have required property 'oneOf'"
   },
   {
-    dataPath: '/properties/1/condition',
     keyword: 'required',
-    message: "should have required property 'isActive'",
-    params: {
-      missingProperty: 'isActive'
-    },
-    schemaPath: '#/definitions/properties/allOf/0/items/properties/condition/definitions/condition/oneOf/2/required'
+    dataPath: '/properties/1/condition',
+    schemaPath: '#/definitions/properties/allOf/0/items/allOf/1/definitions/condition/oneOf/2/required',
+    params: { missingProperty: 'isActive' },
+    message: "should have required property 'isActive'"
   },
   {
     keyword: 'oneOf',
     dataPath: '/properties/1/condition',
-    schemaPath: '#/definitions/properties/allOf/0/items/properties/condition/definitions/condition/oneOf',
+    schemaPath: '#/definitions/properties/allOf/0/items/allOf/1/definitions/condition/oneOf',
     params: { passingSchemas: null },
     message: 'should match exactly one schema in oneOf'
   },
   {
     keyword: 'required',
     dataPath: '/properties/1/condition',
-    schemaPath: '#/allOf/0/items/properties/condition/oneOf/1/required',
-    message: "should have required property 'allMatch'",
+    schemaPath: '#/allOf/0/items/allOf/1/properties/condition/oneOf/1/required',
     params: { missingProperty: 'allMatch' },
+    message: "should have required property 'allMatch'"
   },
   {
     keyword: 'oneOf',
     dataPath: '/properties/1/condition',
-    schemaPath: '#/allOf/0/items/properties/condition/oneOf',
+    schemaPath: '#/allOf/0/items/allOf/1/properties/condition/oneOf',
     params: { passingSchemas: null },
     message: 'should match exactly one schema in oneOf'
   },

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/condition-empty-allMatch.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/condition-empty-allMatch.js
@@ -40,95 +40,77 @@ export const template = {
 
 export const errors = [
   {
-    'dataPath': '/properties/2/condition',
     'keyword': 'required',
-    'message': "should have required property 'equals'",
-    'params': {
-      'missingProperty': 'equals'
-    },
-    'schemaPath': '#/definitions/properties/allOf/0/items/properties/condition/definitions/condition/oneOf/0/required'
+    'dataPath': '/properties/2/condition',
+    'schemaPath': '#/definitions/properties/allOf/0/items/allOf/1/definitions/condition/oneOf/0/required',
+    'params': { missingProperty: 'equals' },
+    'message': "should have required property 'equals'"
   },
   {
-    'dataPath': '/properties/2/condition',
     'keyword': 'required',
-    'message': "should have required property 'oneOf'",
-    'params': {
-      'missingProperty': 'oneOf'
-    },
-    'schemaPath': '#/definitions/properties/allOf/0/items/properties/condition/definitions/condition/oneOf/1/required'
+    'dataPath': '/properties/2/condition',
+    'schemaPath': '#/definitions/properties/allOf/0/items/allOf/1/definitions/condition/oneOf/1/required',
+    'params': { missingProperty: 'oneOf' },
+    'message': "should have required property 'oneOf'"
   },
   {
-    'dataPath': '/properties/2/condition',
     'keyword': 'required',
-    'message': "should have required property 'isActive'",
-    'params': {
-      'missingProperty': 'isActive'
-    },
-    'schemaPath': '#/definitions/properties/allOf/0/items/properties/condition/definitions/condition/oneOf/2/required'
+    'dataPath': '/properties/2/condition',
+    'schemaPath': '#/definitions/properties/allOf/0/items/allOf/1/definitions/condition/oneOf/2/required',
+    'params': { missingProperty: 'isActive' },
+    'message': "should have required property 'isActive'"
   },
   {
-    'dataPath': '/properties/2/condition',
-    'keyword': 'oneOf',
-    'message': 'should match exactly one schema in oneOf',
-    'params': {
-      'passingSchemas': null
-    },
-    'schemaPath': '#/definitions/properties/allOf/0/items/properties/condition/definitions/condition/oneOf'
+    keyword: 'oneOf',
+    dataPath: '/properties/2/condition',
+    schemaPath: '#/definitions/properties/allOf/0/items/allOf/1/definitions/condition/oneOf',
+    params: { passingSchemas: null },
+    message: 'should match exactly one schema in oneOf'
   },
   {
-    'dataPath': '/properties/2/condition',
-    'keyword': 'errorMessage',
-    'message': 'missing property name for condition',
-    'params': {
-      'errors': [
+    keyword: 'errorMessage',
+    dataPath: '/properties/2/condition',
+    schemaPath: '#/definitions/properties/allOf/0/items/allOf/1/definitions/condition/errorMessage',
+    params: {
+      errors: [
         {
-          'keyword': 'required',
-          'dataPath': '/properties/2/condition',
-          'emUsed': true,
-          'schemaPath': '#/definitions/properties/allOf/0/items/properties/condition/definitions/condition/required',
-          'params': {
-            'missingProperty': 'property'
-          },
-          'message': "should have required property 'property'"
-        },
+          keyword: 'required',
+          dataPath: '/properties/2/condition',
+          schemaPath: '#/definitions/properties/allOf/0/items/allOf/1/definitions/condition/required',
+          params: { missingProperty: 'property' },
+          message: "should have required property 'property'",
+          emUsed: true
+        }
       ]
     },
-    'schemaPath': '#/definitions/properties/allOf/0/items/properties/condition/definitions/condition/errorMessage'
+    message: 'missing property name for condition'
   },
   {
-    'dataPath': '/properties/2/condition/allMatch',
-    'keyword': 'minItems',
-    'message': 'should NOT have fewer than 1 items',
-    'params': {
-      'limit': 1
-    },
-    'schemaPath': '#/allOf/0/items/properties/condition/oneOf/1/properties/allMatch/minItems'
+    keyword: 'minItems',
+    dataPath: '/properties/2/condition/allMatch',
+    schemaPath: '#/allOf/0/items/allOf/1/properties/condition/oneOf/1/properties/allMatch/minItems',
+    params: { limit: 1 },
+    message: 'should NOT have fewer than 1 items'
   },
   {
-    'dataPath': '/properties/2/condition',
-    'keyword': 'oneOf',
-    'message': 'should match exactly one schema in oneOf',
-    'params': {
-      'passingSchemas': null
-    },
-    'schemaPath': '#/allOf/0/items/properties/condition/oneOf'
+    keyword: 'oneOf',
+    dataPath: '/properties/2/condition',
+    schemaPath: '#/allOf/0/items/allOf/1/properties/condition/oneOf',
+    params: { passingSchemas: null },
+    message: 'should match exactly one schema in oneOf'
   },
   {
-    'dataPath': '',
-    'keyword': 'type',
-    'message': 'should be array',
-    'params': {
-      'type': 'array'
-    },
-    'schemaPath': '#/oneOf/1/type'
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: { type: 'array' },
+    message: 'should be array'
   },
   {
-    'dataPath': '',
-    'keyword': 'oneOf',
-    'message': 'should match exactly one schema in oneOf',
-    'params': {
-      'passingSchemas': null
-    },
-    'schemaPath': '#/oneOf'
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: { passingSchemas: null },
+    message: 'should match exactly one schema in oneOf'
   }
 ];

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/condition-missing-condition-keyword.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/condition-missing-condition-keyword.js
@@ -33,44 +33,42 @@ export const errors = [
   {
     keyword: 'required',
     dataPath: '/properties/1/condition',
-    schemaPath: '#/definitions/properties/allOf/0/items/properties/condition/definitions/condition/oneOf/0/required',
+    schemaPath: '#/definitions/properties/allOf/0/items/allOf/1/definitions/condition/oneOf/0/required',
     params: { missingProperty: 'equals' },
     message: "should have required property 'equals'"
   },
   {
     keyword: 'required',
     dataPath: '/properties/1/condition',
-    schemaPath: '#/definitions/properties/allOf/0/items/properties/condition/definitions/condition/oneOf/1/required',
+    schemaPath: '#/definitions/properties/allOf/0/items/allOf/1/definitions/condition/oneOf/1/required',
     params: { missingProperty: 'oneOf' },
     message: "should have required property 'oneOf'"
   },
   {
-    dataPath: '/properties/1/condition',
     keyword: 'required',
-    message: "should have required property 'isActive'",
-    params: {
-      missingProperty: 'isActive'
-    },
-    schemaPath: '#/definitions/properties/allOf/0/items/properties/condition/definitions/condition/oneOf/2/required'
+    dataPath: '/properties/1/condition',
+    schemaPath: '#/definitions/properties/allOf/0/items/allOf/1/definitions/condition/oneOf/2/required',
+    params: { missingProperty: 'isActive' },
+    message: "should have required property 'isActive'"
   },
   {
     keyword: 'oneOf',
     dataPath: '/properties/1/condition',
-    schemaPath: '#/definitions/properties/allOf/0/items/properties/condition/definitions/condition/oneOf',
+    schemaPath: '#/definitions/properties/allOf/0/items/allOf/1/definitions/condition/oneOf',
     params: { passingSchemas: null },
     message: 'should match exactly one schema in oneOf'
   },
   {
     keyword: 'required',
     dataPath: '/properties/1/condition',
-    schemaPath: '#/allOf/0/items/properties/condition/oneOf/1/required',
-    message: "should have required property 'allMatch'",
+    schemaPath: '#/allOf/0/items/allOf/1/properties/condition/oneOf/1/required',
     params: { missingProperty: 'allMatch' },
+    message: "should have required property 'allMatch'"
   },
   {
     keyword: 'oneOf',
     dataPath: '/properties/1/condition',
-    schemaPath: '#/allOf/0/items/properties/condition/oneOf',
+    schemaPath: '#/allOf/0/items/allOf/1/properties/condition/oneOf',
     params: { passingSchemas: null },
     message: 'should match exactly one schema in oneOf'
   },

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/condition-missing-property.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/condition-missing-property.js
@@ -33,13 +33,13 @@ export const errors = [
   {
     keyword: 'errorMessage',
     dataPath: '/properties/1/condition',
-    schemaPath: '#/definitions/properties/allOf/0/items/properties/condition/definitions/condition/errorMessage',
+    schemaPath: '#/definitions/properties/allOf/0/items/allOf/1/definitions/condition/errorMessage',
     params: {
       errors: [
         {
           keyword: 'required',
           dataPath: '/properties/1/condition',
-          schemaPath: '#/definitions/properties/allOf/0/items/properties/condition/definitions/condition/required',
+          schemaPath: '#/definitions/properties/allOf/0/items/allOf/1/definitions/condition/required',
           params: { missingProperty: 'property' },
           message: "should have required property 'property'",
           emUsed: true
@@ -51,14 +51,14 @@ export const errors = [
   {
     keyword: 'required',
     dataPath: '/properties/1/condition',
-    schemaPath: '#/allOf/0/items/properties/condition/oneOf/1/required',
-    message: "should have required property 'allMatch'",
+    schemaPath: '#/allOf/0/items/allOf/1/properties/condition/oneOf/1/required',
     params: { missingProperty: 'allMatch' },
+    message: "should have required property 'allMatch'"
   },
   {
     keyword: 'oneOf',
     dataPath: '/properties/1/condition',
-    schemaPath: '#/allOf/0/items/properties/condition/oneOf',
+    schemaPath: '#/allOf/0/items/allOf/1/properties/condition/oneOf',
     params: { passingSchemas: null },
     message: 'should match exactly one schema in oneOf'
   },

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/condition-on-itself-allMatch.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/condition-on-itself-allMatch.js
@@ -1,0 +1,69 @@
+export const template = {
+  'name': 'Condition',
+  'id': 'example.com.condition',
+  'appliesTo': [
+    'bpmn:ServiceTask'
+  ],
+  'properties': [
+    {
+      'id': 'myId',
+      'label': 'input 1',
+      'type': 'String',
+      'binding': {
+        'type': 'property',
+        'name': 'input1'
+      },
+      'condition': {
+        'allMatch': [
+          {
+            'type': 'simple',
+            property: 'myId',
+            equals: 'text'
+          }
+        ]
+      }
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'errorMessage',
+    dataPath: '/properties/0',
+    schemaPath: '#/allOf/0/items/allOf/1/allOf/0/then/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'not',
+          dataPath: '/properties/0',
+          schemaPath: '#/allOf/0/items/allOf/1/allOf/0/then/not',
+          params: {},
+          message: 'should NOT be valid',
+          emUsed: true
+        }
+      ]
+    },
+    message: 'Invalid condition.property, must be different than property.id'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/0',
+    schemaPath: '#/allOf/0/items/allOf/1/allOf/0/if',
+    params: { failingKeyword: 'then' },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: { type: 'array' },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: { passingSchemas: null },
+    message: 'should match exactly one schema in oneOf'
+  }
+];

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/condition-on-itself-dropdown-choices.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/condition-on-itself-dropdown-choices.js
@@ -1,0 +1,78 @@
+export const template = {
+  'name': 'Condition',
+  'id': 'example.com.condition',
+  'appliesTo': [
+    'bpmn:ServiceTask'
+  ],
+  'properties': [
+    {
+      'id': 'myId',
+      'label': 'Dropdown',
+      'type': 'Dropdown',
+      'choices': [
+        {
+          'value': 'opt1',
+          'name':'opt1'
+        },
+        {
+          'value': 'opt2',
+          'name': 'opt2'
+        },
+        {
+          'value': 'opt3',
+          'name': 'opt3',
+          'condition': {
+            'property': 'myId',
+            'equals': 'text'
+          }
+        }
+      ],
+      'binding': {
+        'type': 'zeebe:property',
+        'name': 'method'
+      }
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'errorMessage',
+    dataPath: '/properties/0',
+    schemaPath: '#/allOf/0/items/allOf/1/allOf/1/then/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'not',
+          dataPath: '/properties/0',
+          schemaPath: '#/allOf/0/items/allOf/1/allOf/1/then/not',
+          params: {},
+          message: 'should NOT be valid',
+          emUsed: true
+        }
+      ]
+    },
+    message: 'Invalid condition.property, must be different than property.id'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/0',
+    schemaPath: '#/allOf/0/items/allOf/1/allOf/1/if',
+    params: { failingKeyword: 'then' },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: { type: 'array' },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: { passingSchemas: null },
+    message: 'should match exactly one schema in oneOf'
+  }
+];

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/condition-on-itself.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/condition-on-itself.js
@@ -1,0 +1,64 @@
+export const template = {
+  'name': 'Condition',
+  'id': 'example.com.condition',
+  'appliesTo': [
+    'bpmn:ServiceTask'
+  ],
+  'properties': [
+    {
+      'id': 'myId',
+      'label': 'input 1',
+      'type': 'String',
+      'binding': {
+        'type': 'property',
+        'name': 'input1'
+      },
+      'condition': {
+        property: 'myId',
+        equals: 'text'
+      }
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'errorMessage',
+    dataPath: '/properties/0',
+    schemaPath: '#/allOf/0/items/allOf/1/allOf/0/then/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'not',
+          dataPath: '/properties/0',
+          schemaPath: '#/allOf/0/items/allOf/1/allOf/0/then/not',
+          params: {},
+          message: 'should NOT be valid',
+          emUsed: true
+        }
+      ]
+    },
+    message: 'Invalid condition.property, must be different than property.id'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/0',
+    schemaPath: '#/allOf/0/items/allOf/1/allOf/0/if',
+    params: { failingKeyword: 'then' },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: { type: 'array' },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: { passingSchemas: null },
+    message: 'should match exactly one schema in oneOf'
+  }
+];

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/condition-wrong-type.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/condition-wrong-type.js
@@ -32,48 +32,38 @@ export const template = {
 
 export const errors = [
   {
-    'dataPath': '/properties/1/condition/type',
-    'keyword': 'const',
-    'message': 'should be equal to constant',
-    'params': {
-      'allowedValue': 'simple'
-    },
-    'schemaPath': '#/definitions/properties/allOf/0/items/properties/condition/definitions/condition/properties/type/const'
+    keyword: 'const',
+    dataPath: '/properties/1/condition/type',
+    schemaPath: '#/definitions/properties/allOf/0/items/allOf/1/definitions/condition/properties/type/const',
+    params: { allowedValue: 'simple' },
+    message: 'should be equal to constant'
   },
   {
-    'dataPath': '/properties/1/condition',
-    'keyword': 'required',
-    'message': "should have required property 'allMatch'",
-    'params': {
-      'missingProperty': 'allMatch'
-    },
-    'schemaPath': '#/allOf/0/items/properties/condition/oneOf/1/required'
+    keyword: 'required',
+    dataPath: '/properties/1/condition',
+    schemaPath: '#/allOf/0/items/allOf/1/properties/condition/oneOf/1/required',
+    params: { missingProperty: 'allMatch' },
+    message: "should have required property 'allMatch'"
   },
   {
-    'dataPath': '/properties/1/condition',
-    'keyword': 'oneOf',
-    'message': 'should match exactly one schema in oneOf',
-    'params': {
-      'passingSchemas': null
-    },
-    'schemaPath': '#/allOf/0/items/properties/condition/oneOf'
+    keyword: 'oneOf',
+    dataPath: '/properties/1/condition',
+    schemaPath: '#/allOf/0/items/allOf/1/properties/condition/oneOf',
+    params: { passingSchemas: null },
+    message: 'should match exactly one schema in oneOf'
   },
   {
-    'dataPath': '',
-    'keyword': 'type',
-    'message': 'should be array',
-    'params': {
-      'type': 'array',
-    },
-    'schemaPath': '#/oneOf/1/type'
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: { type: 'array' },
+    message: 'should be array'
   },
   {
-    'dataPath': '',
-    'keyword': 'oneOf',
-    'message': 'should match exactly one schema in oneOf',
-    'params': {
-      'passingSchemas': null
-    },
-    'schemaPath': '#/oneOf'
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: { passingSchemas: null },
+    message: 'should match exactly one schema in oneOf'
   }
 ];

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/condition-wrong-types.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/condition-wrong-types.js
@@ -47,95 +47,91 @@ export const errors = [
   {
     keyword: 'type',
     dataPath: '/properties/1/condition/equals',
-    schemaPath: '#/definitions/properties/allOf/0/items/properties/condition/definitions/condition/oneOf/0/properties/equals/type',
+    schemaPath: '#/definitions/properties/allOf/0/items/allOf/1/definitions/condition/oneOf/0/properties/equals/type',
     params: { type: [ 'string', 'number', 'boolean' ] },
     message: 'should be string,number,boolean'
   },
   {
     keyword: 'required',
     dataPath: '/properties/1/condition',
-    schemaPath: '#/definitions/properties/allOf/0/items/properties/condition/definitions/condition/oneOf/1/required',
+    schemaPath: '#/definitions/properties/allOf/0/items/allOf/1/definitions/condition/oneOf/1/required',
     params: { missingProperty: 'oneOf' },
     message: "should have required property 'oneOf'"
   },
   {
-    dataPath: '/properties/1/condition',
     keyword: 'required',
-    message: "should have required property 'isActive'",
-    params: {
-      missingProperty: 'isActive'
-    },
-    schemaPath: '#/definitions/properties/allOf/0/items/properties/condition/definitions/condition/oneOf/2/required'
+    dataPath: '/properties/1/condition',
+    schemaPath: '#/definitions/properties/allOf/0/items/allOf/1/definitions/condition/oneOf/2/required',
+    params: { missingProperty: 'isActive' },
+    message: "should have required property 'isActive'"
   },
   {
     keyword: 'oneOf',
     dataPath: '/properties/1/condition',
-    schemaPath: '#/definitions/properties/allOf/0/items/properties/condition/definitions/condition/oneOf',
+    schemaPath: '#/definitions/properties/allOf/0/items/allOf/1/definitions/condition/oneOf',
     params: { passingSchemas: null },
     message: 'should match exactly one schema in oneOf'
   },
   {
     keyword: 'required',
     dataPath: '/properties/1/condition',
-    schemaPath: '#/allOf/0/items/properties/condition/oneOf/1/required',
-    message: "should have required property 'allMatch'",
+    schemaPath: '#/allOf/0/items/allOf/1/properties/condition/oneOf/1/required',
     params: { missingProperty: 'allMatch' },
+    message: "should have required property 'allMatch'"
   },
   {
     keyword: 'oneOf',
     dataPath: '/properties/1/condition',
-    schemaPath: '#/allOf/0/items/properties/condition/oneOf',
+    schemaPath: '#/allOf/0/items/allOf/1/properties/condition/oneOf',
     params: { passingSchemas: null },
     message: 'should match exactly one schema in oneOf'
   },
   {
     keyword: 'required',
     dataPath: '/properties/2/condition',
-    schemaPath: '#/definitions/properties/allOf/0/items/properties/condition/definitions/condition/oneOf/0/required',
+    schemaPath: '#/definitions/properties/allOf/0/items/allOf/1/definitions/condition/oneOf/0/required',
     params: { missingProperty: 'equals' },
     message: "should have required property 'equals'"
   },
   {
     keyword: 'type',
     dataPath: '/properties/2/condition/oneOf/0',
-    schemaPath: '#/definitions/properties/allOf/0/items/properties/condition/definitions/condition/oneOf/1/properties/oneOf/items/type',
+    schemaPath: '#/definitions/properties/allOf/0/items/allOf/1/definitions/condition/oneOf/1/properties/oneOf/items/type',
     params: { type: [ 'string', 'number' ] },
     message: 'should be string,number'
   },
   {
     keyword: 'type',
     dataPath: '/properties/2/condition/oneOf/1',
-    schemaPath: '#/definitions/properties/allOf/0/items/properties/condition/definitions/condition/oneOf/1/properties/oneOf/items/type',
+    schemaPath: '#/definitions/properties/allOf/0/items/allOf/1/definitions/condition/oneOf/1/properties/oneOf/items/type',
     params: { type: [ 'string', 'number' ] },
     message: 'should be string,number'
   },
   {
-    dataPath: '/properties/2/condition',
     keyword: 'required',
-    message: "should have required property 'isActive'",
-    params: {
-      missingProperty: 'isActive'
-    },
-    schemaPath: '#/definitions/properties/allOf/0/items/properties/condition/definitions/condition/oneOf/2/required'
+    dataPath: '/properties/2/condition',
+    schemaPath: '#/definitions/properties/allOf/0/items/allOf/1/definitions/condition/oneOf/2/required',
+    params: { missingProperty: 'isActive' },
+    message: "should have required property 'isActive'"
   },
   {
     keyword: 'oneOf',
     dataPath: '/properties/2/condition',
-    schemaPath: '#/definitions/properties/allOf/0/items/properties/condition/definitions/condition/oneOf',
+    schemaPath: '#/definitions/properties/allOf/0/items/allOf/1/definitions/condition/oneOf',
     params: { passingSchemas: null },
     message: 'should match exactly one schema in oneOf'
   },
   {
     keyword: 'required',
     dataPath: '/properties/2/condition',
-    schemaPath: '#/allOf/0/items/properties/condition/oneOf/1/required',
-    message: "should have required property 'allMatch'",
+    schemaPath: '#/allOf/0/items/allOf/1/properties/condition/oneOf/1/required',
     params: { missingProperty: 'allMatch' },
+    message: "should have required property 'allMatch'"
   },
   {
     keyword: 'oneOf',
     dataPath: '/properties/2/condition',
-    schemaPath: '#/allOf/0/items/properties/condition/oneOf',
+    schemaPath: '#/allOf/0/items/allOf/1/properties/condition/oneOf',
     params: { passingSchemas: null },
     message: 'should match exactly one schema in oneOf'
   },

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/condition.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/condition.js
@@ -80,6 +80,7 @@ export const template = {
       }
     },
     {
+      'id': 'someId',
       'label': 'default condition type',
       'type': 'String',
       'condition': {

--- a/packages/zeebe-element-templates-json-schema/test/spec/validationSpec.js
+++ b/packages/zeebe-element-templates-json-schema/test/spec/validationSpec.js
@@ -289,6 +289,15 @@ describe('validation', function() {
 
 
       testTemplate('condition-dropdown-choices-invalid');
+
+
+      testTemplate('condition-on-itself');
+
+
+      testTemplate('condition-on-itself-allMatch');
+
+
+      testTemplate('condition-on-itself-dropdown-choices');
     });
 
 


### PR DESCRIPTION
Closes #125

---

Note that this requires the validator to accept `$data` property. The monaco editor handles this correctly, and in `ajv` you need to pass `$data: true` to the constructor.