### PR TITLE
feat: support `zeebe:userTask` binding property

### DIFF
--- a/packages/zeebe-element-templates-json-schema/src/defs/properties.json
+++ b/packages/zeebe-element-templates-json-schema/src/defs/properties.json
@@ -235,10 +235,10 @@
         "if": {
           "properties": {
             "type": {
-                "enum": [
-                  "String",
-                  "Text"
-                ]
+              "enum": [
+                "String",
+                "Text"
+              ]
             }
           },
           "required": [
@@ -260,7 +260,7 @@
         "if": {
           "properties": {
             "feel": {
-                "const": "required"
+              "const": "required"
             }
           },
           "required": [
@@ -345,6 +345,37 @@
             }
           }
         ]
+      },
+      {
+        "if": {
+          "properties": {
+            "binding": {
+              "properties": {
+                "type": {
+                  "const": "zeebe:userTask"
+                }
+              },
+              "required": [
+                "type"
+              ]
+            }
+          },
+          "required": [
+            "binding"
+          ]
+        },
+        "then": {
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "enum": [
+                "Hidden"
+              ]
+            }
+          }
+        }
       }
 
     ],
@@ -496,7 +527,8 @@
               "bpmn:Message#zeebe:subscription#property",
               "zeebe:taskDefinition",
               "zeebe:calledElement",
-              "zeebe:linkedResource"
+              "zeebe:linkedResource",
+              "zeebe:userTask"
             ]
           },
           "name": {

--- a/packages/zeebe-element-templates-json-schema/src/defs/template.json
+++ b/packages/zeebe-element-templates-json-schema/src/defs/template.json
@@ -215,6 +215,51 @@
           }
         ]
       }
+    },
+    {
+      "if": {
+        "properties": {
+          "properties": {
+            "contains": {
+              "properties": {
+                "binding": {
+                  "properties": {
+                    "type": {
+                      "const": "zeebe:userTask"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ]
+                }
+              },
+              "required": [
+                "binding"
+              ]
+            }
+          }
+        },
+        "required": [
+          "properties"
+        ]
+      },
+      "then":{
+        "required": [
+          "elementType"
+        ],
+        "properties": {
+          "elementType": {
+            "required": [
+              "value"
+            ],
+            "properties": {
+              "value": {
+                "const": "bpmn:UserTask"
+              }
+            }
+          }
+        }
+      }
     }
   ]
 }

--- a/packages/zeebe-element-templates-json-schema/src/error-messages.json
+++ b/packages/zeebe-element-templates-json-schema/src/error-messages.json
@@ -149,7 +149,7 @@
       "properties",
       "type"
     ],
-    "errorMessage": "invalid property.binding type ${0}; must be any of { property, zeebe:taskDefinition:type, zeebe:input, zeebe:output, zeebe:property, zeebe:taskHeader, bpmn:Message#property, bpmn:Message#zeebe:subscription#property, zeebe:taskDefinition, zeebe:calledElement, zeebe:linkedResource }"
+    "errorMessage": "invalid property.binding type ${0}; must be any of { property, zeebe:taskDefinition:type, zeebe:input, zeebe:output, zeebe:property, zeebe:taskHeader, bpmn:Message#property, bpmn:Message#zeebe:subscription#property, zeebe:taskDefinition, zeebe:calledElement, zeebe:linkedResource, zeebe:userTask }"
   },
   {
     "path": [
@@ -178,7 +178,7 @@
     }
   },
   {
-   "path": [
+    "path": [
       "definitions",
       "properties",
       "allOf",

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/invalid-binding-type.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/invalid-binding-type.js
@@ -48,14 +48,15 @@ export const errors = [
               'bpmn:Message#zeebe:subscription#property',
               'zeebe:taskDefinition',
               'zeebe:calledElement',
-              'zeebe:linkedResource'
+              'zeebe:linkedResource',
+              'zeebe:userTask'
             ]
           },
           message: 'should be equal to one of the allowed values'
         }
       ]
     },
