### PR TITLE
feat(zeebe): add zeebe:LinkedResource

### DIFF
--- a/packages/zeebe-element-templates-json-schema/CHANGELOG.md
+++ b/packages/zeebe-element-templates-json-schema/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to [@camunda/zeebe-element-templates-json-schema](https://gi
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FEAT`: support `zeebe:linkedResource` binding
+
 ## 0.21.0
 
 * `FEAT`: support `engines` field ([#146](https://github.com/camunda/element-templates-json-schema/issues/146))

--- a/packages/zeebe-element-templates-json-schema/src/defs/properties.json
+++ b/packages/zeebe-element-templates-json-schema/src/defs/properties.json
@@ -57,7 +57,8 @@
                     "bpmn:Message#property",
                     "bpmn:Message#zeebe:subscription#property",
                     "zeebe:taskDefinition",
-                    "zeebe:calledElement"
+                    "zeebe:calledElement",
+                    "zeebe:linkedResource"
                   ]
                 }
               },
@@ -273,6 +274,48 @@
             }
           }
         }
+      },
+      {
+        "if": {
+          "properties": {
+            "binding": {
+              "properties": {
+                "type": {
+                  "const": "zeebe:linkedResource"
+                }
+              },
+              "required": [
+                "type"
+              ]
+            }
+          },
+          "required": [
+            "binding"
+          ]
+        },
+        "then": {
+          "properties": {
+            "binding": {
+              "properties": {
+                "linkName": {
+                  "type": "string"
+                },
+                "property": {
+                  "enum": [
+                    "resourceId",
+                    "resourceType",
+                    "bindingType",
+                    "versionTag"
+                  ]
+                }
+              },
+              "required": [
+                "linkName",
+                "property"
+              ]
+            }
+          }
+        }
       }
     ],
     "properties": {
@@ -422,7 +465,8 @@
               "bpmn:Message#property",
               "bpmn:Message#zeebe:subscription#property",
               "zeebe:taskDefinition",
-              "zeebe:calledElement"
+              "zeebe:calledElement",
+              "zeebe:linkedResource"
             ]
           },
           "name": {
@@ -444,6 +488,11 @@
             "$id": "#/properties/property/binding/property",
             "type": "string",
             "description": "The name of the property defined in the binding."
+          },
+          "linkName": {
+            "$id": "#/properties/property/binding/linkName",
+            "type": "string",
+            "description": "The `linkName` of the element (zeebe:linkedResource)."
           }
         }
       },

--- a/packages/zeebe-element-templates-json-schema/src/error-messages.json
+++ b/packages/zeebe-element-templates-json-schema/src/error-messages.json
@@ -149,7 +149,7 @@
       "properties",
       "type"
     ],
-    "errorMessage": "invalid property.binding type ${0}; must be any of { property, zeebe:taskDefinition:type, zeebe:input, zeebe:output, zeebe:property, zeebe:taskHeader, bpmn:Message#property, bpmn:Message#zeebe:subscription#property }"
+    "errorMessage": "invalid property.binding type ${0}; must be any of { property, zeebe:taskDefinition:type, zeebe:input, zeebe:output, zeebe:property, zeebe:taskHeader, bpmn:Message#property, bpmn:Message#zeebe:subscription#property, zeebe:taskDefinition, zeebe:calledElement, zeebe:linkedResource }"
   },
   {
     "path": [
@@ -176,5 +176,22 @@
         "contents": "missing icon contents"
       }
     }
+  },
+  {
+   "path": [
+      "definitions",
+      "properties",
+      "allOf",
+      1,
+      "items",
+      "allOf",
+      10,
+      "then",
+      "properties",
+      "binding",
+      "properties",
+      "property"
+    ],
+    "errorMessage": "invalid binding.property ${0}; must be any of { resourceId, resourceType, bindingType, versionTag }"
   }
 ]

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/invalid-binding-type.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/invalid-binding-type.js
@@ -47,14 +47,15 @@ export const errors = [
               'bpmn:Message#property',
               'bpmn:Message#zeebe:subscription#property',
               'zeebe:taskDefinition',
-              'zeebe:calledElement'
+              'zeebe:calledElement',
+              'zeebe:linkedResource'
             ]
           },
           message: 'should be equal to one of the allowed values'
         }
       ]
     },
-    message: 'invalid property.binding type "foo"; must be any of { property, zeebe:taskDefinition:type, zeebe:input, zeebe:output, zeebe:property, zeebe:taskHeader, bpmn:Message#property, bpmn:Message#zeebe:subscription#property }'
+    message: 'invalid property.binding type "foo"; must be any of { property, zeebe:taskDefinition:type, zeebe:input, zeebe:output, zeebe:property, zeebe:taskHeader, bpmn:Message#property, bpmn:Message#zeebe:subscription#property, zeebe:taskDefinition, zeebe:calledElement, zeebe:linkedResource }'
   },
   {
     dataPath: '',

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/linked-resource-invalid-property.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/linked-resource-invalid-property.js
@@ -1,0 +1,77 @@
+export const template = {
+  '$schema': 'https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json',
+  'name': 'linkedResource',
+  'id': 'linkedResource',
+  'version': 1,
+  'appliesTo': [
+    'bpmn:Task'
+  ],
+  'elementType': {
+    'value': 'bpmn:ServiceTask'
+  },
+  'properties': [
+    {
+      'type': 'String',
+      'binding': {
+        'type': 'zeebe:linkedResource',
+        'linkName': 'myLink',
+        'property': 'invalidProperty'
+      }
+    }
+  ]
+};
+
+export const errors = [
+  {
+    'dataPath': '/properties/0/binding/property',
+    'keyword': 'errorMessage',
+    'message': 'invalid binding.property "invalidProperty"; must be any of { resourceId, resourceType, bindingType, versionTag }',
+    'params': {
+      'errors': [
+        {
+          'dataPath': '/properties/0/binding/property',
+          'emUsed': true,
+          'keyword': 'enum',
+          'message': 'should be equal to one of the allowed values',
+          'params': {
+            'allowedValues': [
+              'resourceId',
+              'resourceType',
+              'bindingType',
+              'versionTag'
+            ],
+          },
+          'schemaPath': '#/allOf/1/items/allOf/10/then/properties/binding/properties/property/enum'
+        },
+      ],
+    },
+    'schemaPath': '#/allOf/1/items/allOf/10/then/properties/binding/properties/property/errorMessage'
+  },
+  {
+    'dataPath': '/properties/0',
+    'keyword': 'if',
+    'message': 'should match "then" schema',
+    'params': {
+      'failingKeyword': 'then',
+    },
+    'schemaPath': '#/allOf/1/items/allOf/10/if',
+  },
+  {
+    'dataPath': '',
+    'keyword': 'type',
+    'message': 'should be array',
+    'params': {
+      'type': 'array',
+    },
+    'schemaPath': '#/oneOf/1/type',
+  },
+  {
+    'dataPath': '',
+    'keyword': 'oneOf',
+    'message': 'should match exactly one schema in oneOf',
+    'params': {
+      'passingSchemas': null,
+    },
+    'schemaPath': '#/oneOf',
+  }
+];

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/linked-resource-missing-linkName.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/linked-resource-missing-linkName.js
@@ -1,0 +1,61 @@
+export const template = {
+  '$schema': 'https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json',
+  'name': 'linkedResource',
+  'id': 'linkedResource',
+  'version': 1,
+  'appliesTo': [
+    'bpmn:Task'
+  ],
+  'elementType': {
+    'value': 'bpmn:ServiceTask'
+  },
+  'properties': [
+    {
+      'type': 'String',
+      'value': 'RPA',
+      'binding': {
+        'type': 'zeebe:linkedResource',
+        'property': 'resourceType'
+      }
+    }
+  ]
+};
+
+export const errors = [
+  {
+    'dataPath': '/properties/0/binding',
+    'keyword': 'required',
+    'message': "should have required property 'linkName'",
+    'params': {
+      'missingProperty': 'linkName',
+    },
+    'schemaPath': '#/allOf/1/items/allOf/10/then/properties/binding/required'
+  },
+  {
+    'dataPath': '/properties/0',
+    'keyword': 'if',
+    'message': 'should match "then" schema',
+    'params': {
+      'failingKeyword': 'then',
+    },
+    'schemaPath': '#/allOf/1/items/allOf/10/if'
+  },
+  {
+    'dataPath': '',
+    'keyword': 'type',
+    'message': 'should be array',
+    'params': {
+      'type': 'array',
+    },
+    'schemaPath': '#/oneOf/1/type'
+  },
+  {
+    'dataPath': '',
+    'keyword': 'oneOf',
+    'message': 'should match exactly one schema in oneOf',
+    'params': {
+      'passingSchemas': null,
+    },
+    'schemaPath': '#/oneOf'
+  }
+];

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/linked-resource.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/linked-resource.js
@@ -1,0 +1,61 @@
+export const template = {
+  '$schema': 'https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json',
+  'name': 'linkedResource',
+  'id': 'linkedResource',
+  'version': 1,
+  'appliesTo': [
+    'bpmn:Task'
+  ],
+  'elementType': {
+    'value': 'bpmn:ServiceTask'
+  },
+  'properties': [
+    {
+      'type': 'String',
+      'value': 'RPA',
+      'binding': {
+        'type': 'zeebe:linkedResource',
+        'linkName': 'persistedLink',
+        'property': 'resourceType'
+      }
+    },
+    {
+      'type': 'String',
+      'feel': 'optional',
+      'binding': {
+        'type': 'zeebe:linkedResource',
+        'linkName': 'persistedLink',
+        'property': 'resourceId'
+      }
+    },
+    {
+      'type': 'String',
+      'value': 'versionTag',
+      'binding': {
+        'type': 'zeebe:linkedResource',
+        'linkName': 'persistedLink',
+        'property': 'bindingType'
+      }
+    },
+    {
+      'type': 'String',
+      'value': 'v123',
+      'binding': {
+        'type': 'zeebe:linkedResource',
+        'linkName': 'persistedLink',
+        'property': 'versionTag'
+      }
+    },
+    {
+      'type': 'String',
+      'value': 'RPA',
+      'binding': {
+        'type': 'zeebe:linkedResource',
+        'linkName': 'removedLink',
+        'property': 'resourceType'
+      }
+    }
+  ]
+};
+
+export const errors = null;

--- a/packages/zeebe-element-templates-json-schema/test/spec/validationSpec.js
+++ b/packages/zeebe-element-templates-json-schema/test/spec/validationSpec.js
@@ -391,6 +391,17 @@ describe('validation', function() {
     });
 
 
+    describe('zeebe:linkedResource', function() {
+
+      it('linked-resource');
+
+      it('linked-resource-invalid-property');
+
+      it('linked-resource-missing-linkName');
+
+    });
+
+
     describe('placeholder', function() {
 
       it('placeholder');


### PR DESCRIPTION
This PR adds schema support for `linkedResource` templating.

Related to https://github.com/bpmn-io/bpmn-js-element-templates/issues/137