### PR TITLE
feat(zeebe): allow number and boolean everywhere

### DIFF
--- a/packages/zeebe-element-templates-json-schema/src/defs/properties.json
+++ b/packages/zeebe-element-templates-json-schema/src/defs/properties.json
@@ -35,7 +35,8 @@
                 "Text",
                 "Hidden",
                 "Dropdown",
-                "Boolean"
+                "Boolean",
+                "Number"
               ]
             }
           }
@@ -76,7 +77,9 @@
                 "String",
                 "Text",
                 "Hidden",
-                "Dropdown"
+                "Dropdown",
+                "Boolean",
+                "Number"
               ]
             }
           }
@@ -157,7 +160,9 @@
             "type": {
               "enum": [
                 "String",
-                "Text"
+                "Text",
+                "Number",
+                "Boolean"
               ]
             }
           },
@@ -222,6 +227,31 @@
             "required": [
               "generatedValue"
             ]
+          }
+        }
+      },
+      {
+        "if": {
+          "properties": {
+            "type": {
+                "enum": [
+                  "String",
+                  "Text"
+                ]
+            }
+          },
+          "required": [
+            "feel"
+          ]
+        },
+        "then": {
+          "properties": {
+            "feel": {
+              "enum": [
+                "optional",
+                "required"
+              ]
+            }
           }
         }
       }
@@ -406,12 +436,11 @@
       "feel": {
         "$id": "#/properties/property/feel",
         "type": "string",
-        "default": null,
         "description": "Indicates whether the property can be a feel expression",
         "enum": [
-          null,
           "optional",
-          "required"
+          "required",
+          "static"
         ]
       },
       "language": {

--- a/packages/zeebe-element-templates-json-schema/src/error-messages.json
+++ b/packages/zeebe-element-templates-json-schema/src/error-messages.json
@@ -26,7 +26,7 @@
       "properties",
       "type"
     ],
