### PR TITLE
test: add full validation error output for failed test

### DIFF
--- a/packages/element-templates-json-schema-shared/test/helpers/index.js
+++ b/packages/element-templates-json-schema-shared/test/helpers/index.js
@@ -3,6 +3,8 @@ const {
   set
 } = require('min-dash');
 
+const chai = require('chai');
+
 const { default: Ajv } = require('ajv');
 const AjvErrors = require('ajv-errors');
 
@@ -54,3 +56,19 @@ function setErrorMessage(schema, error) {
 
   return set(schema, errorMessagePath, errorMessage);
 }
+
+function eqlErrors(chai, utils) {
+
+  const Assertion = chai.Assertion;
+
+  Assertion.addMethod('eqlErrors', function(expectedErrors, filter) {
+
+    const actualErrors = this._obj;
+
+    // formats the validation errors, so that they can be used directly in the fixture files.
+    this.eql(expectedErrors,
+      `Errors from validation do not match expected.\n\tValidation returned this error (you can use it in the fixture):\n\t${JSON.stringify(actualErrors, null, 2).replace(/"([^"]+)":/g, '$1:')}\n`);
+  });
+}
+
+chai.use(eqlErrors);

--- a/packages/zeebe-element-templates-json-schema/test/spec/validationSpec.js
+++ b/packages/zeebe-element-templates-json-schema/test/spec/validationSpec.js
@@ -49,7 +49,7 @@ function createTest(name, file, it) {
     } = validateTemplate(template);
 
     // then
-    expect(errors).to.eql(expectedErrors);
+    expect(errors).to.eqlErrors(expectedErrors);
   });
 }
 


### PR DESCRIPTION
### Proposed Changes

Allows developers to directly copy the error to the fixture file. 
I don't mind if this is rejected, it feels a little "odd" but it sped up my workflow immensely so far. Maybe there is a better way to get the full validation error for the fixture file, which I am unaware of. 

Discussion started [here](https://github.com/camunda/element-templates-json-schema/pull/169#discussion_r2144468155).

The output for failing tests now looks like this: 

```
         1) validation
              should validate single template
                zeebe:calledDecision
                  called-decision-incorrect-property:
            AssertionError: Errors from validation do not match expected.
        Validation returned this error:
        [
         {
           keyword: "errorMessage",
           dataPath: "/properties/0/binding/property",
           schemaPath: "#/allOf/1/allOf/5/then/allOf/0/properties/properties/contains/properties/binding/properties/property/errorMessage",
           params: {
             errors: [
               {
                 keyword: "const",
                 dataPath: "/properties/0/binding/property",
                 schemaPath: "#/allOf/1/allOf/5/then/allOf/0/properties/properties/contains/properties/binding/properties/property/const",
                 params: {
                   allowedValue: "decisionId"
                 },
                 message: "should be equal to constant",
                 emUsed: true
               }
             ]
           },
           message: "Binding type \"zeebe:calledDecision\" must contain property \"decisionId\""
         },
         {
           keyword: "contains",
           dataPath: "/properties",
           schemaPath: "#/allOf/1/allOf/5/then/allOf/0/properties/properties/contains",
           params: {
             minContains: 1
           },
           message: "should contain at least 1 valid item(s)"
         },
         {
           keyword: "errorMessage",
           dataPath: "/properties/0/binding/property",
           schemaPath: "#/allOf/1/allOf/5/then/allOf/1/properties/properties/contains/properties/binding/properties/property/errorMessage",
           params: {
             errors: [
               {
                 keyword: "const",
                 dataPath: "/properties/0/binding/property",
                 schemaPath: "#/allOf/1/allOf/5/then/allOf/1/properties/properties/contains/properties/binding/properties/property/const",
                 params: {
                   allowedValue: "resultVariable"
                 },
                 message: "should be equal to constant",
                 emUsed: true
               }
             ]
           },
           message: "Binding type \"zeebe:calledDecision\" must contain property \"resultVariable\""
         },
         {
           keyword: "contains",
           dataPath: "/properties",
           schemaPath: "#/allOf/1/allOf/5/then/allOf/1/properties/properties/contains",
           params: {
             minContains: 1
           },
           message: "should contain at least 1 valid item(s)"
         },
         {
           keyword: "if",
           dataPath: "",
           schemaPath: "#/allOf/1/allOf/5/if",
           params: {
             failingKeyword: "then"
           },
           message: "should match \"then\" schema"
         },
         {
           keyword: "enum",
           dataPath: "/properties/0/binding/property",
           schemaPath: "#/allOf/1/items/properties/binding/allOf/7/then/properties/property/enum",
           params: {
             allowedValues: [
               "decisionId",
               "resultVariable"
             ]
           },
           message: "should be equal to one of the allowed values"
         },
         {
           keyword: "if",
           dataPath: "/properties/0/binding",
           schemaPath: "#/allOf/1/items/properties/binding/allOf/7/if",
           params: {
             failingKeyword: "then"
           },
           message: "should match \"then\" schema"
         },
         {
           keyword: "type",
           dataPath: "",
           schemaPath: "#/oneOf/1/type",
           params: {
             type: "array"
           },
           message: "should be array"
         },
         {
           keyword: "oneOf",
           dataPath: "",
           schemaPath: "#/oneOf",
           params: {
             passingSchemas: null
           },
           message: "should match exactly one schema in oneOf"
         }
       ]
       : expected [ …(9) ] to deeply equal null

```

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->