### PR TITLE
Require `Boolean` and `Number` properties with binding `zeebe:input` or `zeebe:output` to be `"feel": "static"`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "packages/*"
       ],
       "devDependencies": {
-        "@apidevtools/json-schema-ref-parser": "^11.0.0",
+        "@apidevtools/json-schema-ref-parser": "^11.7.3",
         "ajv": "^7.2.3",
         "ajv-errors": "^2.0.1",
         "chai": "^4.3.6",
@@ -26,16 +26,15 @@
       }
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-11.1.1.tgz",
-      "integrity": "sha512-WZyqzPLrWctQB8qB8uGivvzWgvtcVqlmRrayMWSxqjY6pT+CLv9vgyH6j5HqzfdZ95fTvIkBSPcrrUD9/iJ7aA==",
+      "version": "11.7.3",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-11.7.3.tgz",
+      "integrity": "sha512-WApSdLdXEBb/1FUPca2lteASewEfpjEYJ8oXZP+0gExK5qSfsEKBKcA+WjY6Q4wvXwyv0+W6Kvc372pSceib9w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jsdevtools/ono": "^7.1.3",
-        "@types/json-schema": "^7.0.13",
-        "@types/lodash.clonedeep": "^4.5.7",
-        "js-yaml": "^4.1.0",
-        "lodash.clonedeep": "^4.5.0"
+        "@types/json-schema": "^7.0.15",
+        "js-yaml": "^4.1.0"
       },
       "engines": {
         "node": ">= 16"
@@ -1373,21 +1372,6 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
-    },
-    "node_modules/@types/lodash": {
-      "version": "4.14.198",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.198.tgz",
-      "integrity": "sha512-trNJ/vtMZYMLhfN45uLq4ShQSw0/S7xCTLLVM+WM1rmFpba/VS42jVUgaO3w/NOLiWR/09lnYk0yMaA/atdIsg==",
-      "dev": true
-    },
-    "node_modules/@types/lodash.clonedeep": {
-      "version": "4.5.7",
-      "resolved": "https://registry.npmjs.org/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.7.tgz",
-      "integrity": "sha512-ccNqkPptFIXrpVqUECi60/DFxjNKsfoQxSQsgcBJCX/fuX1wgyQieojkcWH/KpE3xzLoWN/2k+ZeGqIN3paSvw==",
-      "dev": true,
-      "dependencies": {
-        "@types/lodash": "*"
-      }
     },
     "node_modules/@types/minimatch": {
       "version": "3.0.5",
@@ -6087,12 +6071,6 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
-    "node_modules/lodash.clonedeep": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
-      "dev": true
-    },
     "node_modules/lodash.ismatch": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
@@ -10435,16 +10413,14 @@
   },
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-11.1.1.tgz",
-      "integrity": "sha512-WZyqzPLrWctQB8qB8uGivvzWgvtcVqlmRrayMWSxqjY6pT+CLv9vgyH6j5HqzfdZ95fTvIkBSPcrrUD9/iJ7aA==",
+      "version": "11.7.3",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-11.7.3.tgz",
+      "integrity": "sha512-WApSdLdXEBb/1FUPca2lteASewEfpjEYJ8oXZP+0gExK5qSfsEKBKcA+WjY6Q4wvXwyv0+W6Kvc372pSceib9w==",
       "dev": true,
       "requires": {
         "@jsdevtools/ono": "^7.1.3",
-        "@types/json-schema": "^7.0.13",
-        "@types/lodash.clonedeep": "^4.5.7",
-        "js-yaml": "^4.1.0",
-        "lodash.clonedeep": "^4.5.0"
+        "@types/json-schema": "^7.0.15",
+        "js-yaml": "^4.1.0"
       }
     },
     "@babel/code-frame": {
@@ -11411,21 +11387,6 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
-    },
-    "@types/lodash": {
-      "version": "4.14.198",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.198.tgz",
-      "integrity": "sha512-trNJ/vtMZYMLhfN45uLq4ShQSw0/S7xCTLLVM+WM1rmFpba/VS42jVUgaO3w/NOLiWR/09lnYk0yMaA/atdIsg==",
-      "dev": true
-    },
-    "@types/lodash.clonedeep": {
-      "version": "4.5.7",
-      "resolved": "https://registry.npmjs.org/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.7.tgz",
-      "integrity": "sha512-ccNqkPptFIXrpVqUECi60/DFxjNKsfoQxSQsgcBJCX/fuX1wgyQieojkcWH/KpE3xzLoWN/2k+ZeGqIN3paSvw==",
-      "dev": true,
-      "requires": {
-        "@types/lodash": "*"
-      }
     },
     "@types/minimatch": {
       "version": "3.0.5",
@@ -14890,12 +14851,6 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
-    },
-    "lodash.clonedeep": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
       "dev": true
     },
     "lodash.ismatch": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "homepage": "https://github.com/camunda/element-templates-json-schema#readme",
   "devDependencies": {
-    "@apidevtools/json-schema-ref-parser": "^11.0.0",
+    "@apidevtools/json-schema-ref-parser": "^11.7.3",
     "ajv": "^7.2.3",
     "ajv-errors": "^2.0.1",
     "chai": "^4.3.6",

--- a/packages/zeebe-element-templates-json-schema/src/defs/properties.json
+++ b/packages/zeebe-element-templates-json-schema/src/defs/properties.json
@@ -316,7 +316,38 @@
             }
           }
         }