-    "errorMessage": "invalid property type ${0} for binding type \"property\"; must be any of { String, Text, Hidden, Dropdown, Boolean }"
+    "errorMessage": "invalid property type ${0} for binding type \"property\"; must be any of { String, Text, Hidden, Dropdown, Boolean, Number }"
   },
   {
     "path": [
@@ -41,7 +41,7 @@
       "properties",
       "type"
     ],
-    "errorMessage": "invalid property type ${0} for binding type ${1/binding/type}; must be any of { String, Text, Hidden, Dropdown }"
+    "errorMessage": "invalid property type ${0} for binding type ${1/binding/type}; must be any of { String, Text, Hidden, Dropdown, Boolean, Number }"
   },
   {
     "path": [
@@ -90,7 +90,7 @@
       "properties",
       "type"
     ],
-    "errorMessage": "feel is only supported for \"String\" and \"Text\" type"
+    "errorMessage": "feel is only supported for \"String\", \"Text\", \"Number\" and \"Boolean\" type"
   },
   {
     "path": [

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/feel-type-mismatch.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/feel-type-mismatch.js
@@ -1,71 +1,61 @@
 export const template = {
-  'name': 'Pattern Template',
-  'id': 'com.example.PatternTemplate',
-  'appliesTo': [
+  name: 'Pattern Template',
+  id: 'com.example.PatternTemplate',
+  appliesTo: [
     'bpmn:Task'
   ],
-  'properties': [
+  properties: [
     {
-      'label': 'Feel (Boolean)',
-      'type': 'Boolean',
-      'binding': {
-        'type': 'property',
-        'name': 'prop'
+      label: 'Text (static)',
+      type: 'Text',
+      binding: {
+        type: 'property',
+        name: 'prop'
       },
-      'feel': 'required'
+      feel: 'static'
     }
   ]
 };
 
-export const errors = [
+export const errors =
+[
   {
-    keyword: 'errorMessage',
-    dataPath: '/properties/0/type',
-    schemaPath: '#/allOf/1/items/allOf/4/then/properties/type/errorMessage',
+    dataPath: '/properties/0/feel',
+    keyword: 'enum',
+    message: 'should be equal to one of the allowed values',
     params: {
-      errors: [
-        {
-          keyword: 'enum',
-          dataPath: '/properties/0/type',
-          schemaPath: '#/allOf/1/items/allOf/4/then/properties/type/enum',
-          params: {
-            allowedValues: [
-              'String',
-              'Text'
-            ]
-          },
-          message: 'should be equal to one of the allowed values',
-          emUsed: true
-        }
+      allowedValues: [
+        'optional',
+        'required'
       ]
     },
-    message: 'feel is only supported for "String" and "Text" type'
+    schemaPath: '#/allOf/1/items/allOf/8/then/properties/feel/enum'
   },
   {
-    keyword: 'if',
     dataPath: '/properties/0',
-    schemaPath: '#/allOf/1/items/allOf/4/if',
+    keyword: 'if',
+    message: 'should match "then" schema',
     params: {
-      failingKeyword: 'then'
+      failingKeyword: 'then',
     },
-    message: 'should match "then" schema'
+    schemaPath: '#/allOf/1/items/allOf/8/if'
   },
   {
-    keyword: 'type',
     dataPath: '',
-    schemaPath: '#/oneOf/1/type',
+    keyword: 'type',
+    message: 'should be array',
     params: {
       type: 'array'
     },
-    message: 'should be array'
+    schemaPath: '#/oneOf/1/type'
   },
   {
-    keyword: 'oneOf',
     dataPath: '',
-    schemaPath: '#/oneOf',
+    keyword: 'oneOf',
+    message: 'should match exactly one schema in oneOf',
     params: {
       passingSchemas: null
     },
-    message: 'should match exactly one schema in oneOf'
+    schemaPath: '#/oneOf'
   }
 ];

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/feel.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/feel.js
@@ -40,6 +40,42 @@ export const template = {
         'name': 'prop'
       },
       'feel': 'optional'
+    },
+    {
+      'label': 'Feel static (Number)',
+      'type': 'Number',
+      'binding': {
+        'type': 'property',
+        'name': 'prop'
+      },
+      'feel': 'static'
+    },
+    {
+      'label': 'Feel optional (Number)',
+      'type': 'Number',
+      'binding': {
+        'type': 'property',
+        'name': 'prop'
+      },
+      'feel': 'optional'
+    },
+    {
+      'label': 'Feel static (Boolean)',
+      'type': 'Boolean',
+      'binding': {
+        'type': 'property',
+        'name': 'prop'
+      },
+      'feel': 'static'
+    },
+    {
+      'label': 'Feel optional (Boolean)',
+      'type': 'Boolean',
+      'binding': {
+        'type': 'property',
+        'name': 'prop'
+      },
+      'feel': 'optional'
     }
   ]
 };

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/invalid-property-type.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/invalid-property-type.js
@@ -42,14 +42,15 @@ export const errors = [
               'Text',
               'Hidden',
               'Dropdown',
-              'Boolean'
+              'Boolean',
+              'Number'
             ]
           },
           message: 'should be equal to one of the allowed values'
         }
       ]
     },
