### PR TITLE
feat: support `placeholder` property

### DIFF
--- a/packages/element-templates-json-schema-shared/CHANGELOG.md
+++ b/packages/element-templates-json-schema-shared/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to [@camunda/element-templates-json-schema-shared](https://g
 
 ___Note:__ Yet to be released changes appear here._
 
+## 0.11.0
+
+* `FEAT`: support `placeholder` property
+
 ## 0.10.2
 
 * `FIX`: allow number values for `Number` properties ([#138](https://github.com/camunda/element-templates-json-schema/issues/138))

--- a/packages/element-templates-json-schema-shared/src/defs/base-properties.json
+++ b/packages/element-templates-json-schema-shared/src/defs/base-properties.json
@@ -51,6 +51,46 @@
             }
           }
         }
+      },
+      {
+        "if": {
+          "oneOf": [
+            {
+              "properties": {
+                "type": {
+                  "enum": [
+                    "String",
+                    "Text"
+                  ]
+                }
+              },
+              "required": [
+                "type"
+              ]
+            },
+            {
+              "not": {
+                "required": [
+                  "type"
+                ]
+              }
+            }
+          ]
+        },
+        "then": {
+          "properties": {
+            "placeholder": {
+              "type": "string"
+            }
+          }
+        },
+        "else": {
+          "not": {
+            "required": [
+              "placeholder"
+            ]
+          }
+        }
       }
     ],
     "properties": {

--- a/packages/element-templates-json-schema/test/fixtures/placeholder-invalid-property.js
+++ b/packages/element-templates-json-schema/test/fixtures/placeholder-invalid-property.js
@@ -1,0 +1,72 @@
+export const template = {
+  name: 'Tooltip',
+  id: 'example.com.tooltip',
+  appliesTo: [
+    'bpmn:ServiceTask'
+  ],
+  properties: [
+    {
+      label: 'Input with placeholder',
+      type: 'Boolean',
+      binding: {
+        type: 'property',
+        name: 'prop'
+      },
+      placeholder: 'Invalid input type'
+    },
+    {
+      label: 'Input with placeholder',
+      type: 'Hidden',
+      binding: {
+        type: 'property',
+        name: 'prop'
+      },
+      placeholder: 'Invalid input type'
+    }
+  ]
+};
+
+export const errors = [
+  {
+    'dataPath': '/properties/0',
+    'keyword': 'not',
+    'message': 'should NOT be valid',
+    'params': {},
+    'schemaPath': '#/allOf/0/items/allOf/3/else/not',
+  },
+  {
+    'dataPath': '/properties/0',
+    'keyword': 'if',
+    'message': 'should match "else" schema',
+    params: { failingKeyword: 'else' },
+    schemaPath: '#/allOf/0/items/allOf/3/if'
+  },
+  {
+    'dataPath': '/properties/1',
+    'keyword': 'not',
+    'message': 'should NOT be valid',
+    'params': {},
+    'schemaPath': '#/allOf/0/items/allOf/3/else/not',
+  },
+  {
+    'dataPath': '/properties/1',
+    'keyword': 'if',
+    'message': 'should match "else" schema',
+    params: { failingKeyword: 'else' },
+    schemaPath: '#/allOf/0/items/allOf/3/if'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: { type: 'array' },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: { passingSchemas: null },
+    message: 'should match exactly one schema in oneOf'
+  }
+];

--- a/packages/element-templates-json-schema/test/fixtures/placeholder-invalid-type.js
+++ b/packages/element-templates-json-schema/test/fixtures/placeholder-invalid-type.js
@@ -1,0 +1,49 @@
+export const template = {
+  name: 'Tooltip',
+  id: 'example.com.tooltip',
+  appliesTo: [
+    'bpmn:ServiceTask'
+  ],
+  properties: [
+    {
+      label: 'Input with placeholder',
+      type: 'String',
+      binding: {
+        type: 'property',
+        name: 'prop'
+      },
+      placeholder: [ 'invalid placeholder type' ]
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'type',
+    dataPath: '/properties/0/placeholder',
+    schemaPath: '#/allOf/0/items/allOf/3/then/properties/placeholder/type',
+    params: { type: 'string' },
+    message: 'should be string'
+  },
+  {
+    dataPath: '/properties/0',
+    keyword: 'if',
+    message: 'should match "then" schema',
+    params: { failingKeyword: 'then' },
+    schemaPath: '#/allOf/0/items/allOf/3/if'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: { type: 'array' },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: { passingSchemas: null },
+    message: 'should match exactly one schema in oneOf'
+  }
+];

--- a/packages/element-templates-json-schema/test/fixtures/placeholder.js
+++ b/packages/element-templates-json-schema/test/fixtures/placeholder.js
@@ -1,0 +1,37 @@
+export const template = {
+  name: 'Tooltip',
+  id: 'example.com.tooltip',
+  appliesTo: [
+    'bpmn:ServiceTask'
+  ],
+  properties: [
+    {
+      label: 'Input with placeholder',
+      type: 'String',
+      binding: {
+        type: 'property',
+        name: 'prop'
+      },
+      placeholder: 'This field has a placeholder'
+    },
+    {
+      label: 'Input with placeholder',
+      type: 'Text',
+      binding: {
+        type: 'property',
+        name: 'prop'
+      },
+      placeholder: 'This field has a placeholder'
+    },
+    {
+      label: 'Input with placeholder',
+      binding: {
+        type: 'property',
+        name: 'prop'
+      },
+      placeholder: 'This field has a placeholder'
+    }
+  ]
+};
+
+export const errors = null;

--- a/packages/element-templates-json-schema/test/spec/validationSpec.js
+++ b/packages/element-templates-json-schema/test/spec/validationSpec.js
@@ -328,6 +328,15 @@ describe('validation', function() {
 
   });
 
+
+  describe('placeholder', function() {
+
+    testTemplate('placeholder');
+
+    testTemplate('placeholder-invalid-property');
+
+    testTemplate('placeholder-invalid-type');
+  });
 });
 
 