+      },
+      {
+        "allOf": [
+          {
+            "if": {
+              "properties": {
+                "binding": {
+                  "properties": {
+                    "type": {
+                      "enum": ["zeebe:input", "zeebe:output"]
+                    }
+                  },
+                  "required": ["type"]
+                },
+                "type": {
+                  "enum": ["Boolean", "Number"]
+                }
+              },
+              "required": ["binding", "type"]
+            },
+            "then": {
+              "required": ["feel"],
+              "properties": {
+                "feel": {
+                  "const": "static"
+                }
+              }
+            }
+          }
+        ]
       }
+      
     ],
     "properties": {
       "binding": {

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/invalid-zeebe-input-feel.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/invalid-zeebe-input-feel.js
@@ -1,0 +1,154 @@
+export const template = {
+  'name': 'InvalidZeebeInputFEEL',
+  'id': 'com.camunda.example.InvalidZeebeInputFEEL',
+  'appliesTo': [
+    'bpmn:Task'
+  ],
+  'properties': [
+    {
+      'label': 'booleanValid',
+      'type': 'Boolean',
+      'binding': {
+        'type': 'zeebe:input',
+        'name': 'booleanValid'
+      },
+      'feel': 'static'
+    },
+    {
+      'label': 'numberValid',
+      'type': 'Number',
+      'binding': {
+        'type': 'zeebe:input',
+        'name': 'numberValid'
+      },
+      'feel': 'static'
+    },
+    {
+      'label': 'booleanInvalid',
+      'type': 'Boolean',
+      'binding': {
+        'type': 'zeebe:input',
+        'name': 'booleanInvalid'
+      }
+    },
+    {
+      'label': 'numberInvalid',
+      'type': 'Number',
+      'binding': {
+        'type': 'zeebe:input',
+        'name': 'numberInvalid'
+      }
+    },
+    {
+      'label': 'booleanInvalidFeel',
+      'type': 'Boolean',
+      'binding': {
+        'type': 'zeebe:input',
+        'name': 'booleanInvalidFeel'
+      },
+      'feel': 'required'
+    },
+    {
+      'label': 'numberInvalidFeel',
+      'type': 'Number',
+      'binding': {
+        'type': 'zeebe:input',
+        'name': 'numberInvalidFeel'
+      },
+      'feel': 'required'
+    }
+  ]
+};
+
+export const errors = [
+  {
+    'dataPath': '/properties/2',
+    'keyword': 'required',
+    'message': 'should have required property \'feel\'',
+    'params': {
+      'missingProperty': 'feel'
+    },
+    'schemaPath': '#/allOf/1/items/allOf/11/allOf/0/then/required'
+  },
+  {
+    'dataPath': '/properties/2',
+    'keyword': 'if',
+    'message': 'should match "then" schema',
+    'params': {
+      'failingKeyword': 'then'
+    },
+    'schemaPath': '#/allOf/1/items/allOf/11/allOf/0/if'
+  },
+  {
+    'dataPath': '/properties/3',
+    'keyword': 'required',
+    'message': 'should have required property \'feel\'',
+    'params': {
+      'missingProperty': 'feel'
+    },
+    'schemaPath': '#/allOf/1/items/allOf/11/allOf/0/then/required'
+  },
+  {
+    'dataPath': '/properties/3',
+    'keyword': 'if',
+    'message': 'should match "then" schema',
+    'params': {
+      'failingKeyword': 'then'
+    },
+    'schemaPath': '#/allOf/1/items/allOf/11/allOf/0/if'
+  },
+  {
+    'dataPath': '/properties/4/feel',
+    'keyword': 'const',
+    'message': 'should be equal to constant',
+    'params': {
+      'allowedValue': 'static'
+    },
+    'schemaPath': '#/allOf/1/items/allOf/11/allOf/0/then/properties/feel/const'
+  },
+  {
+    'dataPath': '/properties/4',
+    'keyword': 'if',
+    'message': 'should match "then" schema',
+    'params': {
+      'failingKeyword': 'then'
+    },
+    'schemaPath': '#/allOf/1/items/allOf/11/allOf/0/if'
+  },
+  {
+    'dataPath': '/properties/5/feel',
+    'keyword': 'const',
+    'message': 'should be equal to constant',
+    'params': {
+      'allowedValue': 'static'
+    },
+    'schemaPath': '#/allOf/1/items/allOf/11/allOf/0/then/properties/feel/const'
+  },
+  {
+    'dataPath': '/properties/5',
+    'keyword': 'if',
+    'message': 'should match "then" schema',
+    'params': {
+      'failingKeyword': 'then'
+    },
+    'schemaPath': '#/allOf/1/items/allOf/11/allOf/0/if'
+  },
+  {
+    'dataPath': '',
+    'keyword': 'type',
+    'message': 'should be array',
+    'params': {
+      'type': 'array'
+    },
+    'schemaPath': '#/oneOf/1/type'
+  },
+  {
+    'dataPath': '',
+    'keyword': 'oneOf',
+    'message': 'should match exactly one schema in oneOf',
+    'params': {
+      'passingSchemas': null
+    },
+    'schemaPath': '#/oneOf'
+  }
+];

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/invalid-zeebe-input-type.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/invalid-zeebe-input-type.js
@@ -16,6 +16,7 @@ export const template = {
     {
       'label': 'bar',
       'type': 'Boolean',
+      'feel': 'static',
       'binding': {
         'type': 'zeebe:input',
         'name': 'bar'
@@ -24,6 +25,7 @@ export const template = {
     {
       'label': 'baz',
       'type': 'Number',
+      'feel': 'static',
       'binding': {
         'type': 'zeebe:input',
         'name': 'baz'

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/invalid-zeebe-output-feel.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/invalid-zeebe-output-feel.js
@@ -1,0 +1,154 @@
+export const template = {
+  'name': 'InvalidZeebeOutputFEEL',
+  'id': 'com.camunda.example.InvalidZeebeOutputFEEL',
+  'appliesTo': [
+    'bpmn:Task'
+  ],
+  'properties': [
+    {
+      'label': 'booleanValid',
+      'type': 'Boolean',
+      'binding': {
+        'type': 'zeebe:output',
+        'source': 'booleanValid'
+      },
+      'feel': 'static'
+    },
+    {
+      'label': 'numberValid',
+      'type': 'Number',
+      'binding': {
+        'type': 'zeebe:output',
+        'source': 'numberValid'
+      },
+      'feel': 'static'
+    },
+    {
+      'label': 'booleanInvalid',
+      'type': 'Boolean',
+      'binding': {
+        'type': 'zeebe:output',
+        'source': 'booleanInvalid'
+      }
+    },
+    {
+      'label': 'numberInvalid',
+      'type': 'Number',
+      'binding': {
+        'type': 'zeebe:output',
+        'source': 'numberInvalid'
+      }
+    },
+    {
+      'label': 'booleanInvalidFeel',
+      'type': 'Boolean',
+      'binding': {
+        'type': 'zeebe:output',
+        'source': 'booleanInvalidFeel'
+      },
+      'feel': 'required'
+    },
+    {
+      'label': 'numberInvalidFeel',
+      'type': 'Number',
+      'binding': {
+        'type': 'zeebe:output',
+        'source': 'numberInvalidFeel'
+      },
+      'feel': 'required'
+    }
+  ]
+};
+
+export const errors = [
+  {
+    'dataPath': '/properties/2',
+    'keyword': 'required',
+    'message': 'should have required property \'feel\'',
+    'params': {
+      'missingProperty': 'feel'
+    },
+    'schemaPath': '#/allOf/1/items/allOf/11/allOf/0/then/required'
+  },
+  {
+    'dataPath': '/properties/2',
+    'keyword': 'if',
+    'message': 'should match "then" schema',
+    'params': {
+      'failingKeyword': 'then'
+    },
+    'schemaPath': '#/allOf/1/items/allOf/11/allOf/0/if'
+  },
+  {
+    'dataPath': '/properties/3',
+    'keyword': 'required',
+    'message': 'should have required property \'feel\'',
+    'params': {
+      'missingProperty': 'feel'
+    },
+    'schemaPath': '#/allOf/1/items/allOf/11/allOf/0/then/required'
+  },
+  {
+    'dataPath': '/properties/3',
+    'keyword': 'if',
+    'message': 'should match "then" schema',
+    'params': {
+      'failingKeyword': 'then'
+    },
+    'schemaPath': '#/allOf/1/items/allOf/11/allOf/0/if'
+  },
+  {
+    'dataPath': '/properties/4/feel',
+    'keyword': 'const',
+    'message': 'should be equal to constant',
+    'params': {
+      'allowedValue': 'static'
+    },
+    'schemaPath': '#/allOf/1/items/allOf/11/allOf/0/then/properties/feel/const'
+  },
+  {
+    'dataPath': '/properties/4',
+    'keyword': 'if',
+    'message': 'should match "then" schema',
+    'params': {
+      'failingKeyword': 'then'
+    },
+    'schemaPath': '#/allOf/1/items/allOf/11/allOf/0/if'
+  },
+  {
+    'dataPath': '/properties/5/feel',
+    'keyword': 'const',
+    'message': 'should be equal to constant',
+    'params': {
+      'allowedValue': 'static'
+    },
+    'schemaPath': '#/allOf/1/items/allOf/11/allOf/0/then/properties/feel/const'
+  },
+  {
+    'dataPath': '/properties/5',
+    'keyword': 'if',
+    'message': 'should match "then" schema',
+    'params': {
+      'failingKeyword': 'then'
+    },
+    'schemaPath': '#/allOf/1/items/allOf/11/allOf/0/if'
+  },
+  {
+    'dataPath': '',
+    'keyword': 'type',
+    'message': 'should be array',
+    'params': {
+      'type': 'array'
+    },
+    'schemaPath': '#/oneOf/1/type'
+  },
+  {
+    'dataPath': '',
+    'keyword': 'oneOf',
+    'message': 'should match exactly one schema in oneOf',
+    'params': {
+      'passingSchemas': null
+    },
+    'schemaPath': '#/oneOf'
+  }
+];

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/invalid-zeebe-output-type.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/invalid-zeebe-output-type.js
@@ -24,6 +24,7 @@ export const template = {
     {
       'label': 'bar',
       'type': 'Boolean',
+      'feel': 'static',
       'binding': {
         'type': 'zeebe:output',
         'source': 'bar'

--- a/packages/zeebe-element-templates-json-schema/test/spec/validationSpec.js
+++ b/packages/zeebe-element-templates-json-schema/test/spec/validationSpec.js
@@ -122,6 +122,12 @@ describe('validation', function() {
     it('missing-binding-zeebe-header-key');
 
 
+    it('invalid-zeebe-input-feel');
+
+
+    it('invalid-zeebe-output-feel');
+
+
     it('with-version');
 
 


### PR DESCRIPTION
Adds a new condition that requires `Boolean` and `Number` properties with binding `zeebe:input` or `zeebe:output` to be `"feel": "static"`. This is to ensure their values will be persisted as FEEL expressions and not intepreted as strings.

### Before

```json
{
  "label": "Foo",
  "type": "Boolean",
  "binding": {
    "type": "zeebe:input",
    "name": "foo"
  }
}
```

would result in

```xml
<zeebe:input source="true" target="foo" />
```

and is therefore interpreted as string.

### After

```json
{
  "label": "Foo",
  "type": "Boolean",
  "binding": {
    "type": "zeebe:input",
    "name": "foo"
  },
  "feel": "static"
}
```

results in

```xml
<zeebe:input source="=true" target="foo" />
```

and is therefore interpreted as boolean.