-    message: 'invalid property type "Foo" for binding type "property"; must be any of { String, Text, Hidden, Dropdown, Boolean }'
+    message: 'invalid property type "Foo" for binding type "property"; must be any of { String, Text, Hidden, Dropdown, Boolean, Number }'
   },
   {
     keyword: 'if',

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/invalid-zeebe-input-type.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/invalid-zeebe-input-type.js
@@ -20,53 +20,71 @@ export const template = {
         'type': 'zeebe:input',
         'name': 'bar'
       }
+    },
+    {
+      'label': 'baz',
+      'type': 'Number',
+      'binding': {
+        'type': 'zeebe:input',
+        'name': 'baz'
+      }
+    },
+    {
+      'label': 'baz',
+      'type': 'Car',
+      'binding': {
+        'type': 'zeebe:input',
+        'name': 'baz'
+      }
     }
   ]
 };
 
 export const errors = [
   {
+    dataPath: '/properties/3/type',
     keyword: 'errorMessage',
-    dataPath: '/properties/1/type',
-    schemaPath: '#/allOf/1/items/allOf/1/then/properties/type/errorMessage',
+    message: 'invalid property type "Car" for binding type "zeebe:input"; must be any of { String, Text, Hidden, Dropdown, Boolean, Number }',
     params: {
       errors: [
         {
-          keyword: 'enum',
+          dataPath: '/properties/3/type',
           emUsed: true,
-          dataPath: '/properties/1/type',
-          schemaPath: '#/allOf/1/items/allOf/1/then/properties/type/enum',
+          keyword: 'enum',
+          message: 'should be equal to one of the allowed values',
           params: {
-            'allowedValues': [
+            allowedValues: [
               'String',
               'Text',
               'Hidden',
-              'Dropdown'
+              'Dropdown',
+              'Boolean',
+              'Number'
             ]
           },
-          message: 'should be equal to one of the allowed values'
+          schemaPath: '#/allOf/1/items/allOf/1/then/properties/type/enum'
         }
       ]
     },
-    message: 'invalid property type "Boolean" for binding type "zeebe:input"; must be any of { String, Text, Hidden, Dropdown }'
+    schemaPath: '#/allOf/1/items/allOf/1/then/properties/type/errorMessage'
   },
   {
+    dataPath: '/properties/3',
     keyword: 'if',
-    dataPath: '/properties/1',
-    schemaPath: '#/allOf/1/items/allOf/1/if',
+    message: 'should match "then" schema',
     params: {
-      'failingKeyword': 'then'
+      failingKeyword: 'then'
     },
-    message: 'should match "then" schema'
+    schemaPath: '#/allOf/1/items/allOf/1/if'
   },
   {
     dataPath: '',
     keyword: 'type',
     message: 'should be array',
     params: {
-      type: 'array',
+      type: 'array'
     },
-    schemaPath: '#/oneOf/1/type',
+    schemaPath: '#/oneOf/1/type'
   },
   {
     dataPath: '',

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/invalid-zeebe-output-type.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/invalid-zeebe-output-type.js
@@ -15,6 +15,14 @@ export const template = {
     },
     {
       'label': 'bar',
+      'type': 'Toggle',
+      'binding': {
+        'type': 'zeebe:output',
+        'source': 'bar'
+      }
+    },
+    {
+      'label': 'bar',
       'type': 'Boolean',
       'binding': {
         'type': 'zeebe:output',
@@ -41,14 +49,16 @@ export const errors = [
               'String',
               'Text',
               'Hidden',
-              'Dropdown'
+              'Dropdown',
+              'Boolean',
+              'Number'
             ]
           },
           message: 'should be equal to one of the allowed values'
         }
       ]
     },
-    message: 'invalid property type "Boolean" for binding type "zeebe:output"; must be any of { String, Text, Hidden, Dropdown }'
+    message: 'invalid property type "Toggle" for binding type "zeebe:output"; must be any of { String, Text, Hidden, Dropdown, Boolean, Number }'
   },
   {
     keyword: 'if',

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/invalid-zeebe-property-type.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/invalid-zeebe-property-type.js
@@ -15,11 +15,19 @@ export const template = {
     },
     {
       'label': 'truthy (boolean)',
-      'type': 'Boolean',
+      'type': 'Toggle',
       'value': true,
       'binding': {
         'type': 'zeebe:property',
         'name': 'bool'
+      }
+    },
+    {
+      'label': 'bar',
+      'type': 'Boolean',
+      'binding': {
+        'type': 'zeebe:property',
+        'name': 'bar'
       }
     }
   ]
@@ -66,13 +74,15 @@ export const errors = [
             'String',
             'Text',
             'Hidden',
-            'Dropdown'
+            'Dropdown',
+            'Boolean',
+            'Number'
           ]
         },
         message: 'should be equal to one of the allowed values'
       }
     ] },