--- a/packages/zeebe-element-templates-json-schema/CHANGELOG.md
+++ b/packages/zeebe-element-templates-json-schema/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to [@camunda/zeebe-element-templates-json-schema](https://gi
 
 ___Note:__ Yet to be released changes appear here._
 
+## 0.20.0
+
+* `FEAT`: support `placeholder` property
+
 ## 0.19.2
 
 * `FIX`: allow number values for `Number` properties ([#138](https://github.com/camunda/element-templates-json-schema/issues/138))

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/placeholder-invalid-property.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/placeholder-invalid-property.js
@@ -1,0 +1,72 @@
+export const template = {
+  name: 'Tooltip',
+  id: 'example.com.tooltip',
+  appliesTo: [
+    'bpmn:ServiceTask'
+  ],
+  properties: [
+    {
+      label: 'Input with placeholder',
+      type: 'Boolean',
+      binding: {
+        type: 'property',
+        name: 'prop'
+      },
+      placeholder: 'Invalid input type'
+    },
+    {
+      label: 'Input with placeholder',
+      type: 'Number',
+      binding: {
+        type: 'property',
+        name: 'prop'
+      },
+      placeholder: 'Invalid input type'
+    }
+  ]
+};
+
+export const errors = [
+  {
+    'dataPath': '/properties/0',
+    'keyword': 'not',
+    'message': 'should NOT be valid',
+    'params': {},
+    'schemaPath': '#/allOf/0/items/allOf/3/else/not',
+  },
+  {
+    'dataPath': '/properties/0',
+    'keyword': 'if',
+    'message': 'should match "else" schema',
+    params: { failingKeyword: 'else' },
+    schemaPath: '#/allOf/0/items/allOf/3/if'
+  },
+  {
+    'dataPath': '/properties/1',
+    'keyword': 'not',
+    'message': 'should NOT be valid',
+    'params': {},
+    'schemaPath': '#/allOf/0/items/allOf/3/else/not',
+  },
+  {
+    'dataPath': '/properties/1',
+    'keyword': 'if',
+    'message': 'should match "else" schema',
+    params: { failingKeyword: 'else' },
+    schemaPath: '#/allOf/0/items/allOf/3/if'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: { type: 'array' },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: { passingSchemas: null },
+    message: 'should match exactly one schema in oneOf'
+  }
+];

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/placeholder-invalid-type.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/placeholder-invalid-type.js
@@ -1,0 +1,49 @@
+export const template = {
+  name: 'Tooltip',
+  id: 'example.com.tooltip',
+  appliesTo: [
+    'bpmn:ServiceTask'
+  ],
+  properties: [
+    {
+      label: 'Input with placeholder',
+      type: 'String',
+      binding: {
+        type: 'property',
+        name: 'prop'
+      },
+      placeholder: [ 'invalid placeholder type' ]
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'type',
+    dataPath: '/properties/0/placeholder',
+    schemaPath: '#/allOf/0/items/allOf/3/then/properties/placeholder/type',
+    params: { type: 'string' },
+    message: 'should be string'
+  },
+  {
+    dataPath: '/properties/0',
+    keyword: 'if',
+    message: 'should match "then" schema',
+    params: { failingKeyword: 'then' },
+    schemaPath: '#/allOf/0/items/allOf/3/if'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: { type: 'array' },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: { passingSchemas: null },
+    message: 'should match exactly one schema in oneOf'
+  }
+];

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/placeholder.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/placeholder.js
@@ -1,0 +1,37 @@
+export const template = {
+  name: 'Tooltip',
+  id: 'example.com.tooltip',
+  appliesTo: [
+    'bpmn:ServiceTask'
+  ],
+  properties: [
+    {
+      label: 'Input with placeholder',
+      type: 'String',
+      binding: {
+        type: 'property',
+        name: 'prop'
+      },
+      placeholder: 'This field has a placeholder'
+    },
+    {
+      label: 'Input with placeholder',
+      type: 'Text',
+      binding: {
+        type: 'property',
+        name: 'prop'
+      },
+      placeholder: 'This field has a placeholder'
+    },
+    {
+      label: 'Input with placeholder',
+      binding: {
+        type: 'property',
+        name: 'prop'
+      },
+      placeholder: 'This field has a placeholder'
+    }
+  ]
+};
+
+export const errors = null;

--- a/packages/zeebe-element-templates-json-schema/test/spec/validationSpec.js
+++ b/packages/zeebe-element-templates-json-schema/test/spec/validationSpec.js
@@ -379,6 +379,16 @@ describe('validation', function() {
 
       testTemplate('called-element-missing-property');
     });
+
+
+    describe('placeholder', function() {
+
+      testTemplate('placeholder');
+
+      testTemplate('placeholder-invalid-property');
+
+      testTemplate('placeholder-invalid-type');
+    });
   });
 
 });


### PR DESCRIPTION
This PR add support for `placeholder` property on `String` and `Text` fields.

Related to https://github.com/bpmn-io/bpmn-js-element-templates/issues/92