-    message: 'invalid property.binding type "foo"; must be any of { property, zeebe:taskDefinition:type, zeebe:input, zeebe:output, zeebe:property, zeebe:taskHeader, bpmn:Message#property, bpmn:Message#zeebe:subscription#property, zeebe:taskDefinition, zeebe:calledElement, zeebe:linkedResource }'
+    message: 'invalid property.binding type "foo"; must be any of { property, zeebe:taskDefinition:type, zeebe:input, zeebe:output, zeebe:property, zeebe:taskHeader, bpmn:Message#property, bpmn:Message#zeebe:subscription#property, zeebe:taskDefinition, zeebe:calledElement, zeebe:linkedResource, zeebe:userTask }'
   },
   {
     dataPath: '',

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/zeebe-user-task-invalid.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/zeebe-user-task-invalid.js
@@ -1,0 +1,77 @@
+export const template = {
+  'name': 'ZeebeUserTaskInvalid',
+  'id': 'com.camunda.example.ZeebeUserTask.Invalid',
+  'appliesTo': [
+    'bpmn:Task'
+  ],
+  'elementType': {
+    'value': 'bpmn:IntermediateCatchEvent'
+  },
+  'properties': [
+    {
+      'type': 'String',
+      'binding': {
+        'type': 'zeebe:userTask',
+      }
+    }
+  ]
+};
+
+export const errors = [
+  {
+    dataPath: '/elementType/value',
+    keyword: 'const',
+    message: 'should be equal to constant',
+    params: {
+      allowedValue: 'bpmn:UserTask'
+    },
+    schemaPath: '#/allOf/1/allOf/3/then/properties/elementType/properties/value/const'
+  },
+  {
+    dataPath: '',
+    keyword: 'if',
+    message: 'should match "then" schema',
+    params: {
+      failingKeyword: 'then'
+    },
+    schemaPath: '#/allOf/1/allOf/3/if'
+  },
+  {
+    dataPath: '/properties/0/type',
+    keyword: 'enum',
+    message: 'should be equal to one of the allowed values',
+    params: {
+      allowedValues: [
+        'Hidden'
+      ]
+    },
+    schemaPath: '#/allOf/1/items/allOf/12/then/properties/type/enum'
+  },
+  {
+    dataPath: '/properties/0',
+    keyword: 'if',
+    message: 'should match "then" schema',
+    params: {
+      failingKeyword: 'then'
+    },
+    schemaPath: '#/allOf/1/items/allOf/12/if'
+  },
+  {
+    dataPath: '',
+    keyword: 'type',
+    message: 'should be array',
+    params: {
+      type: 'array'
+    },
+    schemaPath: '#/oneOf/1/type'
+  },
+  {
+    dataPath: '',
+    keyword: 'oneOf',
+    message: 'should match exactly one schema in oneOf',
+    params: {
+      passingSchemas: null
+    },
+    schemaPath: '#/oneOf'
+  }
+];

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/zeebe-user-task.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/zeebe-user-task.js
@@ -1,0 +1,20 @@
+export const template = {
+  'name': 'ZeebeUserTask',
+  'id': 'com.camunda.example.ZeebeUserTask',
+  'appliesTo': [
+    'bpmn:Task'
+  ],
+  'elementType': {
+    'value': 'bpmn:UserTask'
+  },
+  'properties': [
+    {
+      'type': 'Hidden',
+      'binding': {
+        'type': 'zeebe:userTask',
+      }
+    }
+  ]
+};
+
+export const errors = null;

--- a/packages/zeebe-element-templates-json-schema/test/spec/validationSpec.js
+++ b/packages/zeebe-element-templates-json-schema/test/spec/validationSpec.js
@@ -440,6 +440,15 @@ describe('validation', function() {
 
     });
 
+
+    describe('zeebe:userTask', function() {
+
+      it('zeebe-user-task');
+
+      it('zeebe-user-task-invalid');
+
+    });
+
   });
 
 });


### PR DESCRIPTION
### Proposed Changes

<!--
Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.
--> 

Support `zeebe:userTask` binding property. If specified, it ensures that a (user) task has Camunda user task set as the implementation type.

Related to https://github.com/camunda/camunda-modeler/issues/4582

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->