-    message: 'invalid property type "Boolean" for binding type "zeebe:property"; must be any of { String, Text, Hidden, Dropdown }'
+    message: 'invalid property type "Toggle" for binding type "zeebe:property"; must be any of { String, Text, Hidden, Dropdown, Boolean, Number }'
   },
   {
     keyword: 'if',

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/invalid-zeebe-task-definition-type-type.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/invalid-zeebe-task-definition-type-type.js
@@ -14,6 +14,13 @@ export const template = {
     },
     {
       'label': 'bar',
+      'type': 'Toggle',
+      'binding': {
+        'type': 'zeebe:taskDefinition:type'
+      }
+    },
+    {
+      'label': 'bar',
       'type': 'Boolean',
       'binding': {
         'type': 'zeebe:taskDefinition:type'
@@ -39,14 +46,16 @@ export const errors = [
               'String',
               'Text',
               'Hidden',
-              'Dropdown'
+              'Dropdown',
+              'Boolean',
+              'Number'
             ]
           },
           message: 'should be equal to one of the allowed values'
         }
       ]
     },
-    message: 'invalid property type "Boolean" for binding type "zeebe:taskDefinition:type"; must be any of { String, Text, Hidden, Dropdown }'
+    message: 'invalid property type "Toggle" for binding type "zeebe:taskDefinition:type"; must be any of { String, Text, Hidden, Dropdown, Boolean, Number }'
   },
   {
     keyword: 'if',

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/invalid-zeebe-task-definition.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/invalid-zeebe-task-definition.js
@@ -14,9 +14,16 @@ export const template = {
     },
     {
       'label': 'bar',
-      'type': 'Boolean',
+      'type': 'Toggle',
       'binding': {
         'type': 'zeebe:taskDefinition'
+      }
+    },
+    {
+      'label': 'bar',
+      'type': 'Boolean',
+      'binding': {
+        'type': 'zeebe:taskDefinition:type'
       }
     }
   ]
@@ -57,14 +64,16 @@ export const errors = [
               'String',
               'Text',
               'Hidden',
-              'Dropdown'
+              'Dropdown',
+              'Boolean',
+              'Number'
             ]
           },
           message: 'should be equal to one of the allowed values'
         }
       ]
     },
-    message: 'invalid property type "Boolean" for binding type "zeebe:taskDefinition"; must be any of { String, Text, Hidden, Dropdown }'
+    message: 'invalid property type "Toggle" for binding type "zeebe:taskDefinition"; must be any of { String, Text, Hidden, Dropdown, Boolean, Number }'
   },
   {
     keyword: 'if',

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/invalid-zeebe-task-header-type.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/invalid-zeebe-task-header-type.js
@@ -15,6 +15,14 @@ export const template = {
     },
     {
       'label': 'bar',
+      'type': 'Toggle',
+      'binding': {
+        'type': 'zeebe:taskHeader',
+        'key': 'foo'
+      }
+    },
+    {
+      'label': 'bar',
       'type': 'Boolean',
       'binding': {
         'type': 'zeebe:taskHeader',
@@ -41,14 +49,16 @@ export const errors = [
               'String',
               'Text',
               'Hidden',
-              'Dropdown'
+              'Dropdown',
+              'Boolean',
+              'Number'
             ]
           },
           message: 'should be equal to one of the allowed values'
         }
       ]
     },
-    message: 'invalid property type "Boolean" for binding type "zeebe:taskHeader"; must be any of { String, Text, Hidden, Dropdown }'
+    message: 'invalid property type "Toggle" for binding type "zeebe:taskHeader"; must be any of { String, Text, Hidden, Dropdown, Boolean, Number }'
   },
   {
     keyword: 'if',


### PR DESCRIPTION
- adds `staticValue` option for feel, only valid on Number and Boolean

related to https://github.com/camunda/camunda-modeler/issues/3622