### PR TITLE
fix: validate type of `value`

### DIFF
--- a/packages/element-templates-json-schema-shared/src/defs/base-properties.json
+++ b/packages/element-templates-json-schema-shared/src/defs/base-properties.json
@@ -27,6 +27,30 @@
       },
       {
         "$ref": "condition.json"
+      },
+      {
+        "if": {
+          "properties": {
+            "type": {
+              "not": {
+                "const": "Number"
+              }
+            }
+          },
+          "required": [
+            "type"
+          ]
+        },
+        "then": {
+          "properties": {
+            "value": {
+              "type": [
+                "string",
+                "boolean"
+              ]
+            }
+          }
+        }
       }
     ],
     "properties": {
@@ -34,6 +58,7 @@
         "$id": "#/properties/property/value",
         "type": [
           "string",
+          "number",
           "boolean"
         ],
         "description": "The value of a control field."

--- a/packages/element-templates-json-schema/test/fixtures/number-value.js
+++ b/packages/element-templates-json-schema/test/fixtures/number-value.js
@@ -21,7 +21,7 @@ export const errors = [
   {
     keyword: 'type',
     dataPath: '/properties/0/value',
-    schemaPath: '#/allOf/0/items/properties/value/type',
+    schemaPath: '#/allOf/0/items/allOf/2/then/properties/value/type',
     params: {
       type: [
         'string',
@@ -29,6 +29,15 @@ export const errors = [
       ]
     },
     message: 'should be string,boolean'
+  },
+  {
+    dataPath: '/properties/0',
+    keyword: 'if',
+    message: 'should match "then" schema',
+    params: {
+      failingKeyword: 'then'
+    },
+    schemaPath: '#/allOf/0/items/allOf/2/if'
   },
   {
     dataPath: '',

--- a/packages/zeebe-element-templates-json-schema/src/defs/properties.json
+++ b/packages/zeebe-element-templates-json-schema/src/defs/properties.json
@@ -254,6 +254,25 @@
             }
           }
         }
+      },
+      {
+        "if": {
+          "properties": {
+            "feel": {
+                "const": "required"
+            }
+          },
+          "required": [
+            "feel"
+          ]
+        },
+        "then": {
+          "properties": {
+            "value": {
+              "type": "string"
+            }
+          }
+        }
       }
     ],
     "properties": {

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/feel-value-mismatch.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/feel-value-mismatch.js
@@ -1,0 +1,81 @@
+export const template = {
+  name: 'Pattern Template',
+  id: 'com.example.PatternTemplate',
+  appliesTo: [
+    'bpmn:Task'
+  ],
+  properties: [
+    {
+      type: 'Text',
+      binding: {
+        type: 'zeebe:property',
+        name: 'prop'
+      },
+      feel: 'required',
+      value: 'valid'
+    },
+    {
+      type: 'Boolean',
+      binding: {
+        type: 'zeebe:property',
+        name: 'prop'
+      },
+      feel: 'required',
+      value: true
+    },
+    {
+      type: 'Number',
+      binding: {
+        type: 'zeebe:property',
+        name: 'prop'
+      },
+      feel: 'required',
+      value: 123
+    },
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'type',
+    dataPath: '/properties/1/value',
+    schemaPath: '#/allOf/1/items/allOf/9/then/properties/value/type',
+    params: { type: 'string' },
+    message: 'should be string'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/1',
+    schemaPath: '#/allOf/1/items/allOf/9/if',
+    params: { failingKeyword: 'then' },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'type',
+    dataPath: '/properties/2/value',
+    schemaPath: '#/allOf/1/items/allOf/9/then/properties/value/type',
+    params: { type: 'string' },
+    message: 'should be string'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/2',
+    schemaPath: '#/allOf/1/items/allOf/9/if',
+    params: { failingKeyword: 'then' },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: { type: 'array' },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: { passingSchemas: null },
+    message: 'should match exactly one schema in oneOf'
+  }
+];

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/number-value.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/number-value.js
@@ -13,6 +13,15 @@ export const template = {
         'type': 'property',
         'name': 'name'
       }
+    },
+    {
+      'label': 'Am I awesome?',
+      'type': 'Number',
+      'value': 50,
+      'binding': {
+        'type': 'zeebe:property',
+        'name': 'customProp'
+      }
     }
   ]
 };
@@ -21,7 +30,7 @@ export const errors = [
   {
     keyword: 'type',
     dataPath: '/properties/0/value',
-    schemaPath: '#/allOf/0/items/properties/value/type',
+    schemaPath: '#/allOf/0/items/allOf/2/then/properties/value/type',
     params: {
       type: [
         'string',
@@ -29,6 +38,15 @@ export const errors = [
       ]
     },
     message: 'should be string,boolean'
+  },
+  {
+    dataPath: '/properties/0',
+    keyword: 'if',
+    message: 'should match "then" schema',
+    params: {
+      failingKeyword: 'then'
+    },
+    schemaPath: '#/allOf/0/items/allOf/2/if'
   },
   {
     dataPath: '',

--- a/packages/zeebe-element-templates-json-schema/test/spec/validationSpec.js
+++ b/packages/zeebe-element-templates-json-schema/test/spec/validationSpec.js
@@ -145,6 +145,9 @@ describe('validation', function() {
     testTemplate('feel-type-mismatch');
 
 
+    testTemplate('feel-value-mismatch');
+
+
     testTemplate('language');
 
 


### PR DESCRIPTION
closes https://github.com/camunda/element-templates-json-schema/issues/138

related to https://github.com/bpmn-io/bpmn-js-element-templates/pull/73#issuecomment-1970834323

Note: as opposed to the proposed solution in https://github.com/bpmn-io/bpmn-js-element-templates/pull/73#issuecomment-1970834323, I did not add pattern validation. This would be a breaking change and could break already existing, currently working templates.

We can add pattern validation in a follow-up, but I do not want to push it in the current release.