### PR TITLE
fix(zeebe): require `"feel":"optional/static"` for `Boolean/Number` I/O

### DIFF
--- a/packages/zeebe-element-templates-json-schema/src/defs/properties.json
+++ b/packages/zeebe-element-templates-json-schema/src/defs/properties.json
@@ -340,7 +340,7 @@
               "required": ["feel"],
               "properties": {
                 "feel": {
-                  "const": "static"
+                  "enum": [ "optional", "static" ]
                 }
               }
             }

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/invalid-zeebe-input-feel.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/invalid-zeebe-input-feel.js
@@ -6,20 +6,38 @@ export const template = {
   ],
   'properties': [
     {
-      'label': 'booleanValid',
+      'label': 'booleanValidOptional',
       'type': 'Boolean',
       'binding': {
         'type': 'zeebe:input',
-        'name': 'booleanValid'
+        'name': 'booleanValidOptional'
+      },
+      'feel': 'optional'
+    },
+    {
+      'label': 'numberValidOptional',
+      'type': 'Number',
+      'binding': {
+        'type': 'zeebe:input',
+        'name': 'numberValidOptional'
+      },
+      'feel': 'optional'
+    },
+    {
+      'label': 'booleanValidStatic',
+      'type': 'Boolean',
+      'binding': {
+        'type': 'zeebe:input',
+        'name': 'booleanValidStatic'
       },
       'feel': 'static'
     },
     {
-      'label': 'numberValid',
+      'label': 'numberValidStatic',
       'type': 'Number',
       'binding': {
         'type': 'zeebe:input',
-        'name': 'numberValid'
+        'name': 'numberValidStatic'
       },
       'feel': 'static'
     },
@@ -62,49 +80,13 @@ export const template = {
 
 export const errors = [
   {
-    'dataPath': '/properties/2',
+    'dataPath': '/properties/4',
     'keyword': 'required',
     'message': 'should have required property \'feel\'',
     'params': {
       'missingProperty': 'feel'
     },
     'schemaPath': '#/allOf/1/items/allOf/11/allOf/0/then/required'
-  },
-  {
-    'dataPath': '/properties/2',
-    'keyword': 'if',
-    'message': 'should match "then" schema',
-    'params': {
-      'failingKeyword': 'then'
-    },
-    'schemaPath': '#/allOf/1/items/allOf/11/allOf/0/if'
-  },
-  {
-    'dataPath': '/properties/3',
-    'keyword': 'required',
-    'message': 'should have required property \'feel\'',
-    'params': {
-      'missingProperty': 'feel'
-    },
-    'schemaPath': '#/allOf/1/items/allOf/11/allOf/0/then/required'
-  },
-  {
-    'dataPath': '/properties/3',
-    'keyword': 'if',
-    'message': 'should match "then" schema',
-    'params': {
-      'failingKeyword': 'then'
-    },
-    'schemaPath': '#/allOf/1/items/allOf/11/allOf/0/if'
-  },
-  {
-    'dataPath': '/properties/4/feel',
-    'keyword': 'const',
-    'message': 'should be equal to constant',
-    'params': {
-      'allowedValue': 'static'
-    },
-    'schemaPath': '#/allOf/1/items/allOf/11/allOf/0/then/properties/feel/const'
   },
   {
     'dataPath': '/properties/4',
@@ -116,16 +98,58 @@ export const errors = [
     'schemaPath': '#/allOf/1/items/allOf/11/allOf/0/if'
   },
   {
-    'dataPath': '/properties/5/feel',
-    'keyword': 'const',
-    'message': 'should be equal to constant',
+    'dataPath': '/properties/5',
+    'keyword': 'required',
+    'message': 'should have required property \'feel\'',
     'params': {
-      'allowedValue': 'static'
+      'missingProperty': 'feel'
     },
-    'schemaPath': '#/allOf/1/items/allOf/11/allOf/0/then/properties/feel/const'
+    'schemaPath': '#/allOf/1/items/allOf/11/allOf/0/then/required'
   },
   {
     'dataPath': '/properties/5',
+    'keyword': 'if',
+    'message': 'should match "then" schema',
+    'params': {
+      'failingKeyword': 'then'
+    },
+    'schemaPath': '#/allOf/1/items/allOf/11/allOf/0/if'
+  },
+  {
+    'dataPath': '/properties/6/feel',
+    'keyword': 'enum',
+    'message': 'should be equal to one of the allowed values',
+    'params': {
+      'allowedValues': [
+        'optional',
+        'static'
+      ]
+    },
+    'schemaPath': '#/allOf/1/items/allOf/11/allOf/0/then/properties/feel/enum'
+  },
+  {
+    'dataPath': '/properties/6',
+    'keyword': 'if',
+    'message': 'should match "then" schema',
+    'params': {
+      'failingKeyword': 'then'
+    },
+    'schemaPath': '#/allOf/1/items/allOf/11/allOf/0/if'
+  },
+  {
+    'dataPath': '/properties/7/feel',
+    'keyword': 'enum',
+    'message': 'should be equal to one of the allowed values',
+    'params': {
+      'allowedValues': [
+        'optional',
+        'static'
+      ]
+    },
+    'schemaPath': '#/allOf/1/items/allOf/11/allOf/0/then/properties/feel/enum'
+  },
+  {
+    'dataPath': '/properties/7',
     'keyword': 'if',
     'message': 'should match "then" schema',
     'params': {

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/invalid-zeebe-output-feel.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/invalid-zeebe-output-feel.js
@@ -6,20 +6,38 @@ export const template = {
   ],
   'properties': [
     {
-      'label': 'booleanValid',
+      'label': 'booleanValidOptional',
       'type': 'Boolean',
       'binding': {
         'type': 'zeebe:output',
-        'source': 'booleanValid'
+        'source': 'booleanValidOptional'
+      },
+      'feel': 'optional'
+    },
+    {
+      'label': 'numberValidOptional',
+      'type': 'Number',
+      'binding': {
+        'type': 'zeebe:output',
+        'source': 'numberValidOptional'
+      },
+      'feel': 'optional'
+    },
+    {
+      'label': 'booleanValidStatic',
+      'type': 'Boolean',
+      'binding': {
+        'type': 'zeebe:output',
+        'source': 'booleanValidStatic'
       },
       'feel': 'static'
     },
     {
-      'label': 'numberValid',
+      'label': 'numberValidStatic',
       'type': 'Number',
       'binding': {
         'type': 'zeebe:output',
-        'source': 'numberValid'
+        'source': 'numberValidStatic'
       },
       'feel': 'static'
     },
@@ -62,49 +80,13 @@ export const template = {
 
 export const errors = [
   {
-    'dataPath': '/properties/2',
+    'dataPath': '/properties/4',
     'keyword': 'required',
     'message': 'should have required property \'feel\'',
     'params': {
       'missingProperty': 'feel'
     },
     'schemaPath': '#/allOf/1/items/allOf/11/allOf/0/then/required'
-  },
-  {
-    'dataPath': '/properties/2',
-    'keyword': 'if',
-    'message': 'should match "then" schema',
-    'params': {
-      'failingKeyword': 'then'
-    },
-    'schemaPath': '#/allOf/1/items/allOf/11/allOf/0/if'
-  },
-  {
-    'dataPath': '/properties/3',
-    'keyword': 'required',
-    'message': 'should have required property \'feel\'',
-    'params': {
-      'missingProperty': 'feel'
-    },
-    'schemaPath': '#/allOf/1/items/allOf/11/allOf/0/then/required'
-  },
-  {
-    'dataPath': '/properties/3',
-    'keyword': 'if',
-    'message': 'should match "then" schema',
-    'params': {
-      'failingKeyword': 'then'
-    },
-    'schemaPath': '#/allOf/1/items/allOf/11/allOf/0/if'
-  },
-  {
-    'dataPath': '/properties/4/feel',
-    'keyword': 'const',
-    'message': 'should be equal to constant',
-    'params': {
-      'allowedValue': 'static'
-    },
-    'schemaPath': '#/allOf/1/items/allOf/11/allOf/0/then/properties/feel/const'
   },
   {
     'dataPath': '/properties/4',
@@ -116,16 +98,58 @@ export const errors = [
     'schemaPath': '#/allOf/1/items/allOf/11/allOf/0/if'
   },
   {
-    'dataPath': '/properties/5/feel',
-    'keyword': 'const',
-    'message': 'should be equal to constant',
+    'dataPath': '/properties/5',
+    'keyword': 'required',
+    'message': 'should have required property \'feel\'',
     'params': {
-      'allowedValue': 'static'
+      'missingProperty': 'feel'
     },
-    'schemaPath': '#/allOf/1/items/allOf/11/allOf/0/then/properties/feel/const'
+    'schemaPath': '#/allOf/1/items/allOf/11/allOf/0/then/required'
   },
   {
     'dataPath': '/properties/5',
+    'keyword': 'if',
+    'message': 'should match "then" schema',
+    'params': {
+      'failingKeyword': 'then'
+    },
+    'schemaPath': '#/allOf/1/items/allOf/11/allOf/0/if'
+  },
+  {
+    'dataPath': '/properties/6/feel',
+    'keyword': 'enum',
+    'message': 'should be equal to one of the allowed values',
+    'params': {
+      'allowedValues': [
+        'optional',
+        'static'
+      ]
+    },
+    'schemaPath': '#/allOf/1/items/allOf/11/allOf/0/then/properties/feel/enum'
+  },
+  {
+    'dataPath': '/properties/6',
+    'keyword': 'if',
+    'message': 'should match "then" schema',
+    'params': {
+      'failingKeyword': 'then'
+    },
+    'schemaPath': '#/allOf/1/items/allOf/11/allOf/0/if'
+  },
+  {
+    'dataPath': '/properties/7/feel',
+    'keyword': 'enum',
+    'message': 'should be equal to one of the allowed values',
+    'params': {
+      'allowedValues': [
+        'optional',
+        'static'
+      ]
+    },
+    'schemaPath': '#/allOf/1/items/allOf/11/allOf/0/then/properties/feel/enum'
+  },
+  {
+    'dataPath': '/properties/7',
     'keyword': 'if',
     'message': 'should match "then" schema',
     'params': {


### PR DESCRIPTION
Following up on https://github.com/camunda/element-templates-json-schema/pull/154 this pull request changes the schema to allow both `static` and `optional` for `Boolean` and `Number` properties with a `zeebe:input` or `zeebe:output` binding as these are valid use cases and both `static` and `optional` [will result in a FEEL expression](https://github.com/bpmn-io/bpmn-js-element-templates/blob/main/src/cloud-element-templates/util/FeelUtil.js#L2C36-L2C57).

So both of these are valid:

```json
{
  "label": "Optional FEEL Boolean",
  "type": "Boolean",
  "binding": {
    "type": "zeebe:input",
    "name": "foo"
  },
  "feel": "optional"
},
{
  "label": "Static FEEL Boolean",
  "type": "Boolean",
  "binding": {
    "type": "zeebe:input",
    "name": "foo"
  },
  "feel": "static"
},
```

In the properties panel this will look like:

![image](https://github.com/user-attachments/assets/8553c979-8b28-4f4a-a624-4f751e9d0f8c)

These will always be converted to FEEL expressions:

```xml
<zeebe:input source="=10" target="numberOptional" />
<zeebe:input source="=false" target="booleanOptional" />
<zeebe:input source="=10" target="numberStatic" />
<zeebe:input source="=false" target="booleanStatic" />
```