### PR TITLE
feat: support `bindingType` property for `calledDecision`, `calledElement`, and `formDefinition`

### DIFF
--- a/packages/zeebe-element-templates-json-schema/src/defs/properties.json
+++ b/packages/zeebe-element-templates-json-schema/src/defs/properties.json
@@ -608,6 +608,9 @@
             }
           }
         }
+      },
+      {
+        "$ref": "./properties/bindingType.json"
       }
     ],
     "properties": {
@@ -730,7 +733,11 @@
             "then": {
               "properties": {
                 "property": {
-                  "const": "processId"
+                  "enum": [
+                    "processId",
+                    "bindingType",
+                    "versionTag"
+                  ]
                 }
               },
               "required": [
@@ -779,7 +786,9 @@
                 "property": {
                   "enum": [
                     "formId",
-                    "externalReference"
+                    "externalReference",
+                    "bindingType",
+                    "versionTag"
                   ]
                 }
               },
@@ -804,7 +813,9 @@
                 "property": {
                   "enum": [
                     "decisionId",
-                    "resultVariable"
+                    "resultVariable",
+                    "versionTag",
+                    "bindingType"
                   ]
                 }
               },

--- a/packages/zeebe-element-templates-json-schema/src/defs/properties/bindingType.json
+++ b/packages/zeebe-element-templates-json-schema/src/defs/properties/bindingType.json
@@ -1,0 +1,105 @@
+{
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "binding": {
+            "properties": {
+              "property": {
+                "const": "bindingType"
+              },
+              "type": {
+                "enum": [
+                  "zeebe:calledDecision",
+                  "zeebe:formDefinition",
+                  "zeebe:calledElement"
+                ]
+              }
+            },
+            "required": [
+              "type",
+              "property"
+            ]
+          }
+        },
+        "required": [
+          "binding"
+        ]
+      },
+      "then": {
+        "required": [
+          "type",
+          "value"
+        ],
+        "properties": {
+          "type": {
+            "enum": [
+              "Hidden",
+              "Dropdown"
+            ]
+          },
+          "value": {
+            "enum": [
+              "latest",
+              "versionTag",
+              "deployment"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "binding": {
+            "properties": {
+              "property": {
+                "const": "versionTag"
+              },
+              "type": {
+                "enum": [
+                  "zeebe:calledDecision",
+                  "zeebe:formDefinition",
+                  "zeebe:calledElement"
+                ]
+              }
+            },
+            "required": [
+              "type",
+              "property"
+            ]
+          }
+        },
+        "required": [
+          "binding"
+        ]
+      },
+      "then": {
+        "allOf": [
+          {
+            "required": [
+              "type"
+            ],
+            "properties": {
+              "type": {
+                "enum": [
+                  "Hidden",
+                  "Dropdown",
+                  "String",
+                  "Text"
+                ]
+              }
+            }
+          },
+          {
+            "not": {
+              "required": [
+                "feel"
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/packages/zeebe-element-templates-json-schema/src/defs/properties/bindingType.json
+++ b/packages/zeebe-element-templates-json-schema/src/defs/properties/bindingType.json
@@ -32,6 +32,20 @@
           "value"
         ],
         "properties": {
+          "choices": {
+            "type": "array",
+            "items": {
+              "properties": {
+                "value": {
+                  "enum": [
+                    "latest",
+                    "versionTag",
+                    "deployment"
+                  ]
+                }
+              }
+            }
+          },
           "type": {
             "enum": [
               "Hidden",

--- a/packages/zeebe-element-templates-json-schema/src/defs/template.json
+++ b/packages/zeebe-element-templates-json-schema/src/defs/template.json
@@ -213,6 +213,34 @@
               }
             }
           }
+        ],
+        "properties": {
+          "properties": {
+            "contains": {
+              "properties": {
+                "binding": {
+                  "properties": {
+                    "type": {
+                      "const": "zeebe:calledElement"
+                    },
+                    "property": {
+                      "const": "processId"
+                    }
+                  },
+                  "required": [
+                    "property",
+                    "type"
+                  ]
+                }
+              },
+              "required": [
+                "binding"
+              ]
+            }
+          }
+        },
+        "required": [
+          "properties"
         ]
       }
     },
@@ -600,250 +628,7 @@
       }
     },
     {
-      "if": {
-        "properties": {
-          "properties": {
-            "contains": {
-              "properties": {
-                "binding": {
-                  "properties": {
-                    "property": {
-                      "const": "bindingType"
-                    },
-                    "type": {
-                      "enum": [
-                        "zeebe:calledDecision",
-                        "zeebe:formDefinition",
-                        "zeebe:calledElement"
-                      ]
-                    }
-                  },
-                  "required": [
-                    "property",
-                    "type"
-                  ]
-                },
-                "value": {
-                  "const": "versionTag"
-                }
-              },
-              "required": [
-                "binding",
-                "value"
-              ]
-            }
-          }
-        },
-        "required": [
-          "properties"
-        ]
-      },
-      "then": {
-        "properties": {
-          "properties": {
-            "contains": {
-              "properties": {
-                "binding": {
-                  "properties": {
-                    "type": {
-                      "enum": [
-                        "zeebe:calledDecision",
-                        "zeebe:formDefinition",
-                        "zeebe:calledElement"
-                      ]
-                    },
-                    "property": {
-                      "const": "versionTag"
-                    }
-                  },
-                  "required": [
-                    "property",
-                    "type"
-                  ]
-                }
-              },
-              "required": [
-                "binding"
-              ]
-            }
-          }
-        },
-        "required": [
-          "properties"
-        ]
-      }
-    },
-    {
-      "if": {
-        "properties": {
-          "properties": {
-            "contains": {
-              "properties": {
-                "binding": {
-                  "properties": {
-                    "property": {
-                      "const": "versionTag"
-                    }
-                  },
-                  "required": [
-                    "property"
-                  ]
-                }
-              },
-              "required": ["binding"],
-              "not": {
-                "required": [
-                  "condition"
-                ]
-              }
-            }
-          }
-        },
-        "required": ["properties"]
-      },
-      "then": {
-        "properties": {
-          "properties": {
-            "contains": {
-              "properties": {
-                "binding": {
-                  "properties": {
-                    "property": {
-                      "const": "bindingType"
-                    }
-                  },
-                  "required": ["property"]
-                },
-                "value": {
-                  "const": "versionTag"
-                }
-              },
-              "required": ["binding", "value"]
-            }
-          }
-        },
-        "required": ["properties"]
-      }
-    },
-    {
-      "if": {
-        "properties": {
-          "properties": {
-            "contains": {
-              "properties": {
-                "binding": {
-                  "properties": {
-                    "property": {
-                      "const": "bindingType"
-                    },
-                    "type": {
-                      "const": "zeebe:formDefinition"
-                    }
-                  },
-                  "required": [
-                    "property",
-                    "type"
-                  ]
-                }
-              },
-              "required": [
-                "binding"
-              ]
-            }
-          }
-        },
-        "required": [
-          "properties"
-        ]
-      },
-      "then": {
-        "properties": {
-          "properties": {
-            "contains": {
-              "properties": {
-                "binding": {
-                  "properties": {
-                    "type": {
-                      "const": "zeebe:formDefinition"
-                    },
-                    "property": {
-                      "const": "formId"
-                    }
-                  },
-                  "required": [
-                    "property",
-                    "type"
-                  ]
-                }
-              },
-              "required": [
-                "binding"
-              ]
-            }
-          }
-        },
-        "required": [
-          "properties"
-        ]
-      }
-    },
-    {
-      "if": {
-        "properties": {
-          "properties": {
-            "contains": {
-              "properties": {
-                "binding": {
-                  "properties": {
-                    "type": {
-                      "const": "zeebe:calledElement"
-                    }
-                  },
-                  "required": [
-                    "type"
-                  ]
-                }
-              },
-              "required": [
-                "binding"
-              ]
-            }
-          }
-        },
-        "required": [
-          "properties"
-        ]
-      },
-      "then": {
-        "properties": {
-          "properties": {
-            "contains": {
-              "properties": {
-                "binding": {
-                  "properties": {
-                    "type": {
-                      "const": "zeebe:calledElement"
-                    },
-                    "property": {
-                      "const": "processId"
-                    }
-                  },
-                  "required": [
-                    "property",
-                    "type"
-                  ]
-                }
-              },
-              "required": [
-                "binding"
-              ]
-            }
-          }
-        },
-        "required": [
-          "properties"
-        ]
-      }
+      "$ref": "./template/bindingType.json"
     },
     {
       "if": {

--- a/packages/zeebe-element-templates-json-schema/src/defs/template.json
+++ b/packages/zeebe-element-templates-json-schema/src/defs/template.json
@@ -608,6 +608,252 @@
                 "binding": {
                   "properties": {
                     "property": {
+                      "const": "bindingType"
+                    },
+                    "type": {
+                      "enum": [
+                        "zeebe:calledDecision",
+                        "zeebe:formDefinition",
+                        "zeebe:calledElement"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "property",
+                    "type"
+                  ]
+                },
+                "value": {
+                  "const": "versionTag"
+                }
+              },
+              "required": [
+                "binding",
+                "value"
+              ]
+            }
+          }
+        },
+        "required": [
+          "properties"
+        ]
+      },
+      "then": {
+        "properties": {
+          "properties": {
+            "contains": {
+              "properties": {
+                "binding": {
+                  "properties": {
+                    "type": {
+                      "enum": [
+                        "zeebe:calledDecision",
+                        "zeebe:formDefinition",
+                        "zeebe:calledElement"
+                      ]
+                    },
+                    "property": {
+                      "const": "versionTag"
+                    }
+                  },
+                  "required": [
+                    "property",
+                    "type"
+                  ]
+                }
+              },
+              "required": [
+                "binding"
+              ]
+            }
+          }
+        },
+        "required": [
+          "properties"
+        ]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "properties": {
+            "contains": {
+              "properties": {
+                "binding": {
+                  "properties": {
+                    "property": {
+                      "const": "versionTag"
+                    }
+                  },
+                  "required": [
+                    "property"
+                  ]
+                }
+              },
+              "required": ["binding"],
+              "not": {
+                "required": [
+                  "condition"
+                ]
+              }
+            }
+          }
+        },
+        "required": ["properties"]
+      },
+      "then": {
+        "properties": {
+          "properties": {
+            "contains": {
+              "properties": {
+                "binding": {
+                  "properties": {
+                    "property": {
+                      "const": "bindingType"
+                    }
+                  },
+                  "required": ["property"]
+                },
+                "value": {
+                  "const": "versionTag"
+                }
+              },
+              "required": ["binding", "value"]
+            }
+          }
+        },
+        "required": ["properties"]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "properties": {
+            "contains": {
+              "properties": {
+                "binding": {
+                  "properties": {
+                    "property": {
+                      "const": "bindingType"
+                    },
+                    "type": {
+                      "const": "zeebe:formDefinition"
+                    }
+                  },
+                  "required": [
+                    "property",
+                    "type"
+                  ]
+                }
+              },
+              "required": [
+                "binding"
+              ]
+            }
+          }
+        },
+        "required": [
+          "properties"
+        ]
+      },
+      "then": {
+        "properties": {
+          "properties": {
+            "contains": {
+              "properties": {
+                "binding": {
+                  "properties": {
+                    "type": {
+                      "const": "zeebe:formDefinition"
+                    },
+                    "property": {
+                      "const": "formId"
+                    }
+                  },
+                  "required": [
+                    "property",
+                    "type"
+                  ]
+                }
+              },
+              "required": [
+                "binding"
+              ]
+            }
+          }
+        },
+        "required": [
+          "properties"
+        ]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "properties": {
+            "contains": {
+              "properties": {
+                "binding": {
+                  "properties": {
+                    "type": {
+                      "const": "zeebe:calledElement"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ]
+                }
+              },
+              "required": [
+                "binding"
+              ]
+            }
+          }
+        },
+        "required": [
+          "properties"
+        ]
+      },
+      "then": {
+        "properties": {
+          "properties": {
+            "contains": {
+              "properties": {
+                "binding": {
+                  "properties": {
+                    "type": {
+                      "const": "zeebe:calledElement"
+                    },
+                    "property": {
+                      "const": "processId"
+                    }
+                  },
+                  "required": [
+                    "property",
+                    "type"
+                  ]
+                }
+              },
+              "required": [
+                "binding"
+              ]
+            }
+          }
+        },
+        "required": [
+          "properties"
+        ]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "properties": {
+            "contains": {
+              "properties": {
+                "binding": {
+                  "properties": {
+                    "property": {
                       "const": "formId"
                     },
                     "type": {

--- a/packages/zeebe-element-templates-json-schema/src/defs/template/bindingType.json
+++ b/packages/zeebe-element-templates-json-schema/src/defs/template/bindingType.json
@@ -1,0 +1,203 @@
+{
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "properties": {
+            "contains": {
+              "properties": {
+                "binding": {
+                  "properties": {
+                    "property": {
+                      "const": "bindingType"
+                    },
+                    "type": {
+                      "enum": [
+                        "zeebe:calledDecision",
+                        "zeebe:formDefinition",
+                        "zeebe:calledElement"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "property",
+                    "type"
+                  ]
+                },
+                "value": {
+                  "const": "versionTag"
+                }
+              },
+              "required": [
+                "binding",
+                "value"
+              ]
+            }
+          }
+        },
+        "required": [
+          "properties"
+        ]
+      },
+      "then": {
+        "properties": {
+          "properties": {
+            "contains": {
+              "properties": {
+                "binding": {
+                  "properties": {
+                    "type": {
+                      "enum": [
+                        "zeebe:calledDecision",
+                        "zeebe:formDefinition",
+                        "zeebe:calledElement"
+                      ]
+                    },
+                    "property": {
+                      "const": "versionTag"
+                    }
+                  },
+                  "required": [
+                    "property",
+                    "type"
+                  ]
+                }
+              },
+              "required": [
+                "binding"
+              ]
+            }
+          }
+        },
+        "required": [
+          "properties"
+        ]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "properties": {
+            "contains": {
+              "properties": {
+                "binding": {
+                  "properties": {
+                    "property": {
+                      "const": "versionTag"
+                    }
+                  },
+                  "required": [
+                    "property"
+                  ]
+                }
+              },
+              "required": [
+                "binding"
+              ],
+              "not": {
+                "required": [
+                  "condition"
+                ]
+              }
+            }
+          }
+        },
+        "required": [
+          "properties"
+        ]
+      },
+      "then": {
+        "properties": {
+          "properties": {
+            "contains": {
+              "properties": {
+                "binding": {
+                  "properties": {
+                    "property": {
+                      "const": "bindingType"
+                    }
+                  },
+                  "required": [
+                    "property"
+                  ]
+                },
+                "value": {
+                  "const": "versionTag"
+                }
+              },
+              "required": [
+                "binding",
+                "value"
+              ]
+            }
+          }
+        },
+        "required": [
+          "properties"
+        ]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "properties": {
+            "contains": {
+              "properties": {
+                "binding": {
+                  "properties": {
+                    "property": {
+                      "const": "bindingType"
+                    },
+                    "type": {
+                      "const": "zeebe:formDefinition"
+                    }
+                  },
+                  "required": [
+                    "property",
+                    "type"
+                  ]
+                }
+              },
+              "required": [
+                "binding"
+              ]
+            }
+          }
+        },
+        "required": [
+          "properties"
+        ]
+      },
+      "then": {
+        "properties": {
+          "properties": {
+            "contains": {
+              "properties": {
+                "binding": {
+                  "properties": {
+                    "type": {
+                      "const": "zeebe:formDefinition"
+                    },
+                    "property": {
+                      "const": "formId"
+                    }
+                  },
+                  "required": [
+                    "property",
+                    "type"
+                  ]
+                }
+              },
+              "required": [
+                "binding"
+              ]
+            }
+          }
+        },
+        "required": [
+          "properties"
+        ]
+      }
+    }
+  ]
+}

--- a/packages/zeebe-element-templates-json-schema/src/defs/template/bindingType.json
+++ b/packages/zeebe-element-templates-json-schema/src/defs/template/bindingType.json
@@ -82,6 +82,14 @@
               "properties": {
                 "binding": {
                   "properties": {
+                    "type": {
+                      "enum": [
+                        "zeebe:calledDecision",
+                        "zeebe:calledElement",
+                        "zeebe:formDefinition",
+                        "zeebe:linkedResource"
+                      ]
+                    },
                     "property": {
                       "const": "versionTag"
                     }

--- a/packages/zeebe-element-templates-json-schema/src/defs/template/bindingType.json
+++ b/packages/zeebe-element-templates-json-schema/src/defs/template/bindingType.json
@@ -123,11 +123,15 @@
                 },
                 "value": {
                   "const": "versionTag"
+                },
+                "type": {
+                  "const": "Hidden"
                 }
               },
               "required": [
                 "binding",
-                "value"
+                "value",
+                "type"
               ]
             }
           }

--- a/packages/zeebe-element-templates-json-schema/src/error-messages.json
+++ b/packages/zeebe-element-templates-json-schema/src/error-messages.json
@@ -323,7 +323,116 @@
       "allOf",
       1,
       "allOf",
+      8,
+      "then",
+      "properties",
+      "properties"
+    ],
+    "errorMessage": "Binding with property=`bindingType` and value=`versionTag` must be set when using a binding with property=`versionTag`"
+  },
+  {
+    "path": [
+      "definitions",
+      "properties",
+      "allOf",
+      1,
+      "items",
+      "allOf",
+      20,
+      "allOf",
+      0,
+      "then",
+      "properties",
+      "type"
+    ],
+    "errorMessage": "Incorrect type ${0}. Must be one of { Hidden, Dropdown } for binding with `property`=`bindingType`"
+  },
+  {
+    "path": [
+      "definitions",
+      "properties",
+      "allOf",
+      1,
+      "items",
+      "allOf",
+      20,
+      "allOf",
+      1,
+      "then",
+      "allOf",
+      0,
+      "properties",
+      "type"
+    ],
+    "errorMessage": "Incorrect type ${0}. Must be one of { String, Text, Hidden, Dropdown } for binding with `property`=`versionTag`"
+  },
+  {
+    "path": [
+      "definitions",
+      "properties",
+      "allOf",
+      1,
+      "items",
+      "allOf",
+      20,
+      "allOf",
+      1,
+      "then",
+      "allOf",
+      1
+    ],
+    "errorMessage": "Binding with `property`=`versionTag` does not support `feel`"
+  },
+  {
+    "path": [
+      "definitions",
+      "template",
+      "allOf",
+      1,
+      "allOf",
       7,
+      "then",
+      "properties",
+      "properties"
+    ],
+    "errorMessage": "Missing binding with `property`=`versionTag` as binding with `property`=`bindingType` and `value`=`versionTag` is set"
+  },
+  {
+    "path": [
+      "definitions",
+      "template",
+      "allOf",
+      1,
+      "allOf",
+      9,
+      "then",
+      "properties",
+      "properties"
+    ],
+    "errorMessage": "`property`=`bindingType` is not supported when using `property`=`externalReference`. Use `formId` with `bindingType`"
+  },
+  {
+    "path": [
+      "definitions",
+      "template",
+      "allOf",
+      1,
+      "allOf",
+      10,
+      "then",
+      "properties",
+      "properties"
+    ],
+    "errorMessage": "Binding with `property`=`processId` and `type`=`zeebe:calledElement` is required, when using a binding with `type`=`zeebe:calledElement`"
+  },
+  {
+    "path": [
+      "definitions",
+      "template",
+      "allOf",
+      1,
+      "allOf",
+      11,
       "then",
       "properties",
       "properties"

--- a/packages/zeebe-element-templates-json-schema/src/error-messages.json
+++ b/packages/zeebe-element-templates-json-schema/src/error-messages.json
@@ -323,7 +323,9 @@
       "allOf",
       1,
       "allOf",
-      8,
+      7,
+      "allOf",
+      1,
       "then",
       "properties",
       "properties"
@@ -391,6 +393,8 @@
       1,
       "allOf",
       7,
+      "allOf",
+      0,
       "then",
       "properties",
       "properties"
@@ -404,7 +408,9 @@
       "allOf",
       1,
       "allOf",
-      9,
+      7,
+      "allOf",
+      2,
       "then",
       "properties",
       "properties"
@@ -418,7 +424,7 @@
       "allOf",
       1,
       "allOf",
-      10,
+      2,
       "then",
       "properties",
       "properties"
@@ -432,7 +438,7 @@
       "allOf",
       1,
       "allOf",
-      11,
+      8,
       "then",
       "properties",
       "properties"

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/additional-property.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/additional-property.js
@@ -1,0 +1,19 @@
+export const template = {
+  'name': 'AdditionalProperty',
+  'id': 'com.camunda.example.AdditionalProperty',
+  'appliesTo': [
+    'bpmn:Task'
+  ],
+  'properties': [
+    {
+      'type': 'Hidden',
+      'binding': {
+        'type': 'property',
+        'name': 'foo',
+        'property': 'versionTag' // This property is not used and should not cause an error
+      }
+    }
+  ]
+};
+
+export const errors = null;

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/called-decision/deployment.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/called-decision/deployment.js
@@ -1,0 +1,45 @@
+export const template = {
+  '$schema': 'https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json',
+  'name': 'Reusable Rule Template',
+  'id': 'io.camunda.examples.Decision',
+  'description': 'A reusable rule template',
+  'version': 1,
+  'engines': {
+    'camunda': '^8.6'
+  },
+  'appliesTo': [
+    'bpmn:Task',
+    'bpmn:BusinessRuleTask'
+  ],
+  'elementType': {
+    'value': 'bpmn:BusinessRuleTask'
+  },
+  'properties': [
+    {
+      'type': 'Hidden',
+      'value': 'aReusableRule',
+      'binding': {
+        'type': 'zeebe:calledDecision',
+        'property': 'decisionId'
+      }
+    },
+    {
+      'type': 'Hidden',
+      'value': 'aResultVariable',
+      'binding': {
+        'type': 'zeebe:calledDecision',
+        'property': 'resultVariable'
+      }
+    },
+    {
+      'type': 'Hidden',
+      'value': 'deployment',
+      'binding': {
+        'type': 'zeebe:calledDecision',
+        'property': 'bindingType'
+      }
+    }
+  ]
+};
+
+export const errors = null;

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/called-decision/dropdown-invalid-choices.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/called-decision/dropdown-invalid-choices.js
@@ -1,0 +1,140 @@
+export const template = {
+  '$schema': 'https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json',
+  'name': 'Reusable Rule Template',
+  'id': 'io.camunda.examples.Decision',
+  'description': 'A reusable rule template',
+  'version': 1,
+  'engines': {
+    'camunda': '^8.6'
+  },
+  'appliesTo': [
+    'bpmn:Task',
+    'bpmn:BusinessRuleTask'
+  ],
+  'elementType': {
+    'value': 'bpmn:BusinessRuleTask'
+  },
+  'properties': [
+    {
+      'type': 'Hidden',
+      'value': 'aReusableRule',
+      'binding': {
+        'type': 'zeebe:calledDecision',
+        'property': 'decisionId'
+      }
+    },
+    {
+      'type': 'Hidden',
+      'value': 'aResultVariable',
+      'binding': {
+        'type': 'zeebe:calledDecision',
+        'property': 'resultVariable'
+      }
+    },
+    {
+      'type': 'Dropdown',
+      'label': 'Binding',
+      'id': 'bindingType',
+      'binding': {
+        'type': 'zeebe:calledDecision',
+        'property': 'bindingType'
+      },
+      'choices': [
+        {
+          'name': 'Latest',
+          'value': 'foo'
+        },
+        {
+          'name': 'Deployment',
+          'value': 'bar'
+        },
+        {
+          'name': 'Version Tag',
+          'value': 'baz'
+        }
+      ],
+      'value': 'latest',
+    },
+    {
+      'type': 'String',
+      'label': 'Version tag',
+      'binding': {
+        'type': 'zeebe:calledDecision',
+        'property': 'versionTag'
+      },
+      'condition': {
+        'property': 'bindingType',
+        'equals': 'versionTag'
+      }
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'enum',
+    dataPath: '/properties/2/choices/0/value',
+    schemaPath: '#/allOf/1/items/allOf/20/allOf/0/then/properties/choices/items/properties/value/enum',
+    params: {
+      allowedValues: [
+        'latest',
+        'versionTag',
+        'deployment'
+      ]
+    },
+    message: 'should be equal to one of the allowed values'
+  },
+  {
+    keyword: 'enum',
+    dataPath: '/properties/2/choices/1/value',
+    schemaPath: '#/allOf/1/items/allOf/20/allOf/0/then/properties/choices/items/properties/value/enum',
+    params: {
+      allowedValues: [
+        'latest',
+        'versionTag',
+        'deployment'
+      ]
+    },
+    message: 'should be equal to one of the allowed values'
+  },
+  {
+    keyword: 'enum',
+    dataPath: '/properties/2/choices/2/value',
+    schemaPath: '#/allOf/1/items/allOf/20/allOf/0/then/properties/choices/items/properties/value/enum',
+    params: {
+      allowedValues: [
+        'latest',
+        'versionTag',
+        'deployment'
+      ]
+    },
+    message: 'should be equal to one of the allowed values'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/2',
+    schemaPath: '#/allOf/1/items/allOf/20/allOf/0/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: {
+      type: 'array'
+    },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: {
+      passingSchemas: null
+    },
+    message: 'should match exactly one schema in oneOf'
+  }
+];

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/called-decision/dropdown.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/called-decision/dropdown.js
@@ -1,0 +1,73 @@
+export const template = {
+  '$schema': 'https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json',
+  'name': 'Reusable Rule Template',
+  'id': 'io.camunda.examples.Decision',
+  'description': 'A reusable rule template',
+  'version': 1,
+  'engines': {
+    'camunda': '^8.6'
+  },
+  'appliesTo': [
+    'bpmn:Task',
+    'bpmn:BusinessRuleTask'
+  ],
+  'elementType': {
+    'value': 'bpmn:BusinessRuleTask'
+  },
+  'properties': [
+    {
+      'type': 'Hidden',
+      'value': 'aReusableRule',
+      'binding': {
+        'type': 'zeebe:calledDecision',
+        'property': 'decisionId'
+      }
+    },
+    {
+      'type': 'Hidden',
+      'value': 'aResultVariable',
+      'binding': {
+        'type': 'zeebe:calledDecision',
+        'property': 'resultVariable'
+      }
+    },
+    {
+      'type': 'Dropdown',
+      'label': 'Binding',
+      'id': 'bindingType',
+      'binding': {
+        'type': 'zeebe:calledDecision',
+        'property': 'bindingType'
+      },
+      'choices': [
+        {
+          'name': 'Latest',
+          'value': 'latest'
+        },
+        {
+          'name': 'Deployment',
+          'value': 'deployment'
+        },
+        {
+          'name': 'Version Tag',
+          'value': 'versionTag'
+        }
+      ],
+      'value': 'latest',
+    },
+    {
+      'type': 'String',
+      'label': 'Version tag',
+      'binding': {
+        'type': 'zeebe:calledDecision',
+        'property': 'versionTag'
+      },
+      'condition': {
+        'property': 'bindingType',
+        'equals': 'versionTag'
+      }
+    }
+  ]
+};
+
+export const errors = null;

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/called-decision/invalid-feel.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/called-decision/invalid-feel.js
@@ -1,0 +1,152 @@
+export const template = {
+  '$schema': 'https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json',
+  'name': 'Reusable Rule Template',
+  'id': 'io.camunda.examples.Decision',
+  'description': 'A reusable rule template',
+  'version': 1,
+  'engines': {
+    'camunda': '^8.6'
+  },
+  'appliesTo': [
+    'bpmn:Task',
+    'bpmn:BusinessRuleTask'
+  ],
+  'elementType': {
+    'value': 'bpmn:BusinessRuleTask'
+  },
+  'properties': [
+    {
+      'type': 'Hidden',
+      'value': 'aReusableRule',
+      'binding': {
+        'type': 'zeebe:calledDecision',
+        'property': 'decisionId'
+      }
+    },
+    {
+      'type': 'Hidden',
+      'value': 'aResultVariable',
+      'binding': {
+        'type': 'zeebe:calledDecision',
+        'property': 'resultVariable'
+      }
+    },
+    {
+      'type': 'Dropdown',
+      'value': 'deployment',
+      'choices': [
+        {
+          'value': 'deployment',
+          'name': 'Deployment'
+        },
+        {
+          'value': 'versionTag',
+          'name': 'Version Tag'
+        } ],
+      'feel': 'static',
+      'binding': {
+        'type': 'zeebe:calledDecision',
+        'property': 'bindingType'
+      }
+    },
+    {
+      'type': 'Hidden',
+      'value': 'deployment',
+      'feel': 'required',
+      'binding': {
+        'type': 'zeebe:calledDecision',
+        'property': 'bindingType'
+      }
+    }
+  ]
+};
+
+// This just catching a transitive error as Hidden and Dropdown cannot be feel anyways.
+export const errors = [
+  {
+    keyword: 'errorMessage',
+    dataPath: '/properties/2/type',
+    schemaPath: '#/allOf/1/items/allOf/4/then/properties/type/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'enum',
+          dataPath: '/properties/2/type',
+          schemaPath: '#/allOf/1/items/allOf/4/then/properties/type/enum',
+          params: {
+            allowedValues: [
+              'String',
+              'Text',
+              'Number',
+              'Boolean'
+            ]
+          },
+          message: 'should be equal to one of the allowed values',
+          emUsed: true
+        }
+      ]
+    },
+    message: 'feel is only supported for "String", "Text", "Number" and "Boolean" type'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/2',
+    schemaPath: '#/allOf/1/items/allOf/4/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'errorMessage',
+    dataPath: '/properties/3/type',
+    schemaPath: '#/allOf/1/items/allOf/4/then/properties/type/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'enum',
+          dataPath: '/properties/3/type',
+          schemaPath: '#/allOf/1/items/allOf/4/then/properties/type/enum',
+          params: {
+            allowedValues: [
+              'String',
+              'Text',
+              'Number',
+              'Boolean'
+            ]
+          },
+          message: 'should be equal to one of the allowed values',
+          emUsed: true
+        }
+      ]
+    },
+    message: 'feel is only supported for "String", "Text", "Number" and "Boolean" type'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/3',
+    schemaPath: '#/allOf/1/items/allOf/4/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: {
+      type: 'array'
+    },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: {
+      passingSchemas: null
+    },
+    message: 'should match exactly one schema in oneOf'
+  }
+];

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/called-decision/invalid-input-type.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/called-decision/invalid-input-type.js
@@ -1,0 +1,243 @@
+export const template = {
+  '$schema': 'https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json',
+  'name': 'Reusable Rule Template',
+  'id': 'io.camunda.examples.Decision',
+  'description': 'A reusable rule template',
+  'version': 1,
+  'engines': {
+    'camunda': '^8.6'
+  },
+  'appliesTo': [
+    'bpmn:Task',
+    'bpmn:BusinessRuleTask'
+  ],
+  'elementType': {
+    'value': 'bpmn:BusinessRuleTask'
+  },
+  'properties': [
+    {
+      'type': 'Hidden',
+      'value': 'aReusableRule',
+      'binding': {
+        'type': 'zeebe:calledDecision',
+        'property': 'decisionId'
+      }
+    },
+    {
+      'type': 'Hidden',
+      'value': 'aResultVariable',
+      'binding': {
+        'type': 'zeebe:calledDecision',
+        'property': 'resultVariable'
+      }
+    },
+    {
+      'type': 'String',
+      'value': 'latest',
+      'binding': {
+        'type': 'zeebe:calledDecision',
+        'property': 'bindingType'
+      }
+    },
+    {
+      'type': 'Number',
+      'value': 1,
+      'binding': {
+        'type': 'zeebe:calledDecision',
+        'property': 'bindingType'
+      }
+    },
+    {
+      'type': 'Text',
+      'value': 'latest',
+      'binding': {
+        'type': 'zeebe:calledDecision',
+        'property': 'bindingType'
+      }
+    },
+    {
+      'type': 'Boolean',
+      'value': true,
+      'binding': {
+        'type': 'zeebe:calledDecision',
+        'property': 'bindingType'
+      }
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'errorMessage',
+    dataPath: '/properties/2/type',
+    schemaPath: '#/allOf/1/items/allOf/20/allOf/0/then/properties/type/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'enum',
+          dataPath: '/properties/2/type',
+          schemaPath: '#/allOf/1/items/allOf/20/allOf/0/then/properties/type/enum',
+          params: {
+            allowedValues: [
+              'Hidden',
+              'Dropdown'
+            ]
+          },
+          message: 'should be equal to one of the allowed values',
+          emUsed: true
+        }
+      ]
+    },
+    message: 'Incorrect type "String". Must be one of { Hidden, Dropdown } for binding with `property`=`bindingType`'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/2',
+    schemaPath: '#/allOf/1/items/allOf/20/allOf/0/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'errorMessage',
+    dataPath: '/properties/3/type',
+    schemaPath: '#/allOf/1/items/allOf/20/allOf/0/then/properties/type/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'enum',
+          dataPath: '/properties/3/type',
+          schemaPath: '#/allOf/1/items/allOf/20/allOf/0/then/properties/type/enum',
+          params: {
+            allowedValues: [
+              'Hidden',
+              'Dropdown'
+            ]
+          },
+          message: 'should be equal to one of the allowed values',
+          emUsed: true
+        }
+      ]
+    },
+    message: 'Incorrect type "Number". Must be one of { Hidden, Dropdown } for binding with `property`=`bindingType`'
+  },
+  {
+    keyword: 'enum',
+    dataPath: '/properties/3/value',
+    schemaPath: '#/allOf/1/items/allOf/20/allOf/0/then/properties/value/enum',
+    params: {
+      allowedValues: [
+        'latest',
+        'versionTag',
+        'deployment'
+      ]
+    },
+    message: 'should be equal to one of the allowed values'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/3',
+    schemaPath: '#/allOf/1/items/allOf/20/allOf/0/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'errorMessage',
+    dataPath: '/properties/4/type',
+    schemaPath: '#/allOf/1/items/allOf/20/allOf/0/then/properties/type/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'enum',
+          dataPath: '/properties/4/type',
+          schemaPath: '#/allOf/1/items/allOf/20/allOf/0/then/properties/type/enum',
+          params: {
+            allowedValues: [
+              'Hidden',
+              'Dropdown'
+            ]
+          },
+          message: 'should be equal to one of the allowed values',
+          emUsed: true
+        }
+      ]
+    },
+    message: 'Incorrect type "Text". Must be one of { Hidden, Dropdown } for binding with `property`=`bindingType`'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/4',
+    schemaPath: '#/allOf/1/items/allOf/20/allOf/0/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'errorMessage',
+    dataPath: '/properties/5/type',
+    schemaPath: '#/allOf/1/items/allOf/20/allOf/0/then/properties/type/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'enum',
+          dataPath: '/properties/5/type',
+          schemaPath: '#/allOf/1/items/allOf/20/allOf/0/then/properties/type/enum',
+          params: {
+            allowedValues: [
+              'Hidden',
+              'Dropdown'
+            ]
+          },
+          message: 'should be equal to one of the allowed values',
+          emUsed: true
+        }
+      ]
+    },
+    message: 'Incorrect type "Boolean". Must be one of { Hidden, Dropdown } for binding with `property`=`bindingType`'
+  },
+  {
+    keyword: 'enum',
+    dataPath: '/properties/5/value',
+    schemaPath: '#/allOf/1/items/allOf/20/allOf/0/then/properties/value/enum',
+    params: {
+      allowedValues: [
+        'latest',
+        'versionTag',
+        'deployment'
+      ]
+    },
+    message: 'should be equal to one of the allowed values'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/5',
+    schemaPath: '#/allOf/1/items/allOf/20/allOf/0/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: {
+      type: 'array'
+    },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: {
+      passingSchemas: null
+    },
+    message: 'should match exactly one schema in oneOf'
+  }
+];
+

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/called-decision/invalid-value.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/called-decision/invalid-value.js
@@ -1,0 +1,87 @@
+export const template = {
+  '$schema': 'https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json',
+  'name': 'Reusable Rule Template',
+  'id': 'io.camunda.examples.Decision',
+  'description': 'A reusable rule template',
+  'version': 1,
+  'engines': {
+    'camunda': '^8.6'
+  },
+  'appliesTo': [
+    'bpmn:Task',
+    'bpmn:BusinessRuleTask'
+  ],
+  'elementType': {
+    'value': 'bpmn:BusinessRuleTask'
+  },
+  'properties': [
+    {
+      'type': 'Hidden',
+      'value': 'aReusableRule',
+      'binding': {
+        'type': 'zeebe:calledDecision',
+        'property': 'decisionId'
+      }
+    },
+    {
+      'type': 'Hidden',
+      'value': 'aResultVariable',
+      'binding': {
+        'type': 'zeebe:calledDecision',
+        'property': 'resultVariable'
+      }
+    },
+    {
+      'type': 'Hidden',
+      'value': 'youShallNotPass',
+      'binding': {
+        'type': 'zeebe:calledDecision',
+        'property': 'bindingType'
+      }
+    }
+  ]
+};
+
+
+export const errors = [
+  {
+    keyword: 'enum',
+    dataPath: '/properties/2/value',
+    schemaPath: '#/allOf/1/items/allOf/20/allOf/0/then/properties/value/enum',
+    params: {
+      allowedValues: [
+        'latest',
+        'versionTag',
+        'deployment'
+      ]
+    },
+    message: 'should be equal to one of the allowed values'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/2',
+    schemaPath: '#/allOf/1/items/allOf/20/allOf/0/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: {
+      type: 'array'
+    },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: {
+      passingSchemas: null
+    },
+    message: 'should match exactly one schema in oneOf'
+  }
+];

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/called-decision/latest.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/called-decision/latest.js
@@ -1,0 +1,45 @@
+export const template = {
+  '$schema': 'https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json',
+  'name': 'Reusable Rule Template',
+  'id': 'io.camunda.examples.Decision',
+  'description': 'A reusable rule template',
+  'version': 1,
+  'engines': {
+    'camunda': '^8.6'
+  },
+  'appliesTo': [
+    'bpmn:Task',
+    'bpmn:BusinessRuleTask'
+  ],
+  'elementType': {
+    'value': 'bpmn:BusinessRuleTask'
+  },
+  'properties': [
+    {
+      'type': 'Hidden',
+      'value': 'aReusableRule',
+      'binding': {
+        'type': 'zeebe:calledDecision',
+        'property': 'decisionId'
+      }
+    },
+    {
+      'type': 'Hidden',
+      'value': 'aResultVariable',
+      'binding': {
+        'type': 'zeebe:calledDecision',
+        'property': 'resultVariable'
+      }
+    },
+    {
+      'type': 'Hidden',
+      'value': 'latest',
+      'binding': {
+        'type': 'zeebe:calledDecision',
+        'property': 'bindingType'
+      }
+    }
+  ]
+};
+
+export const errors = null;

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/called-decision/missing-property-binding-type.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/called-decision/missing-property-binding-type.js
@@ -1,0 +1,153 @@
+export const template = {
+  '$schema': 'https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json',
+  'name': 'Reusable Rule Template',
+  'id': 'io.camunda.examples.Decision',
+  'description': 'A reusable rule template',
+  'version': 1,
+  'engines': {
+    'camunda': '^8.6'
+  },
+  'appliesTo': [
+    'bpmn:Task',
+    'bpmn:BusinessRuleTask'
+  ],
+  'elementType': {
+    'value': 'bpmn:BusinessRuleTask'
+  },
+  'properties': [
+    {
+      'type': 'Hidden',
+      'value': 'aReusableRule',
+      'binding': {
+        'type': 'zeebe:calledDecision',
+        'property': 'decisionId'
+      }
+    },
+    {
+      'type': 'Hidden',
+      'value': 'aResultVariable',
+      'binding': {
+        'type': 'zeebe:calledDecision',
+        'property': 'resultVariable'
+      }
+    },
+    {
+      'type': 'Hidden',
+      'value': 'vers-1',
+      'binding': {
+        'type': 'zeebe:calledDecision',
+        'property': 'versionTag'
+      }
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'errorMessage',
+    dataPath: '/properties',
+    schemaPath: '#/allOf/1/allOf/8/then/properties/properties/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'const',
+          dataPath: '/properties/0/binding/property',
+          schemaPath: '#/allOf/1/allOf/8/then/properties/properties/contains/properties/binding/properties/property/const',
+          params: {
+            allowedValue: 'bindingType'
+          },
+          message: 'should be equal to constant',
+          emUsed: true
+        },
+        {
+          keyword: 'const',
+          dataPath: '/properties/0/value',
+          schemaPath: '#/allOf/1/allOf/8/then/properties/properties/contains/properties/value/const',
+          params: {
+            allowedValue: 'versionTag'
+          },
+          message: 'should be equal to constant',
+          emUsed: true
+        },
+        {
+          keyword: 'const',
+          dataPath: '/properties/1/binding/property',
+          schemaPath: '#/allOf/1/allOf/8/then/properties/properties/contains/properties/binding/properties/property/const',
+          params: {
+            allowedValue: 'bindingType'
+          },
+          message: 'should be equal to constant',
+          emUsed: true
+        },
+        {
+          keyword: 'const',
+          dataPath: '/properties/1/value',
+          schemaPath: '#/allOf/1/allOf/8/then/properties/properties/contains/properties/value/const',
+          params: {
+            allowedValue: 'versionTag'
+          },
+          message: 'should be equal to constant',
+          emUsed: true
+        },
+        {
+          keyword: 'const',
+          dataPath: '/properties/2/binding/property',
+          schemaPath: '#/allOf/1/allOf/8/then/properties/properties/contains/properties/binding/properties/property/const',
+          params: {
+            allowedValue: 'bindingType'
+          },
+          message: 'should be equal to constant',
+          emUsed: true
+        },
+        {
+          keyword: 'const',
+          dataPath: '/properties/2/value',
+          schemaPath: '#/allOf/1/allOf/8/then/properties/properties/contains/properties/value/const',
+          params: {
+            allowedValue: 'versionTag'
+          },
+          message: 'should be equal to constant',
+          emUsed: true
+        },
+        {
+          keyword: 'contains',
+          dataPath: '/properties',
+          schemaPath: '#/allOf/1/allOf/8/then/properties/properties/contains',
+          params: {
+            minContains: 1
+          },
+          message: 'should contain at least 1 valid item(s)',
+          emUsed: true
+        }
+      ]
+    },
+    message: 'Binding with property=`bindingType` and value=`versionTag` must be set when using a binding with property=`versionTag`'
+  },
+  {
+    keyword: 'if',
+    dataPath: '',
+    schemaPath: '#/allOf/1/allOf/8/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: {
+      type: 'array'
+    },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: {
+      passingSchemas: null
+    },
+    message: 'should match exactly one schema in oneOf'
+  }
+];

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/called-decision/missing-property-binding-type.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/called-decision/missing-property-binding-type.js
@@ -46,13 +46,13 @@ export const errors = [
   {
     keyword: 'errorMessage',
     dataPath: '/properties',
-    schemaPath: '#/allOf/1/allOf/8/then/properties/properties/errorMessage',
+    schemaPath: '#/allOf/1/allOf/7/allOf/1/then/properties/properties/errorMessage',
     params: {
       errors: [
         {
           keyword: 'const',
           dataPath: '/properties/0/binding/property',
-          schemaPath: '#/allOf/1/allOf/8/then/properties/properties/contains/properties/binding/properties/property/const',
+          schemaPath: '#/allOf/1/allOf/7/allOf/1/then/properties/properties/contains/properties/binding/properties/property/const',
           params: {
             allowedValue: 'bindingType'
           },
@@ -62,7 +62,7 @@ export const errors = [
         {
           keyword: 'const',
           dataPath: '/properties/0/value',
-          schemaPath: '#/allOf/1/allOf/8/then/properties/properties/contains/properties/value/const',
+          schemaPath: '#/allOf/1/allOf/7/allOf/1/then/properties/properties/contains/properties/value/const',
           params: {
             allowedValue: 'versionTag'
           },
@@ -72,7 +72,7 @@ export const errors = [
         {
           keyword: 'const',
           dataPath: '/properties/1/binding/property',
-          schemaPath: '#/allOf/1/allOf/8/then/properties/properties/contains/properties/binding/properties/property/const',
+          schemaPath: '#/allOf/1/allOf/7/allOf/1/then/properties/properties/contains/properties/binding/properties/property/const',
           params: {
             allowedValue: 'bindingType'
           },
@@ -82,7 +82,7 @@ export const errors = [
         {
           keyword: 'const',
           dataPath: '/properties/1/value',
-          schemaPath: '#/allOf/1/allOf/8/then/properties/properties/contains/properties/value/const',
+          schemaPath: '#/allOf/1/allOf/7/allOf/1/then/properties/properties/contains/properties/value/const',
           params: {
             allowedValue: 'versionTag'
           },
@@ -92,7 +92,7 @@ export const errors = [
         {
           keyword: 'const',
           dataPath: '/properties/2/binding/property',
-          schemaPath: '#/allOf/1/allOf/8/then/properties/properties/contains/properties/binding/properties/property/const',
+          schemaPath: '#/allOf/1/allOf/7/allOf/1/then/properties/properties/contains/properties/binding/properties/property/const',
           params: {
             allowedValue: 'bindingType'
           },
@@ -102,7 +102,7 @@ export const errors = [
         {
           keyword: 'const',
           dataPath: '/properties/2/value',
-          schemaPath: '#/allOf/1/allOf/8/then/properties/properties/contains/properties/value/const',
+          schemaPath: '#/allOf/1/allOf/7/allOf/1/then/properties/properties/contains/properties/value/const',
           params: {
             allowedValue: 'versionTag'
           },
@@ -112,7 +112,7 @@ export const errors = [
         {
           keyword: 'contains',
           dataPath: '/properties',
-          schemaPath: '#/allOf/1/allOf/8/then/properties/properties/contains',
+          schemaPath: '#/allOf/1/allOf/7/allOf/1/then/properties/properties/contains',
           params: {
             minContains: 1
           },
@@ -126,7 +126,7 @@ export const errors = [
   {
     keyword: 'if',
     dataPath: '',
-    schemaPath: '#/allOf/1/allOf/8/if',
+    schemaPath: '#/allOf/1/allOf/7/allOf/1/if',
     params: {
       failingKeyword: 'then'
     },

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/called-decision/missing-property-versionTag.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/called-decision/missing-property-versionTag.js
@@ -46,13 +46,13 @@ export const errors = [
   {
     keyword: 'errorMessage',
     dataPath: '/properties',
-    schemaPath: '#/allOf/1/allOf/7/then/properties/properties/errorMessage',
+    schemaPath: '#/allOf/1/allOf/7/allOf/0/then/properties/properties/errorMessage',
     params: {
       errors: [
         {
           keyword: 'const',
           dataPath: '/properties/0/binding/property',
-          schemaPath: '#/allOf/1/allOf/7/then/properties/properties/contains/properties/binding/properties/property/const',
+          schemaPath: '#/allOf/1/allOf/7/allOf/0/then/properties/properties/contains/properties/binding/properties/property/const',
           params: {
             allowedValue: 'versionTag'
           },
@@ -62,7 +62,7 @@ export const errors = [
         {
           keyword: 'const',
           dataPath: '/properties/1/binding/property',
-          schemaPath: '#/allOf/1/allOf/7/then/properties/properties/contains/properties/binding/properties/property/const',
+          schemaPath: '#/allOf/1/allOf/7/allOf/0/then/properties/properties/contains/properties/binding/properties/property/const',
           params: {
             allowedValue: 'versionTag'
           },
@@ -72,7 +72,7 @@ export const errors = [
         {
           keyword: 'const',
           dataPath: '/properties/2/binding/property',
-          schemaPath: '#/allOf/1/allOf/7/then/properties/properties/contains/properties/binding/properties/property/const',
+          schemaPath: '#/allOf/1/allOf/7/allOf/0/then/properties/properties/contains/properties/binding/properties/property/const',
           params: {
             allowedValue: 'versionTag'
           },
@@ -82,7 +82,7 @@ export const errors = [
         {
           keyword: 'contains',
           dataPath: '/properties',
-          schemaPath: '#/allOf/1/allOf/7/then/properties/properties/contains',
+          schemaPath: '#/allOf/1/allOf/7/allOf/0/then/properties/properties/contains',
           params: {
             minContains: 1
           },
@@ -96,7 +96,7 @@ export const errors = [
   {
     keyword: 'if',
     dataPath: '',
-    schemaPath: '#/allOf/1/allOf/7/if',
+    schemaPath: '#/allOf/1/allOf/7/allOf/0/if',
     params: {
       failingKeyword: 'then'
     },

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/called-decision/missing-property-versionTag.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/called-decision/missing-property-versionTag.js
@@ -1,0 +1,123 @@
+export const template = {
+  '$schema': 'https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json',
+  'name': 'Reusable Rule Template',
+  'id': 'io.camunda.examples.Decision',
+  'description': 'A reusable rule template',
+  'version': 1,
+  'engines': {
+    'camunda': '^8.6'
+  },
+  'appliesTo': [
+    'bpmn:Task',
+    'bpmn:BusinessRuleTask'
+  ],
+  'elementType': {
+    'value': 'bpmn:BusinessRuleTask'
+  },
+  'properties': [
+    {
+      'type': 'Hidden',
+      'value': 'aReusableRule',
+      'binding': {
+        'type': 'zeebe:calledDecision',
+        'property': 'decisionId'
+      }
+    },
+    {
+      'type': 'Hidden',
+      'value': 'aResultVariable',
+      'binding': {
+        'type': 'zeebe:calledDecision',
+        'property': 'resultVariable'
+      }
+    },
+    {
+      'type': 'Hidden',
+      'value': 'versionTag',
+      'binding': {
+        'type': 'zeebe:calledDecision',
+        'property': 'bindingType'
+      }
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'errorMessage',
+    dataPath: '/properties',
+    schemaPath: '#/allOf/1/allOf/7/then/properties/properties/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'const',
+          dataPath: '/properties/0/binding/property',
+          schemaPath: '#/allOf/1/allOf/7/then/properties/properties/contains/properties/binding/properties/property/const',
+          params: {
+            allowedValue: 'versionTag'
+          },
+          message: 'should be equal to constant',
+          emUsed: true
+        },
+        {
+          keyword: 'const',
+          dataPath: '/properties/1/binding/property',
+          schemaPath: '#/allOf/1/allOf/7/then/properties/properties/contains/properties/binding/properties/property/const',
+          params: {
+            allowedValue: 'versionTag'
+          },
+          message: 'should be equal to constant',
+          emUsed: true
+        },
+        {
+          keyword: 'const',
+          dataPath: '/properties/2/binding/property',
+          schemaPath: '#/allOf/1/allOf/7/then/properties/properties/contains/properties/binding/properties/property/const',
+          params: {
+            allowedValue: 'versionTag'
+          },
+          message: 'should be equal to constant',
+          emUsed: true
+        },
+        {
+          keyword: 'contains',
+          dataPath: '/properties',
+          schemaPath: '#/allOf/1/allOf/7/then/properties/properties/contains',
+          params: {
+            minContains: 1
+          },
+          message: 'should contain at least 1 valid item(s)',
+          emUsed: true
+        }
+      ]
+    },
+    message: 'Missing binding with `property`=`versionTag` as binding with `property`=`bindingType` and `value`=`versionTag` is set'
+  },
+  {
+    keyword: 'if',
+    dataPath: '',
+    schemaPath: '#/allOf/1/allOf/7/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: {
+      type: 'array'
+    },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: {
+      passingSchemas: null
+    },
+    message: 'should match exactly one schema in oneOf'
+  }
+];

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/called-decision/versionTag-invalid-feel.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/called-decision/versionTag-invalid-feel.js
@@ -1,0 +1,100 @@
+export const template = {
+  '$schema': 'https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json',
+  'name': 'Reusable Rule Template',
+  'id': 'io.camunda.examples.Decision',
+  'description': 'A reusable rule template',
+  'version': 1,
+  'engines': {
+    'camunda': '^8.6'
+  },
+  'appliesTo': [
+    'bpmn:Task',
+    'bpmn:BusinessRuleTask'
+  ],
+  'elementType': {
+    'value': 'bpmn:BusinessRuleTask'
+  },
+  'properties': [
+    {
+      'type': 'Hidden',
+      'value': 'aReusableRule',
+      'binding': {
+        'type': 'zeebe:calledDecision',
+        'property': 'decisionId'
+      }
+    },
+    {
+      'type': 'Hidden',
+      'value': 'aResultVariable',
+      'binding': {
+        'type': 'zeebe:calledDecision',
+        'property': 'resultVariable'
+      }
+    },
+    {
+      'type': 'Hidden',
+      'value': 'versionTag',
+      'binding': {
+        'type': 'zeebe:calledDecision',
+        'property': 'bindingType'
+      }
+    },
+    {
+      'type': 'String',
+      'feel': 'optional',
+      'value': 'vers-1',
+      'binding': {
+        'type': 'zeebe:calledDecision',
+        'property': 'versionTag'
+      }
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'errorMessage',
+    dataPath: '/properties/3',
+    schemaPath: '#/allOf/1/items/allOf/20/allOf/1/then/allOf/1/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'not',
+          dataPath: '/properties/3',
+          schemaPath: '#/allOf/1/items/allOf/20/allOf/1/then/allOf/1/not',
+          params: {},
+          message: 'should NOT be valid',
+          emUsed: true
+        }
+      ]
+    },
+    message: 'Binding with `property`=`versionTag` does not support `feel`'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/3',
+    schemaPath: '#/allOf/1/items/allOf/20/allOf/1/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: {
+      type: 'array'
+    },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: {
+      passingSchemas: null
+    },
+    message: 'should match exactly one schema in oneOf'
+  }
+];

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/called-decision/versionTag-invalid-input-type.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/called-decision/versionTag-invalid-input-type.js
@@ -1,0 +1,149 @@
+export const template = {
+  '$schema': 'https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json',
+  'name': 'Reusable Rule Template',
+  'id': 'io.camunda.examples.Decision',
+  'description': 'A reusable rule template',
+  'version': 1,
+  'engines': {
+    'camunda': '^8.6'
+  },
+  'appliesTo': [
+    'bpmn:Task',
+    'bpmn:BusinessRuleTask'
+  ],
+  'elementType': {
+    'value': 'bpmn:BusinessRuleTask'
+  },
+  'properties': [
+    {
+      'type': 'Hidden',
+      'value': 'aReusableRule',
+      'binding': {
+        'type': 'zeebe:calledDecision',
+        'property': 'decisionId'
+      }
+    },
+    {
+      'type': 'Hidden',
+      'value': 'aResultVariable',
+      'binding': {
+        'type': 'zeebe:calledDecision',
+        'property': 'resultVariable'
+      }
+    },
+    {
+      'type': 'Hidden',
+      'value': 'versionTag',
+      'binding': {
+        'type': 'zeebe:calledDecision',
+        'property': 'bindingType'
+      }
+    },
+    {
+      'type': 'Number',
+      'value': 1,
+      'binding': {
+        'type': 'zeebe:calledDecision',
+        'property': 'versionTag'
+      }
+    },
+    {
+      'type': 'Boolean',
+      'value': true,
+      'binding': {
+        'type': 'zeebe:calledDecision',
+        'property': 'versionTag'
+      }
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'errorMessage',
+    dataPath: '/properties/3/type',
+    schemaPath: '#/allOf/1/items/allOf/20/allOf/1/then/allOf/0/properties/type/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'enum',
+          dataPath: '/properties/3/type',
+          schemaPath: '#/allOf/1/items/allOf/20/allOf/1/then/allOf/0/properties/type/enum',
+          params: {
+            allowedValues: [
+              'Hidden',
+              'Dropdown',
+              'String',
+              'Text'
+            ]
+          },
+          message: 'should be equal to one of the allowed values',
+          emUsed: true
+        }
+      ]
+    },
+    message: 'Incorrect type "Number". Must be one of { String, Text, Hidden, Dropdown } for binding with `property`=`versionTag`'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/3',
+    schemaPath: '#/allOf/1/items/allOf/20/allOf/1/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'errorMessage',
+    dataPath: '/properties/4/type',
+    schemaPath: '#/allOf/1/items/allOf/20/allOf/1/then/allOf/0/properties/type/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'enum',
+          dataPath: '/properties/4/type',
+          schemaPath: '#/allOf/1/items/allOf/20/allOf/1/then/allOf/0/properties/type/enum',
+          params: {
+            allowedValues: [
+              'Hidden',
+              'Dropdown',
+              'String',
+              'Text'
+            ]
+          },
+          message: 'should be equal to one of the allowed values',
+          emUsed: true
+        }
+      ]
+    },
+    message: 'Incorrect type "Boolean". Must be one of { String, Text, Hidden, Dropdown } for binding with `property`=`versionTag`'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/4',
+    schemaPath: '#/allOf/1/items/allOf/20/allOf/1/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: {
+      type: 'array'
+    },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: {
+      passingSchemas: null
+    },
+    message: 'should match exactly one schema in oneOf'
+  }
+]
+;

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/called-decision/versionTag-invalid-unconditional.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/called-decision/versionTag-invalid-unconditional.js
@@ -1,36 +1,59 @@
 export const template = {
   '$schema': 'https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json',
-  'id': 'io.camunda.examples.Payment',
-  'name': 'Payment',
-  'description': 'Payment process call activity',
+  'name': 'Reusable Rule Template',
+  'id': 'io.camunda.examples.Decision',
+  'description': 'A reusable rule template',
+  'version': 1,
+  'engines': {
+    'camunda': '^8.6'
+  },
   'appliesTo': [
-    'bpmn:Task'
+    'bpmn:Task',
+    'bpmn:BusinessRuleTask'
   ],
   'elementType': {
-    'value': 'bpmn:CallActivity'
+    'value': 'bpmn:BusinessRuleTask'
   },
-  'properties':[
+  'properties': [
     {
-      'label': 'Payment ID',
+      'type': 'Hidden',
+      'value': 'aReusableRule',
+      'binding': {
+        'type': 'zeebe:calledDecision',
+        'property': 'decisionId'
+      }
+    },
+    {
+      'type': 'Hidden',
+      'value': 'aResultVariable',
+      'binding': {
+        'type': 'zeebe:calledDecision',
+        'property': 'resultVariable'
+      }
+    },
+    {
+      'type': 'Dropdown',
+      'value': 'versionTag',
+      'choices': [
+        {
+          'name': 'versionTag',
+          'value': 'versionTag'
+        },
+        {
+          'name': 'deployment',
+          'value': 'deployment'
+        }
+      ],
+      'binding': {
+        'type': 'zeebe:calledDecision',
+        'property': 'bindingType'
+      }
+    },
+    {
       'type': 'String',
-      'binding': {
-        'type': 'zeebe:input',
-        'name': 'paymentID'
-      }
-    },
-    {
-      'type': 'Hidden',
-      'value': 'paymentProcess',
-      'binding': {
-        'type': 'zeebe:calledElement',
-        'property': 'processId'
-      }
-    },
-    {
-      'type': 'Hidden',
       'value': 'vers-1',
       'binding': {
-        'type': 'zeebe:calledElement',
+        'type': 'zeebe:calledDecision',
         'property': 'versionTag'
       }
     }
@@ -45,34 +68,24 @@ export const errors = [
     params: {
       errors: [
         {
-          keyword: 'required',
-          dataPath: '/properties/0',
-          schemaPath: '#/allOf/1/allOf/7/allOf/1/then/properties/properties/contains/required',
-          params: {
-            missingProperty: 'value'
-          },
-          message: "should have required property 'value'",
-          emUsed: true
-        },
-        {
-          keyword: 'required',
-          dataPath: '/properties/0/binding',
-          schemaPath: '#/allOf/1/allOf/7/allOf/1/then/properties/properties/contains/properties/binding/required',
-          params: {
-            missingProperty: 'property'
-          },
-          message: "should have required property 'property'",
-          emUsed: true
-        },
-        {
-          dataPath: '/properties/0/type',
-          emUsed: true,
           keyword: 'const',
-          message: 'should be equal to constant',
+          dataPath: '/properties/0/binding/property',
+          schemaPath: '#/allOf/1/allOf/7/allOf/1/then/properties/properties/contains/properties/binding/properties/property/const',
           params: {
-            allowedValue: 'Hidden'
+            allowedValue: 'bindingType'
           },
-          schemaPath: '#/allOf/1/allOf/7/allOf/1/then/properties/properties/contains/properties/type/const'
+          message: 'should be equal to constant',
+          emUsed: true
+        },
+        {
+          keyword: 'const',
+          dataPath: '/properties/0/value',
+          schemaPath: '#/allOf/1/allOf/7/allOf/1/then/properties/properties/contains/properties/value/const',
+          params: {
+            allowedValue: 'versionTag'
+          },
+          message: 'should be equal to constant',
+          emUsed: true
         },
         {
           keyword: 'const',
@@ -96,7 +109,17 @@ export const errors = [
         },
         {
           keyword: 'const',
-          dataPath: '/properties/2/binding/property',
+          dataPath: '/properties/2/type',
+          schemaPath: '#/allOf/1/allOf/7/allOf/1/then/properties/properties/contains/properties/type/const',
+          params: {
+            allowedValue: 'Hidden'
+          },
+          message: 'should be equal to constant',
+          emUsed: true
+        },
+        {
+          keyword: 'const',
+          dataPath: '/properties/3/binding/property',
           schemaPath: '#/allOf/1/allOf/7/allOf/1/then/properties/properties/contains/properties/binding/properties/property/const',
           params: {
             allowedValue: 'bindingType'
@@ -106,10 +129,20 @@ export const errors = [
         },
         {
           keyword: 'const',
-          dataPath: '/properties/2/value',
+          dataPath: '/properties/3/value',
           schemaPath: '#/allOf/1/allOf/7/allOf/1/then/properties/properties/contains/properties/value/const',
           params: {
             allowedValue: 'versionTag'
+          },
+          message: 'should be equal to constant',
+          emUsed: true
+        },
+        {
+          keyword: 'const',
+          dataPath: '/properties/3/type',
+          schemaPath: '#/allOf/1/allOf/7/allOf/1/then/properties/properties/contains/properties/type/const',
+          params: {
+            allowedValue: 'Hidden'
           },
           message: 'should be equal to constant',
           emUsed: true

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/called-decision/versionTag.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/called-decision/versionTag.js
@@ -1,0 +1,53 @@
+export const template = {
+  '$schema': 'https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json',
+  'name': 'Reusable Rule Template',
+  'id': 'io.camunda.examples.Decision',
+  'description': 'A reusable rule template',
+  'version': 1,
+  'engines': {
+    'camunda': '^8.6'
+  },
+  'appliesTo': [
+    'bpmn:Task',
+    'bpmn:BusinessRuleTask'
+  ],
+  'elementType': {
+    'value': 'bpmn:BusinessRuleTask'
+  },
+  'properties': [
+    {
+      'type': 'Hidden',
+      'value': 'aReusableRule',
+      'binding': {
+        'type': 'zeebe:calledDecision',
+        'property': 'decisionId'
+      }
+    },
+    {
+      'type': 'Hidden',
+      'value': 'aResultVariable',
+      'binding': {
+        'type': 'zeebe:calledDecision',
+        'property': 'resultVariable'
+      }
+    },
+    {
+      'type': 'Hidden',
+      'value': 'versionTag',
+      'binding': {
+        'type': 'zeebe:calledDecision',
+        'property': 'bindingType'
+      }
+    },
+    {
+      'type': 'String',
+      'value': 'vers-1',
+      'binding': {
+        'type': 'zeebe:calledDecision',
+        'property': 'versionTag'
+      }
+    }
+  ]
+};
+
+export const errors = null;

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/called-element/deployment.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/called-element/deployment.js
@@ -25,6 +25,14 @@ export const template = {
         'type': 'zeebe:calledElement',
         'property': 'processId'
       }
+    },
+    {
+      'type': 'Hidden',
+      'value': 'deployment',
+      'binding': {
+        'type': 'zeebe:calledElement',
+        'property': 'bindingType'
+      }
     }
   ]
 };

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/called-element/dropdown-invalid-choices.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/called-element/dropdown-invalid-choices.js
@@ -1,0 +1,135 @@
+export const template = {
+  '$schema': 'https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json',
+  'id': 'io.camunda.examples.Payment',
+  'name': 'Payment',
+  'description': 'Payment process call activity',
+  'appliesTo': [
+    'bpmn:Task'
+  ],
+  'elementType': {
+    'value': 'bpmn:CallActivity'
+  },
+  'properties':[
+    {
+      'label': 'Payment ID',
+      'type': 'String',
+      'binding': {
+        'type': 'zeebe:input',
+        'name': 'paymentID'
+      }
+    },
+    {
+      'type': 'Hidden',
+      'value': 'paymentProcess',
+      'binding': {
+        'type': 'zeebe:calledElement',
+        'property': 'processId'
+      }
+    },
+    {
+      'type': 'Dropdown',
+      'label': 'Binding',
+      'id': 'bindingType',
+      'binding': {
+        'type': 'zeebe:calledElement',
+        'property': 'bindingType'
+      },
+      'choices': [
+        {
+          'name': 'Latest',
+          'value': 'foo'
+        },
+        {
+          'name': 'Deployment',
+          'value': 'bar'
+        },
+        {
+          'name': 'Version Tag',
+          'value': 'baz'
+        }
+      ],
+      'value': 'latest',
+    },
+    {
+      'type': 'String',
+      'label': 'Version tag',
+      'binding': {
+        'type': 'zeebe:calledElement',
+        'property': 'versionTag'
+      },
+      'condition': {
+        'property': 'bindingType',
+        'equals': 'versionTag'
+      }
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'enum',
+    dataPath: '/properties/2/choices/0/value',
+    schemaPath: '#/allOf/1/items/allOf/20/allOf/0/then/properties/choices/items/properties/value/enum',
+    params: {
+      allowedValues: [
+        'latest',
+        'versionTag',
+        'deployment'
+      ]
+    },
+    message: 'should be equal to one of the allowed values'
+  },
+  {
+    keyword: 'enum',
+    dataPath: '/properties/2/choices/1/value',
+    schemaPath: '#/allOf/1/items/allOf/20/allOf/0/then/properties/choices/items/properties/value/enum',
+    params: {
+      allowedValues: [
+        'latest',
+        'versionTag',
+        'deployment'
+      ]
+    },
+    message: 'should be equal to one of the allowed values'
+  },
+  {
+    keyword: 'enum',
+    dataPath: '/properties/2/choices/2/value',
+    schemaPath: '#/allOf/1/items/allOf/20/allOf/0/then/properties/choices/items/properties/value/enum',
+    params: {
+      allowedValues: [
+        'latest',
+        'versionTag',
+        'deployment'
+      ]
+    },
+    message: 'should be equal to one of the allowed values'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/2',
+    schemaPath: '#/allOf/1/items/allOf/20/allOf/0/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: {
+      type: 'array'
+    },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: {
+      passingSchemas: null
+    },
+    message: 'should match exactly one schema in oneOf'
+  }
+];

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/called-element/dropdown.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/called-element/dropdown.js
@@ -1,0 +1,68 @@
+export const template = {
+  '$schema': 'https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json',
+  'id': 'io.camunda.examples.Payment',
+  'name': 'Payment',
+  'description': 'Payment process call activity',
+  'appliesTo': [
+    'bpmn:Task'
+  ],
+  'elementType': {
+    'value': 'bpmn:CallActivity'
+  },
+  'properties':[
+    {
+      'label': 'Payment ID',
+      'type': 'String',
+      'binding': {
+        'type': 'zeebe:input',
+        'name': 'paymentID'
+      }
+    },
+    {
+      'type': 'Hidden',
+      'value': 'paymentProcess',
+      'binding': {
+        'type': 'zeebe:calledElement',
+        'property': 'processId'
+      }
+    },
+    {
+      'type': 'Dropdown',
+      'label': 'Binding',
+      'id': 'bindingType',
+      'binding': {
+        'type': 'zeebe:calledElement',
+        'property': 'bindingType'
+      },
+      'choices': [
+        {
+          'name': 'Latest',
+          'value': 'latest'
+        },
+        {
+          'name': 'Deployment',
+          'value': 'deployment'
+        },
+        {
+          'name': 'Version Tag',
+          'value': 'versionTag'
+        }
+      ],
+      'value': 'latest',
+    },
+    {
+      'type': 'String',
+      'label': 'Version tag',
+      'binding': {
+        'type': 'zeebe:calledElement',
+        'property': 'versionTag'
+      },
+      'condition': {
+        'property': 'bindingType',
+        'equals': 'versionTag'
+      }
+    }
+  ]
+};
+
+export const errors = null;

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/called-element/invalid-feel.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/called-element/invalid-feel.js
@@ -1,0 +1,147 @@
+export const template = {
+  '$schema': 'https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json',
+  'id': 'io.camunda.examples.Payment',
+  'name': 'Payment',
+  'description': 'Payment process call activity',
+  'appliesTo': [
+    'bpmn:Task'
+  ],
+  'elementType': {
+    'value': 'bpmn:CallActivity'
+  },
+  'properties':[
+    {
+      'label': 'Payment ID',
+      'type': 'String',
+      'binding': {
+        'type': 'zeebe:input',
+        'name': 'paymentID'
+      }
+    },
+    {
+      'type': 'Hidden',
+      'value': 'paymentProcess',
+      'binding': {
+        'type': 'zeebe:calledElement',
+        'property': 'processId'
+      }
+    },
+    {
+      'type': 'Dropdown',
+      'value': 'deployment',
+      'choices': [
+        {
+          'value': 'deployment',
+          'name': 'Deployment'
+        },
+        {
+          'value': 'versionTag',
+          'name': 'Version Tag'
+        } ],
+      'feel': 'static',
+      'binding': {
+        'type': 'zeebe:calledElement',
+        'property': 'bindingType'
+      }
+    },
+    {
+      'type': 'Hidden',
+      'value': 'deployment',
+      'feel': 'required',
+      'binding': {
+        'type': 'zeebe:calledElement',
+        'property': 'bindingType'
+      }
+    }
+  ]
+};
+
+// This just catching a transitive error as Hidden and Dropdown cannot be feel anyways.
+export const errors = [
+  {
+    keyword: 'errorMessage',
+    dataPath: '/properties/2/type',
+    schemaPath: '#/allOf/1/items/allOf/4/then/properties/type/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'enum',
+          dataPath: '/properties/2/type',
+          schemaPath: '#/allOf/1/items/allOf/4/then/properties/type/enum',
+          params: {
+            allowedValues: [
+              'String',
+              'Text',
+              'Number',
+              'Boolean'
+            ]
+          },
+          message: 'should be equal to one of the allowed values',
+          emUsed: true
+        }
+      ]
+    },
+    message: 'feel is only supported for "String", "Text", "Number" and "Boolean" type'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/2',
+    schemaPath: '#/allOf/1/items/allOf/4/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'errorMessage',
+    dataPath: '/properties/3/type',
+    schemaPath: '#/allOf/1/items/allOf/4/then/properties/type/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'enum',
+          dataPath: '/properties/3/type',
+          schemaPath: '#/allOf/1/items/allOf/4/then/properties/type/enum',
+          params: {
+            allowedValues: [
+              'String',
+              'Text',
+              'Number',
+              'Boolean'
+            ]
+          },
+          message: 'should be equal to one of the allowed values',
+          emUsed: true
+        }
+      ]
+    },
+    message: 'feel is only supported for "String", "Text", "Number" and "Boolean" type'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/3',
+    schemaPath: '#/allOf/1/items/allOf/4/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: {
+      type: 'array'
+    },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: {
+      passingSchemas: null
+    },
+    message: 'should match exactly one schema in oneOf'
+  }
+];

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/called-element/invalid-input-type.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/called-element/invalid-input-type.js
@@ -1,0 +1,238 @@
+export const template = {
+  '$schema': 'https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json',
+  'id': 'io.camunda.examples.Payment',
+  'name': 'Payment',
+  'description': 'Payment process call activity',
+  'appliesTo': [
+    'bpmn:Task'
+  ],
+  'elementType': {
+    'value': 'bpmn:CallActivity'
+  },
+  'properties':[
+    {
+      'label': 'Payment ID',
+      'type': 'String',
+      'binding': {
+        'type': 'zeebe:input',
+        'name': 'paymentID'
+      }
+    },
+    {
+      'type': 'Hidden',
+      'value': 'paymentProcess',
+      'binding': {
+        'type': 'zeebe:calledElement',
+        'property': 'processId'
+      }
+    },
+    {
+      'type': 'String',
+      'value': 'latest',
+      'binding': {
+        'type': 'zeebe:calledElement',
+        'property': 'bindingType'
+      }
+    },
+    {
+      'type': 'Number',
+      'value': 1,
+      'binding': {
+        'type': 'zeebe:calledElement',
+        'property': 'bindingType'
+      }
+    },
+    {
+      'type': 'Text',
+      'value': 'latest',
+      'binding': {
+        'type': 'zeebe:calledElement',
+        'property': 'bindingType'
+      }
+    },
+    {
+      'type': 'Boolean',
+      'value': true,
+      'binding': {
+        'type': 'zeebe:calledElement',
+        'property': 'bindingType'
+      }
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'errorMessage',
+    dataPath: '/properties/2/type',
+    schemaPath: '#/allOf/1/items/allOf/20/allOf/0/then/properties/type/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'enum',
+          dataPath: '/properties/2/type',
+          schemaPath: '#/allOf/1/items/allOf/20/allOf/0/then/properties/type/enum',
+          params: {
+            allowedValues: [
+              'Hidden',
+              'Dropdown'
+            ]
+          },
+          message: 'should be equal to one of the allowed values',
+          emUsed: true
+        }
+      ]
+    },
+    message: 'Incorrect type "String". Must be one of { Hidden, Dropdown } for binding with `property`=`bindingType`'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/2',
+    schemaPath: '#/allOf/1/items/allOf/20/allOf/0/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'errorMessage',
+    dataPath: '/properties/3/type',
+    schemaPath: '#/allOf/1/items/allOf/20/allOf/0/then/properties/type/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'enum',
+          dataPath: '/properties/3/type',
+          schemaPath: '#/allOf/1/items/allOf/20/allOf/0/then/properties/type/enum',
+          params: {
+            allowedValues: [
+              'Hidden',
+              'Dropdown'
+            ]
+          },
+          message: 'should be equal to one of the allowed values',
+          emUsed: true
+        }
+      ]
+    },
+    message: 'Incorrect type "Number". Must be one of { Hidden, Dropdown } for binding with `property`=`bindingType`'
+  },
+  {
+    keyword: 'enum',
+    dataPath: '/properties/3/value',
+    schemaPath: '#/allOf/1/items/allOf/20/allOf/0/then/properties/value/enum',
+    params: {
+      allowedValues: [
+        'latest',
+        'versionTag',
+        'deployment'
+      ]
+    },
+    message: 'should be equal to one of the allowed values'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/3',
+    schemaPath: '#/allOf/1/items/allOf/20/allOf/0/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'errorMessage',
+    dataPath: '/properties/4/type',
+    schemaPath: '#/allOf/1/items/allOf/20/allOf/0/then/properties/type/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'enum',
+          dataPath: '/properties/4/type',
+          schemaPath: '#/allOf/1/items/allOf/20/allOf/0/then/properties/type/enum',
+          params: {
+            allowedValues: [
+              'Hidden',
+              'Dropdown'
+            ]
+          },
+          message: 'should be equal to one of the allowed values',
+          emUsed: true
+        }
+      ]
+    },
+    message: 'Incorrect type "Text". Must be one of { Hidden, Dropdown } for binding with `property`=`bindingType`'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/4',
+    schemaPath: '#/allOf/1/items/allOf/20/allOf/0/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'errorMessage',
+    dataPath: '/properties/5/type',
+    schemaPath: '#/allOf/1/items/allOf/20/allOf/0/then/properties/type/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'enum',
+          dataPath: '/properties/5/type',
+          schemaPath: '#/allOf/1/items/allOf/20/allOf/0/then/properties/type/enum',
+          params: {
+            allowedValues: [
+              'Hidden',
+              'Dropdown'
+            ]
+          },
+          message: 'should be equal to one of the allowed values',
+          emUsed: true
+        }
+      ]
+    },
+    message: 'Incorrect type "Boolean". Must be one of { Hidden, Dropdown } for binding with `property`=`bindingType`'
+  },
+  {
+    keyword: 'enum',
+    dataPath: '/properties/5/value',
+    schemaPath: '#/allOf/1/items/allOf/20/allOf/0/then/properties/value/enum',
+    params: {
+      allowedValues: [
+        'latest',
+        'versionTag',
+        'deployment'
+      ]
+    },
+    message: 'should be equal to one of the allowed values'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/5',
+    schemaPath: '#/allOf/1/items/allOf/20/allOf/0/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: {
+      type: 'array'
+    },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: {
+      passingSchemas: null
+    },
+    message: 'should match exactly one schema in oneOf'
+  }
+];
+

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/called-element/invalid-value.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/called-element/invalid-value.js
@@ -4,19 +4,18 @@ export const template = {
   'name': 'Payment',
   'description': 'Payment process call activity',
   'appliesTo': [
-    'bpmn:Task',
-    'bpmn:CallActivity'
+    'bpmn:Task'
   ],
   'elementType': {
     'value': 'bpmn:CallActivity'
   },
   'properties':[
     {
-      'type': 'Hidden',
-      'value': 'paymentProcess',
+      'label': 'Payment ID',
+      'type': 'String',
       'binding': {
-        'type': 'zeebe:calledElement',
-        'property': 'nonExistingProperty'
+        'type': 'zeebe:input',
+        'name': 'paymentID'
       }
     },
     {
@@ -28,52 +27,35 @@ export const template = {
       }
     },
     {
-      'label': 'Payment ID',
-      'type': 'String',
+      'type': 'Hidden',
+      'value': 'youShallNotPass',
       'binding': {
-        'type': 'zeebe:input',
-        'name': 'paymentID'
-      }
-    },
-    {
-      'label': 'Amount',
-      'type': 'String',
-      'binding': {
-        'type': 'zeebe:input',
-        'name': 'amount'
-      }
-    },
-    {
-      'label': 'Outcome',
-      'type': 'String',
-      'description': 'Name of variable to store the result data in.',
-      'value': 'paymentOutcome',
-      'binding': {
-        'type': 'zeebe:output',
-        'source': '=outcome'
+        'type': 'zeebe:calledElement',
+        'property': 'bindingType'
       }
     }
   ]
 };
 
+
 export const errors = [
   {
     keyword: 'enum',
-    dataPath: '/properties/0/binding/property',
-    schemaPath: '#/allOf/1/items/properties/binding/allOf/5/then/properties/property/enum',
+    dataPath: '/properties/2/value',
+    schemaPath: '#/allOf/1/items/allOf/20/allOf/0/then/properties/value/enum',
     params: {
       allowedValues: [
-        'processId',
-        'bindingType',
-        'versionTag'
+        'latest',
+        'versionTag',
+        'deployment'
       ]
     },
     message: 'should be equal to one of the allowed values'
   },
   {
     keyword: 'if',
-    dataPath: '/properties/0/binding',
-    schemaPath: '#/allOf/1/items/properties/binding/allOf/5/if',
+    dataPath: '/properties/2',
+    schemaPath: '#/allOf/1/items/allOf/20/allOf/0/if',
     params: {
       failingKeyword: 'then'
     },

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/called-element/latest.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/called-element/latest.js
@@ -25,6 +25,14 @@ export const template = {
         'type': 'zeebe:calledElement',
         'property': 'processId'
       }
+    },
+    {
+      'type': 'Hidden',
+      'value': 'latest',
+      'binding': {
+        'type': 'zeebe:calledElement',
+        'property': 'bindingType'
+      }
     }
   ]
 };

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/called-element/missing-property-binding-type.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/called-element/missing-property-binding-type.js
@@ -41,13 +41,13 @@ export const errors = [
   {
     keyword: 'errorMessage',
     dataPath: '/properties',
-    schemaPath: '#/allOf/1/allOf/8/then/properties/properties/errorMessage',
+    schemaPath: '#/allOf/1/allOf/7/allOf/1/then/properties/properties/errorMessage',
     params: {
       errors: [
         {
           keyword: 'required',
           dataPath: '/properties/0',
-          schemaPath: '#/allOf/1/allOf/8/then/properties/properties/contains/required',
+          schemaPath: '#/allOf/1/allOf/7/allOf/1/then/properties/properties/contains/required',
           params: {
             missingProperty: 'value'
           },
@@ -57,7 +57,7 @@ export const errors = [
         {
           keyword: 'required',
           dataPath: '/properties/0/binding',
-          schemaPath: '#/allOf/1/allOf/8/then/properties/properties/contains/properties/binding/required',
+          schemaPath: '#/allOf/1/allOf/7/allOf/1/then/properties/properties/contains/properties/binding/required',
           params: {
             missingProperty: 'property'
           },
@@ -67,7 +67,7 @@ export const errors = [
         {
           keyword: 'const',
           dataPath: '/properties/1/binding/property',
-          schemaPath: '#/allOf/1/allOf/8/then/properties/properties/contains/properties/binding/properties/property/const',
+          schemaPath: '#/allOf/1/allOf/7/allOf/1/then/properties/properties/contains/properties/binding/properties/property/const',
           params: {
             allowedValue: 'bindingType'
           },
@@ -77,7 +77,7 @@ export const errors = [
         {
           keyword: 'const',
           dataPath: '/properties/1/value',
-          schemaPath: '#/allOf/1/allOf/8/then/properties/properties/contains/properties/value/const',
+          schemaPath: '#/allOf/1/allOf/7/allOf/1/then/properties/properties/contains/properties/value/const',
           params: {
             allowedValue: 'versionTag'
           },
@@ -87,7 +87,7 @@ export const errors = [
         {
           keyword: 'const',
           dataPath: '/properties/2/binding/property',
-          schemaPath: '#/allOf/1/allOf/8/then/properties/properties/contains/properties/binding/properties/property/const',
+          schemaPath: '#/allOf/1/allOf/7/allOf/1/then/properties/properties/contains/properties/binding/properties/property/const',
           params: {
             allowedValue: 'bindingType'
           },
@@ -97,7 +97,7 @@ export const errors = [
         {
           keyword: 'const',
           dataPath: '/properties/2/value',
-          schemaPath: '#/allOf/1/allOf/8/then/properties/properties/contains/properties/value/const',
+          schemaPath: '#/allOf/1/allOf/7/allOf/1/then/properties/properties/contains/properties/value/const',
           params: {
             allowedValue: 'versionTag'
           },
@@ -107,7 +107,7 @@ export const errors = [
         {
           keyword: 'contains',
           dataPath: '/properties',
-          schemaPath: '#/allOf/1/allOf/8/then/properties/properties/contains',
+          schemaPath: '#/allOf/1/allOf/7/allOf/1/then/properties/properties/contains',
           params: {
             minContains: 1
           },
@@ -121,7 +121,7 @@ export const errors = [
   {
     keyword: 'if',
     dataPath: '',
-    schemaPath: '#/allOf/1/allOf/8/if',
+    schemaPath: '#/allOf/1/allOf/7/allOf/1/if',
     params: {
       failingKeyword: 'then'
     },

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/called-element/missing-property-binding-type.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/called-element/missing-property-binding-type.js
@@ -1,0 +1,148 @@
+export const template = {
+  '$schema': 'https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json',
+  'id': 'io.camunda.examples.Payment',
+  'name': 'Payment',
+  'description': 'Payment process call activity',
+  'appliesTo': [
+    'bpmn:Task'
+  ],
+  'elementType': {
+    'value': 'bpmn:CallActivity'
+  },
+  'properties':[
+    {
+      'label': 'Payment ID',
+      'type': 'String',
+      'binding': {
+        'type': 'zeebe:input',
+        'name': 'paymentID'
+      }
+    },
+    {
+      'type': 'Hidden',
+      'value': 'paymentProcess',
+      'binding': {
+        'type': 'zeebe:calledElement',
+        'property': 'processId'
+      }
+    },
+    {
+      'type': 'Hidden',
+      'value': 'vers-1',
+      'binding': {
+        'type': 'zeebe:calledElement',
+        'property': 'versionTag'
+      }
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'errorMessage',
+    dataPath: '/properties',
+    schemaPath: '#/allOf/1/allOf/8/then/properties/properties/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'required',
+          dataPath: '/properties/0',
+          schemaPath: '#/allOf/1/allOf/8/then/properties/properties/contains/required',
+          params: {
+            missingProperty: 'value'
+          },
+          message: "should have required property 'value'",
+          emUsed: true
+        },
+        {
+          keyword: 'required',
+          dataPath: '/properties/0/binding',
+          schemaPath: '#/allOf/1/allOf/8/then/properties/properties/contains/properties/binding/required',
+          params: {
+            missingProperty: 'property'
+          },
+          message: "should have required property 'property'",
+          emUsed: true
+        },
+        {
+          keyword: 'const',
+          dataPath: '/properties/1/binding/property',
+          schemaPath: '#/allOf/1/allOf/8/then/properties/properties/contains/properties/binding/properties/property/const',
+          params: {
+            allowedValue: 'bindingType'
+          },
+          message: 'should be equal to constant',
+          emUsed: true
+        },
+        {
+          keyword: 'const',
+          dataPath: '/properties/1/value',
+          schemaPath: '#/allOf/1/allOf/8/then/properties/properties/contains/properties/value/const',
+          params: {
+            allowedValue: 'versionTag'
+          },
+          message: 'should be equal to constant',
+          emUsed: true
+        },
+        {
+          keyword: 'const',
+          dataPath: '/properties/2/binding/property',
+          schemaPath: '#/allOf/1/allOf/8/then/properties/properties/contains/properties/binding/properties/property/const',
+          params: {
+            allowedValue: 'bindingType'
+          },
+          message: 'should be equal to constant',
+          emUsed: true
+        },
+        {
+          keyword: 'const',
+          dataPath: '/properties/2/value',
+          schemaPath: '#/allOf/1/allOf/8/then/properties/properties/contains/properties/value/const',
+          params: {
+            allowedValue: 'versionTag'
+          },
+          message: 'should be equal to constant',
+          emUsed: true
+        },
+        {
+          keyword: 'contains',
+          dataPath: '/properties',
+          schemaPath: '#/allOf/1/allOf/8/then/properties/properties/contains',
+          params: {
+            minContains: 1
+          },
+          message: 'should contain at least 1 valid item(s)',
+          emUsed: true
+        }
+      ]
+    },
+    message: 'Binding with property=`bindingType` and value=`versionTag` must be set when using a binding with property=`versionTag`'
+  },
+  {
+    keyword: 'if',
+    dataPath: '',
+    schemaPath: '#/allOf/1/allOf/8/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: {
+      type: 'array'
+    },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: {
+      passingSchemas: null
+    },
+    message: 'should match exactly one schema in oneOf'
+  }
+];

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/called-element/missing-property-versionTag.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/called-element/missing-property-versionTag.js
@@ -41,13 +41,13 @@ export const errors = [
   {
     keyword: 'errorMessage',
     dataPath: '/properties',
-    schemaPath: '#/allOf/1/allOf/7/then/properties/properties/errorMessage',
+    schemaPath: '#/allOf/1/allOf/7/allOf/0/then/properties/properties/errorMessage',
     params: {
       errors: [
         {
           keyword: 'required',
           dataPath: '/properties/0/binding',
-          schemaPath: '#/allOf/1/allOf/7/then/properties/properties/contains/properties/binding/required',
+          schemaPath: '#/allOf/1/allOf/7/allOf/0/then/properties/properties/contains/properties/binding/required',
           params: {
             missingProperty: 'property'
           },
@@ -57,7 +57,7 @@ export const errors = [
         {
           keyword: 'enum',
           dataPath: '/properties/0/binding/type',
-          schemaPath: '#/allOf/1/allOf/7/then/properties/properties/contains/properties/binding/properties/type/enum',
+          schemaPath: '#/allOf/1/allOf/7/allOf/0/then/properties/properties/contains/properties/binding/properties/type/enum',
           params: {
             allowedValues: [
               'zeebe:calledDecision',
@@ -71,7 +71,7 @@ export const errors = [
         {
           keyword: 'const',
           dataPath: '/properties/1/binding/property',
-          schemaPath: '#/allOf/1/allOf/7/then/properties/properties/contains/properties/binding/properties/property/const',
+          schemaPath: '#/allOf/1/allOf/7/allOf/0/then/properties/properties/contains/properties/binding/properties/property/const',
           params: {
             allowedValue: 'versionTag'
           },
@@ -81,7 +81,7 @@ export const errors = [
         {
           keyword: 'const',
           dataPath: '/properties/2/binding/property',
-          schemaPath: '#/allOf/1/allOf/7/then/properties/properties/contains/properties/binding/properties/property/const',
+          schemaPath: '#/allOf/1/allOf/7/allOf/0/then/properties/properties/contains/properties/binding/properties/property/const',
           params: {
             allowedValue: 'versionTag'
           },
@@ -91,7 +91,7 @@ export const errors = [
         {
           keyword: 'contains',
           dataPath: '/properties',
-          schemaPath: '#/allOf/1/allOf/7/then/properties/properties/contains',
+          schemaPath: '#/allOf/1/allOf/7/allOf/0/then/properties/properties/contains',
           params: {
             minContains: 1
           },
@@ -105,7 +105,7 @@ export const errors = [
   {
     keyword: 'if',
     dataPath: '',
-    schemaPath: '#/allOf/1/allOf/7/if',
+    schemaPath: '#/allOf/1/allOf/7/allOf/0/if',
     params: {
       failingKeyword: 'then'
     },

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/called-element/missing-property-versionTag.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/called-element/missing-property-versionTag.js
@@ -1,0 +1,132 @@
+export const template = {
+  '$schema': 'https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json',
+  'id': 'io.camunda.examples.Payment',
+  'name': 'Payment',
+  'description': 'Payment process call activity',
+  'appliesTo': [
+    'bpmn:Task'
+  ],
+  'elementType': {
+    'value': 'bpmn:CallActivity'
+  },
+  'properties':[
+    {
+      'label': 'Payment ID',
+      'type': 'String',
+      'binding': {
+        'type': 'zeebe:input',
+        'name': 'paymentID'
+      }
+    },
+    {
+      'type': 'Hidden',
+      'value': 'paymentProcess',
+      'binding': {
+        'type': 'zeebe:calledElement',
+        'property': 'processId'
+      }
+    },
+    {
+      'type': 'Hidden',
+      'value': 'versionTag',
+      'binding': {
+        'type': 'zeebe:calledElement',
+        'property': 'bindingType'
+      }
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'errorMessage',
+    dataPath: '/properties',
+    schemaPath: '#/allOf/1/allOf/7/then/properties/properties/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'required',
+          dataPath: '/properties/0/binding',
+          schemaPath: '#/allOf/1/allOf/7/then/properties/properties/contains/properties/binding/required',
+          params: {
+            missingProperty: 'property'
+          },
+          message: "should have required property 'property'",
+          emUsed: true
+        },
+        {
+          keyword: 'enum',
+          dataPath: '/properties/0/binding/type',
+          schemaPath: '#/allOf/1/allOf/7/then/properties/properties/contains/properties/binding/properties/type/enum',
+          params: {
+            allowedValues: [
+              'zeebe:calledDecision',
+              'zeebe:formDefinition',
+              'zeebe:calledElement'
+            ]
+          },
+          message: 'should be equal to one of the allowed values',
+          emUsed: true
+        },
+        {
+          keyword: 'const',
+          dataPath: '/properties/1/binding/property',
+          schemaPath: '#/allOf/1/allOf/7/then/properties/properties/contains/properties/binding/properties/property/const',
+          params: {
+            allowedValue: 'versionTag'
+          },
+          message: 'should be equal to constant',
+          emUsed: true
+        },
+        {
+          keyword: 'const',
+          dataPath: '/properties/2/binding/property',
+          schemaPath: '#/allOf/1/allOf/7/then/properties/properties/contains/properties/binding/properties/property/const',
+          params: {
+            allowedValue: 'versionTag'
+          },
+          message: 'should be equal to constant',
+          emUsed: true
+        },
+        {
+          keyword: 'contains',
+          dataPath: '/properties',
+          schemaPath: '#/allOf/1/allOf/7/then/properties/properties/contains',
+          params: {
+            minContains: 1
+          },
+          message: 'should contain at least 1 valid item(s)',
+          emUsed: true
+        }
+      ]
+    },
+    message: 'Missing binding with `property`=`versionTag` as binding with `property`=`bindingType` and `value`=`versionTag` is set'
+  },
+  {
+    keyword: 'if',
+    dataPath: '',
+    schemaPath: '#/allOf/1/allOf/7/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: {
+      type: 'array'
+    },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: {
+      passingSchemas: null
+    },
+    message: 'should match exactly one schema in oneOf'
+  }
+];

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/called-element/versionTag-invalid-feel.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/called-element/versionTag-invalid-feel.js
@@ -4,19 +4,18 @@ export const template = {
   'name': 'Payment',
   'description': 'Payment process call activity',
   'appliesTo': [
-    'bpmn:Task',
-    'bpmn:CallActivity'
+    'bpmn:Task'
   ],
   'elementType': {
     'value': 'bpmn:CallActivity'
   },
   'properties':[
     {
-      'type': 'Hidden',
-      'value': 'paymentProcess',
+      'label': 'Payment ID',
+      'type': 'String',
       'binding': {
-        'type': 'zeebe:calledElement',
-        'property': 'nonExistingProperty'
+        'type': 'zeebe:input',
+        'name': 'paymentID'
       }
     },
     {
@@ -28,29 +27,20 @@ export const template = {
       }
     },
     {
-      'label': 'Payment ID',
-      'type': 'String',
+      'type': 'Hidden',
+      'value': 'versionTag',
       'binding': {
-        'type': 'zeebe:input',
-        'name': 'paymentID'
+        'type': 'zeebe:calledElement',
+        'property': 'bindingType'
       }
     },
     {
-      'label': 'Amount',
       'type': 'String',
+      'feel': 'optional',
+      'value': 'vers-1',
       'binding': {
-        'type': 'zeebe:input',
-        'name': 'amount'
-      }
-    },
-    {
-      'label': 'Outcome',
-      'type': 'String',
-      'description': 'Name of variable to store the result data in.',
-      'value': 'paymentOutcome',
-      'binding': {
-        'type': 'zeebe:output',
-        'source': '=outcome'
+        'type': 'zeebe:calledElement',
+        'property': 'versionTag'
       }
     }
   ]
@@ -58,22 +48,27 @@ export const template = {
 
 export const errors = [
   {
-    keyword: 'enum',
-    dataPath: '/properties/0/binding/property',
-    schemaPath: '#/allOf/1/items/properties/binding/allOf/5/then/properties/property/enum',
+    keyword: 'errorMessage',
+    dataPath: '/properties/3',
+    schemaPath: '#/allOf/1/items/allOf/20/allOf/1/then/allOf/1/errorMessage',
     params: {
-      allowedValues: [
-        'processId',
-        'bindingType',
-        'versionTag'
+      errors: [
+        {
+          keyword: 'not',
+          dataPath: '/properties/3',
+          schemaPath: '#/allOf/1/items/allOf/20/allOf/1/then/allOf/1/not',
+          params: {},
+          message: 'should NOT be valid',
+          emUsed: true
+        }
       ]
     },
-    message: 'should be equal to one of the allowed values'
+    message: 'Binding with `property`=`versionTag` does not support `feel`'
   },
   {
     keyword: 'if',
-    dataPath: '/properties/0/binding',
-    schemaPath: '#/allOf/1/items/properties/binding/allOf/5/if',
+    dataPath: '/properties/3',
+    schemaPath: '#/allOf/1/items/allOf/20/allOf/1/if',
     params: {
       failingKeyword: 'then'
     },

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/called-element/versionTag-invalid-input-type.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/called-element/versionTag-invalid-input-type.js
@@ -1,0 +1,144 @@
+export const template = {
+  '$schema': 'https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json',
+  'id': 'io.camunda.examples.Payment',
+  'name': 'Payment',
+  'description': 'Payment process call activity',
+  'appliesTo': [
+    'bpmn:Task'
+  ],
+  'elementType': {
+    'value': 'bpmn:CallActivity'
+  },
+  'properties':[
+    {
+      'label': 'Payment ID',
+      'type': 'String',
+      'binding': {
+        'type': 'zeebe:input',
+        'name': 'paymentID'
+      }
+    },
+    {
+      'type': 'Hidden',
+      'value': 'paymentProcess',
+      'binding': {
+        'type': 'zeebe:calledElement',
+        'property': 'processId'
+      }
+    },
+    {
+      'type': 'Hidden',
+      'value': 'versionTag',
+      'binding': {
+        'type': 'zeebe:calledElement',
+        'property': 'bindingType'
+      }
+    },
+    {
+      'type': 'Number',
+      'value': 1,
+      'binding': {
+        'type': 'zeebe:calledElement',
+        'property': 'versionTag'
+      }
+    },
+    {
+      'type': 'Boolean',
+      'value': true,
+      'binding': {
+        'type': 'zeebe:calledElement',
+        'property': 'versionTag'
+      }
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'errorMessage',
+    dataPath: '/properties/3/type',
+    schemaPath: '#/allOf/1/items/allOf/20/allOf/1/then/allOf/0/properties/type/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'enum',
+          dataPath: '/properties/3/type',
+          schemaPath: '#/allOf/1/items/allOf/20/allOf/1/then/allOf/0/properties/type/enum',
+          params: {
+            allowedValues: [
+              'Hidden',
+              'Dropdown',
+              'String',
+              'Text'
+            ]
+          },
+          message: 'should be equal to one of the allowed values',
+          emUsed: true
+        }
+      ]
+    },
+    message: 'Incorrect type "Number". Must be one of { String, Text, Hidden, Dropdown } for binding with `property`=`versionTag`'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/3',
+    schemaPath: '#/allOf/1/items/allOf/20/allOf/1/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'errorMessage',
+    dataPath: '/properties/4/type',
+    schemaPath: '#/allOf/1/items/allOf/20/allOf/1/then/allOf/0/properties/type/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'enum',
+          dataPath: '/properties/4/type',
+          schemaPath: '#/allOf/1/items/allOf/20/allOf/1/then/allOf/0/properties/type/enum',
+          params: {
+            allowedValues: [
+              'Hidden',
+              'Dropdown',
+              'String',
+              'Text'
+            ]
+          },
+          message: 'should be equal to one of the allowed values',
+          emUsed: true
+        }
+      ]
+    },
+    message: 'Incorrect type "Boolean". Must be one of { String, Text, Hidden, Dropdown } for binding with `property`=`versionTag`'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/4',
+    schemaPath: '#/allOf/1/items/allOf/20/allOf/1/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: {
+      type: 'array'
+    },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: {
+      passingSchemas: null
+    },
+    message: 'should match exactly one schema in oneOf'
+  }
+]
+;

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/called-element/versionTag-invalid-unconditional.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/called-element/versionTag-invalid-unconditional.js
@@ -27,7 +27,25 @@ export const template = {
       }
     },
     {
-      'type': 'Hidden',
+      'type': 'Dropdown',
+      'value': 'versionTag',
+      'choices': [
+        {
+          'name': 'versionTag',
+          'value': 'versionTag'
+        },
+        {
+          'name': 'deployment',
+          'value': 'deployment'
+        }
+      ],
+      'binding': {
+        'type': 'zeebe:calledElement',
+        'property': 'bindingType'
+      }
+    },
+    {
+      'type': 'String',
       'value': 'vers-1',
       'binding': {
         'type': 'zeebe:calledElement',
@@ -65,14 +83,14 @@ export const errors = [
           emUsed: true
         },
         {
-          dataPath: '/properties/0/type',
-          emUsed: true,
           keyword: 'const',
-          message: 'should be equal to constant',
+          dataPath: '/properties/0/type',
+          schemaPath: '#/allOf/1/allOf/7/allOf/1/then/properties/properties/contains/properties/type/const',
           params: {
             allowedValue: 'Hidden'
           },
-          schemaPath: '#/allOf/1/allOf/7/allOf/1/then/properties/properties/contains/properties/type/const'
+          message: 'should be equal to constant',
+          emUsed: true
         },
         {
           keyword: 'const',
@@ -96,7 +114,17 @@ export const errors = [
         },
         {
           keyword: 'const',
-          dataPath: '/properties/2/binding/property',
+          dataPath: '/properties/2/type',
+          schemaPath: '#/allOf/1/allOf/7/allOf/1/then/properties/properties/contains/properties/type/const',
+          params: {
+            allowedValue: 'Hidden'
+          },
+          message: 'should be equal to constant',
+          emUsed: true
+        },
+        {
+          keyword: 'const',
+          dataPath: '/properties/3/binding/property',
           schemaPath: '#/allOf/1/allOf/7/allOf/1/then/properties/properties/contains/properties/binding/properties/property/const',
           params: {
             allowedValue: 'bindingType'
@@ -106,10 +134,20 @@ export const errors = [
         },
         {
           keyword: 'const',
-          dataPath: '/properties/2/value',
+          dataPath: '/properties/3/value',
           schemaPath: '#/allOf/1/allOf/7/allOf/1/then/properties/properties/contains/properties/value/const',
           params: {
             allowedValue: 'versionTag'
+          },
+          message: 'should be equal to constant',
+          emUsed: true
+        },
+        {
+          keyword: 'const',
+          dataPath: '/properties/3/type',
+          schemaPath: '#/allOf/1/allOf/7/allOf/1/then/properties/properties/contains/properties/type/const',
+          params: {
+            allowedValue: 'Hidden'
           },
           message: 'should be equal to constant',
           emUsed: true

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/called-element/versionTag.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/called-element/versionTag.js
@@ -25,6 +25,22 @@ export const template = {
         'type': 'zeebe:calledElement',
         'property': 'processId'
       }
+    },
+    {
+      'type': 'Hidden',
+      'value': 'versionTag',
+      'binding': {
+        'type': 'zeebe:calledElement',
+        'property': 'bindingType'
+      }
+    },
+    {
+      'type': 'String',
+      'value': 'vers-1',
+      'binding': {
+        'type': 'zeebe:calledElement',
+        'property': 'versionTag'
+      }
     }
   ]
 };

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/form-definition/deployment.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/form-definition/deployment.js
@@ -1,0 +1,37 @@
+export const template = {
+  '$schema': 'https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json',
+  'name': 'Form Definition with FormId',
+  'id': 'formDefinitionWithFormId',
+  'appliesTo': [
+    'bpmn:Task'
+  ],
+  'elementType': {
+    'value': 'bpmn:UserTask'
+  },
+  'properties': [
+    {
+      'type': 'Hidden',
+      'binding': {
+        'type': 'zeebe:userTask',
+      }
+    },
+    {
+      'type': 'Hidden',
+      'value': 'aFormId',
+      'binding': {
+        'type': 'zeebe:formDefinition',
+        'property': 'formId'
+      }
+    },
+    {
+      'type': 'Hidden',
+      'value': 'deployment',
+      'binding': {
+        'type': 'zeebe:formDefinition',
+        'property': 'bindingType'
+      }
+    }
+  ]
+};
+
+export const errors = null;

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/form-definition/dropdown-invalid-choices.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/form-definition/dropdown-invalid-choices.js
@@ -1,0 +1,132 @@
+export const template = {
+  '$schema': 'https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json',
+  'name': 'Form Definition with FormId',
+  'id': 'formDefinitionWithFormId',
+  'appliesTo': [
+    'bpmn:Task'
+  ],
+  'elementType': {
+    'value': 'bpmn:UserTask'
+  },
+  'properties': [
+    {
+      'type': 'Hidden',
+      'binding': {
+        'type': 'zeebe:userTask',
+      }
+    },
+    {
+      'type': 'Hidden',
+      'value': 'aFormId',
+      'binding': {
+        'type': 'zeebe:formDefinition',
+        'property': 'formId'
+      }
+    },
+    {
+      'type': 'Dropdown',
+      'label': 'Binding',
+      'id': 'bindingType',
+      'binding': {
+        'type': 'zeebe:formDefinition',
+        'property': 'bindingType'
+      },
+      'choices': [
+        {
+          'name': 'Latest',
+          'value': 'foo'
+        },
+        {
+          'name': 'Deployment',
+          'value': 'bar'
+        },
+        {
+          'name': 'Version Tag',
+          'value': 'baz'
+        }
+      ],
+      'value': 'latest',
+    },
+    {
+      'type': 'String',
+      'label': 'Version tag',
+      'binding': {
+        'type': 'zeebe:formDefinition',
+        'property': 'versionTag'
+      },
+      'condition': {
+        'property': 'bindingType',
+        'equals': 'versionTag'
+      }
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'enum',
+    dataPath: '/properties/2/choices/0/value',
+    schemaPath: '#/allOf/1/items/allOf/20/allOf/0/then/properties/choices/items/properties/value/enum',
+    params: {
+      allowedValues: [
+        'latest',
+        'versionTag',
+        'deployment'
+      ]
+    },
+    message: 'should be equal to one of the allowed values'
+  },
+  {
+    keyword: 'enum',
+    dataPath: '/properties/2/choices/1/value',
+    schemaPath: '#/allOf/1/items/allOf/20/allOf/0/then/properties/choices/items/properties/value/enum',
+    params: {
+      allowedValues: [
+        'latest',
+        'versionTag',
+        'deployment'
+      ]
+    },
+    message: 'should be equal to one of the allowed values'
+  },
+  {
+    keyword: 'enum',
+    dataPath: '/properties/2/choices/2/value',
+    schemaPath: '#/allOf/1/items/allOf/20/allOf/0/then/properties/choices/items/properties/value/enum',
+    params: {
+      allowedValues: [
+        'latest',
+        'versionTag',
+        'deployment'
+      ]
+    },
+    message: 'should be equal to one of the allowed values'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/2',
+    schemaPath: '#/allOf/1/items/allOf/20/allOf/0/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: {
+      type: 'array'
+    },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: {
+      passingSchemas: null
+    },
+    message: 'should match exactly one schema in oneOf'
+  }
+];

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/form-definition/dropdown.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/form-definition/dropdown.js
@@ -1,0 +1,65 @@
+export const template = {
+  '$schema': 'https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json',
+  'name': 'Form Definition with FormId',
+  'id': 'formDefinitionWithFormId',
+  'appliesTo': [
+    'bpmn:Task'
+  ],
+  'elementType': {
+    'value': 'bpmn:UserTask'
+  },
+  'properties': [
+    {
+      'type': 'Hidden',
+      'binding': {
+        'type': 'zeebe:userTask',
+      }
+    },
+    {
+      'type': 'Hidden',
+      'value': 'aFormId',
+      'binding': {
+        'type': 'zeebe:formDefinition',
+        'property': 'formId'
+      }
+    },
+    {
+      'type': 'Dropdown',
+      'label': 'Binding',
+      'id': 'bindingType',
+      'binding': {
+        'type': 'zeebe:formDefinition',
+        'property': 'bindingType'
+      },
+      'choices': [
+        {
+          'name': 'Latest',
+          'value': 'latest'
+        },
+        {
+          'name': 'Deployment',
+          'value': 'deployment'
+        },
+        {
+          'name': 'Version Tag',
+          'value': 'versionTag'
+        }
+      ],
+      'value': 'latest',
+    },
+    {
+      'type': 'String',
+      'label': 'Version tag',
+      'binding': {
+        'type': 'zeebe:formDefinition',
+        'property': 'versionTag'
+      },
+      'condition': {
+        'property': 'bindingType',
+        'equals': 'versionTag'
+      }
+    }
+  ]
+};
+
+export const errors = null;

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/form-definition/invalid-feel.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/form-definition/invalid-feel.js
@@ -1,0 +1,144 @@
+export const template = {
+  '$schema': 'https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json',
+  'name': 'Form Definition with FormId',
+  'id': 'formDefinitionWithFormId',
+  'appliesTo': [
+    'bpmn:Task'
+  ],
+  'elementType': {
+    'value': 'bpmn:UserTask'
+  },
+  'properties': [
+    {
+      'type': 'Hidden',
+      'binding': {
+        'type': 'zeebe:userTask',
+      }
+    },
+    {
+      'type': 'Hidden',
+      'value': 'aFormId',
+      'binding': {
+        'type': 'zeebe:formDefinition',
+        'property': 'formId'
+      }
+    },
+    {
+      'type': 'Dropdown',
+      'value': 'deployment',
+      'choices': [
+        {
+          'value': 'deployment',
+          'name': 'Deployment'
+        },
+        {
+          'value': 'versionTag',
+          'name': 'Version Tag'
+        } ],
+      'feel': 'static',
+      'binding': {
+        'type': 'zeebe:formDefinition',
+        'property': 'bindingType'
+      }
+    },
+    {
+      'type': 'Hidden',
+      'value': 'deployment',
+      'feel': 'required',
+      'binding': {
+        'type': 'zeebe:formDefinition',
+        'property': 'bindingType'
+      }
+    }
+  ]
+};
+
+// This just catching a transitive error as Hidden and Dropdown cannot be feel anyways.
+export const errors = [
+  {
+    keyword: 'errorMessage',
+    dataPath: '/properties/2/type',
+    schemaPath: '#/allOf/1/items/allOf/4/then/properties/type/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'enum',
+          dataPath: '/properties/2/type',
+          schemaPath: '#/allOf/1/items/allOf/4/then/properties/type/enum',
+          params: {
+            allowedValues: [
+              'String',
+              'Text',
+              'Number',
+              'Boolean'
+            ]
+          },
+          message: 'should be equal to one of the allowed values',
+          emUsed: true
+        }
+      ]
+    },
+    message: 'feel is only supported for "String", "Text", "Number" and "Boolean" type'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/2',
+    schemaPath: '#/allOf/1/items/allOf/4/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'errorMessage',
+    dataPath: '/properties/3/type',
+    schemaPath: '#/allOf/1/items/allOf/4/then/properties/type/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'enum',
+          dataPath: '/properties/3/type',
+          schemaPath: '#/allOf/1/items/allOf/4/then/properties/type/enum',
+          params: {
+            allowedValues: [
+              'String',
+              'Text',
+              'Number',
+              'Boolean'
+            ]
+          },
+          message: 'should be equal to one of the allowed values',
+          emUsed: true
+        }
+      ]
+    },
+    message: 'feel is only supported for "String", "Text", "Number" and "Boolean" type'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/3',
+    schemaPath: '#/allOf/1/items/allOf/4/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: {
+      type: 'array'
+    },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: {
+      passingSchemas: null
+    },
+    message: 'should match exactly one schema in oneOf'
+  }
+];

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/form-definition/invalid-input-type.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/form-definition/invalid-input-type.js
@@ -1,0 +1,235 @@
+export const template = {
+  '$schema': 'https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json',
+  'name': 'Form Definition with FormId',
+  'id': 'formDefinitionWithFormId',
+  'appliesTo': [
+    'bpmn:Task'
+  ],
+  'elementType': {
+    'value': 'bpmn:UserTask'
+  },
+  'properties': [
+    {
+      'type': 'Hidden',
+      'binding': {
+        'type': 'zeebe:userTask',
+      }
+    },
+    {
+      'type': 'Hidden',
+      'value': 'aFormId',
+      'binding': {
+        'type': 'zeebe:formDefinition',
+        'property': 'formId'
+      }
+    },
+    {
+      'type': 'String',
+      'value': 'latest',
+      'binding': {
+        'type': 'zeebe:formDefinition',
+        'property': 'bindingType'
+      }
+    },
+    {
+      'type': 'Number',
+      'value': 1,
+      'binding': {
+        'type': 'zeebe:formDefinition',
+        'property': 'bindingType'
+      }
+    },
+    {
+      'type': 'Text',
+      'value': 'latest',
+      'binding': {
+        'type': 'zeebe:formDefinition',
+        'property': 'bindingType'
+      }
+    },
+    {
+      'type': 'Boolean',
+      'value': true,
+      'binding': {
+        'type': 'zeebe:formDefinition',
+        'property': 'bindingType'
+      }
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'errorMessage',
+    dataPath: '/properties/2/type',
+    schemaPath: '#/allOf/1/items/allOf/20/allOf/0/then/properties/type/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'enum',
+          dataPath: '/properties/2/type',
+          schemaPath: '#/allOf/1/items/allOf/20/allOf/0/then/properties/type/enum',
+          params: {
+            allowedValues: [
+              'Hidden',
+              'Dropdown'
+            ]
+          },
+          message: 'should be equal to one of the allowed values',
+          emUsed: true
+        }
+      ]
+    },
+    message: 'Incorrect type "String". Must be one of { Hidden, Dropdown } for binding with `property`=`bindingType`'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/2',
+    schemaPath: '#/allOf/1/items/allOf/20/allOf/0/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'errorMessage',
+    dataPath: '/properties/3/type',
+    schemaPath: '#/allOf/1/items/allOf/20/allOf/0/then/properties/type/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'enum',
+          dataPath: '/properties/3/type',
+          schemaPath: '#/allOf/1/items/allOf/20/allOf/0/then/properties/type/enum',
+          params: {
+            allowedValues: [
+              'Hidden',
+              'Dropdown'
+            ]
+          },
+          message: 'should be equal to one of the allowed values',
+          emUsed: true
+        }
+      ]
+    },
+    message: 'Incorrect type "Number". Must be one of { Hidden, Dropdown } for binding with `property`=`bindingType`'
+  },
+  {
+    keyword: 'enum',
+    dataPath: '/properties/3/value',
+    schemaPath: '#/allOf/1/items/allOf/20/allOf/0/then/properties/value/enum',
+    params: {
+      allowedValues: [
+        'latest',
+        'versionTag',
+        'deployment'
+      ]
+    },
+    message: 'should be equal to one of the allowed values'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/3',
+    schemaPath: '#/allOf/1/items/allOf/20/allOf/0/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'errorMessage',
+    dataPath: '/properties/4/type',
+    schemaPath: '#/allOf/1/items/allOf/20/allOf/0/then/properties/type/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'enum',
+          dataPath: '/properties/4/type',
+          schemaPath: '#/allOf/1/items/allOf/20/allOf/0/then/properties/type/enum',
+          params: {
+            allowedValues: [
+              'Hidden',
+              'Dropdown'
+            ]
+          },
+          message: 'should be equal to one of the allowed values',
+          emUsed: true
+        }
+      ]
+    },
+    message: 'Incorrect type "Text". Must be one of { Hidden, Dropdown } for binding with `property`=`bindingType`'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/4',
+    schemaPath: '#/allOf/1/items/allOf/20/allOf/0/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'errorMessage',
+    dataPath: '/properties/5/type',
+    schemaPath: '#/allOf/1/items/allOf/20/allOf/0/then/properties/type/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'enum',
+          dataPath: '/properties/5/type',
+          schemaPath: '#/allOf/1/items/allOf/20/allOf/0/then/properties/type/enum',
+          params: {
+            allowedValues: [
+              'Hidden',
+              'Dropdown'
+            ]
+          },
+          message: 'should be equal to one of the allowed values',
+          emUsed: true
+        }
+      ]
+    },
+    message: 'Incorrect type "Boolean". Must be one of { Hidden, Dropdown } for binding with `property`=`bindingType`'
+  },
+  {
+    keyword: 'enum',
+    dataPath: '/properties/5/value',
+    schemaPath: '#/allOf/1/items/allOf/20/allOf/0/then/properties/value/enum',
+    params: {
+      allowedValues: [
+        'latest',
+        'versionTag',
+        'deployment'
+      ]
+    },
+    message: 'should be equal to one of the allowed values'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/5',
+    schemaPath: '#/allOf/1/items/allOf/20/allOf/0/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: {
+      type: 'array'
+    },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: {
+      passingSchemas: null
+    },
+    message: 'should match exactly one schema in oneOf'
+  }
+];
+

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/form-definition/invalid-value.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/form-definition/invalid-value.js
@@ -1,7 +1,7 @@
 export const template = {
   '$schema': 'https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json',
-  'name': 'Form Definition with external reference',
-  'id': 'formDefinitionWithExternalReference',
+  'name': 'Form Definition with FormId',
+  'id': 'formDefinitionWithFormId',
   'appliesTo': [
     'bpmn:Task'
   ],
@@ -17,46 +17,42 @@ export const template = {
     },
     {
       'type': 'Hidden',
-      'value': 'aReference',
+      'value': 'aFormId',
       'binding': {
         'type': 'zeebe:formDefinition',
-        'property': 'externalReference'
+        'property': 'formId'
       }
     },
     {
       'type': 'Hidden',
-      'value': 'anId',
+      'value': 'youShallNotPass',
       'binding': {
         'type': 'zeebe:formDefinition',
-        'property': 'formId'
+        'property': 'bindingType'
       }
     }
   ]
 };
 
+
 export const errors = [
   {
-    keyword: 'errorMessage',
-    dataPath: '/properties',
-    schemaPath: '#/allOf/1/allOf/11/then/properties/properties/errorMessage',
+    keyword: 'enum',
+    dataPath: '/properties/2/value',
+    schemaPath: '#/allOf/1/items/allOf/20/allOf/0/then/properties/value/enum',
     params: {
-      errors: [
-        {
-          keyword: 'not',
-          dataPath: '/properties',
-          schemaPath: '#/allOf/1/allOf/11/then/properties/properties/not',
-          params: {},
-          message: 'should NOT be valid',
-          emUsed: true
-        }
+      allowedValues: [
+        'latest',
+        'versionTag',
+        'deployment'
       ]
     },
-    message: '"formId" and "externalReference" cannot be used together'
+    message: 'should be equal to one of the allowed values'
   },
   {
     keyword: 'if',
-    dataPath: '',
-    schemaPath: '#/allOf/1/allOf/11/if',
+    dataPath: '/properties/2',
+    schemaPath: '#/allOf/1/items/allOf/20/allOf/0/if',
     params: {
       failingKeyword: 'then'
     },

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/form-definition/latest.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/form-definition/latest.js
@@ -1,0 +1,37 @@
+export const template = {
+  '$schema': 'https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json',
+  'name': 'Form Definition with FormId',
+  'id': 'formDefinitionWithFormId',
+  'appliesTo': [
+    'bpmn:Task'
+  ],
+  'elementType': {
+    'value': 'bpmn:UserTask'
+  },
+  'properties': [
+    {
+      'type': 'Hidden',
+      'binding': {
+        'type': 'zeebe:userTask',
+      }
+    },
+    {
+      'type': 'Hidden',
+      'value': 'aFormId',
+      'binding': {
+        'type': 'zeebe:formDefinition',
+        'property': 'formId'
+      }
+    },
+    {
+      'type': 'Hidden',
+      'value': 'latest',
+      'binding': {
+        'type': 'zeebe:formDefinition',
+        'property': 'bindingType'
+      }
+    }
+  ]
+};
+
+export const errors = null;

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/form-definition/missing-property-binding-type.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/form-definition/missing-property-binding-type.js
@@ -38,13 +38,13 @@ export const errors = [
   {
     keyword: 'errorMessage',
     dataPath: '/properties',
-    schemaPath: '#/allOf/1/allOf/8/then/properties/properties/errorMessage',
+    schemaPath: '#/allOf/1/allOf/7/allOf/1/then/properties/properties/errorMessage',
     params: {
       errors: [
         {
           keyword: 'required',
           dataPath: '/properties/0',
-          schemaPath: '#/allOf/1/allOf/8/then/properties/properties/contains/required',
+          schemaPath: '#/allOf/1/allOf/7/allOf/1/then/properties/properties/contains/required',
           params: {
             missingProperty: 'value'
           },
@@ -54,7 +54,7 @@ export const errors = [
         {
           keyword: 'required',
           dataPath: '/properties/0/binding',
-          schemaPath: '#/allOf/1/allOf/8/then/properties/properties/contains/properties/binding/required',
+          schemaPath: '#/allOf/1/allOf/7/allOf/1/then/properties/properties/contains/properties/binding/required',
           params: {
             missingProperty: 'property'
           },
@@ -64,7 +64,7 @@ export const errors = [
         {
           keyword: 'const',
           dataPath: '/properties/1/binding/property',
-          schemaPath: '#/allOf/1/allOf/8/then/properties/properties/contains/properties/binding/properties/property/const',
+          schemaPath: '#/allOf/1/allOf/7/allOf/1/then/properties/properties/contains/properties/binding/properties/property/const',
           params: {
             allowedValue: 'bindingType'
           },
@@ -74,7 +74,7 @@ export const errors = [
         {
           keyword: 'const',
           dataPath: '/properties/1/value',
-          schemaPath: '#/allOf/1/allOf/8/then/properties/properties/contains/properties/value/const',
+          schemaPath: '#/allOf/1/allOf/7/allOf/1/then/properties/properties/contains/properties/value/const',
           params: {
             allowedValue: 'versionTag'
           },
@@ -84,7 +84,7 @@ export const errors = [
         {
           keyword: 'const',
           dataPath: '/properties/2/binding/property',
-          schemaPath: '#/allOf/1/allOf/8/then/properties/properties/contains/properties/binding/properties/property/const',
+          schemaPath: '#/allOf/1/allOf/7/allOf/1/then/properties/properties/contains/properties/binding/properties/property/const',
           params: {
             allowedValue: 'bindingType'
           },
@@ -94,7 +94,7 @@ export const errors = [
         {
           keyword: 'const',
           dataPath: '/properties/2/value',
-          schemaPath: '#/allOf/1/allOf/8/then/properties/properties/contains/properties/value/const',
+          schemaPath: '#/allOf/1/allOf/7/allOf/1/then/properties/properties/contains/properties/value/const',
           params: {
             allowedValue: 'versionTag'
           },
@@ -104,7 +104,7 @@ export const errors = [
         {
           keyword: 'contains',
           dataPath: '/properties',
-          schemaPath: '#/allOf/1/allOf/8/then/properties/properties/contains',
+          schemaPath: '#/allOf/1/allOf/7/allOf/1/then/properties/properties/contains',
           params: {
             minContains: 1
           },
@@ -118,7 +118,7 @@ export const errors = [
   {
     keyword: 'if',
     dataPath: '',
-    schemaPath: '#/allOf/1/allOf/8/if',
+    schemaPath: '#/allOf/1/allOf/7/allOf/1/if',
     params: {
       failingKeyword: 'then'
     },

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/form-definition/missing-property-binding-type.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/form-definition/missing-property-binding-type.js
@@ -1,0 +1,145 @@
+export const template = {
+  '$schema': 'https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json',
+  'name': 'Form Definition with FormId',
+  'id': 'formDefinitionWithFormId',
+  'appliesTo': [
+    'bpmn:Task'
+  ],
+  'elementType': {
+    'value': 'bpmn:UserTask'
+  },
+  'properties': [
+    {
+      'type': 'Hidden',
+      'binding': {
+        'type': 'zeebe:userTask',
+      }
+    },
+    {
+      'type': 'Hidden',
+      'value': 'aFormId',
+      'binding': {
+        'type': 'zeebe:formDefinition',
+        'property': 'formId'
+      }
+    },
+    {
+      'type': 'Hidden',
+      'value': 'vers-1',
+      'binding': {
+        'type': 'zeebe:formDefinition',
+        'property': 'versionTag'
+      }
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'errorMessage',
+    dataPath: '/properties',
+    schemaPath: '#/allOf/1/allOf/8/then/properties/properties/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'required',
+          dataPath: '/properties/0',
+          schemaPath: '#/allOf/1/allOf/8/then/properties/properties/contains/required',
+          params: {
+            missingProperty: 'value'
+          },
+          message: "should have required property 'value'",
+          emUsed: true
+        },
+        {
+          keyword: 'required',
+          dataPath: '/properties/0/binding',
+          schemaPath: '#/allOf/1/allOf/8/then/properties/properties/contains/properties/binding/required',
+          params: {
+            missingProperty: 'property'
+          },
+          message: "should have required property 'property'",
+          emUsed: true
+        },
+        {
+          keyword: 'const',
+          dataPath: '/properties/1/binding/property',
+          schemaPath: '#/allOf/1/allOf/8/then/properties/properties/contains/properties/binding/properties/property/const',
+          params: {
+            allowedValue: 'bindingType'
+          },
+          message: 'should be equal to constant',
+          emUsed: true
+        },
+        {
+          keyword: 'const',
+          dataPath: '/properties/1/value',
+          schemaPath: '#/allOf/1/allOf/8/then/properties/properties/contains/properties/value/const',
+          params: {
+            allowedValue: 'versionTag'
+          },
+          message: 'should be equal to constant',
+          emUsed: true
+        },
+        {
+          keyword: 'const',
+          dataPath: '/properties/2/binding/property',
+          schemaPath: '#/allOf/1/allOf/8/then/properties/properties/contains/properties/binding/properties/property/const',
+          params: {
+            allowedValue: 'bindingType'
+          },
+          message: 'should be equal to constant',
+          emUsed: true
+        },
+        {
+          keyword: 'const',
+          dataPath: '/properties/2/value',
+          schemaPath: '#/allOf/1/allOf/8/then/properties/properties/contains/properties/value/const',
+          params: {
+            allowedValue: 'versionTag'
+          },
+          message: 'should be equal to constant',
+          emUsed: true
+        },
+        {
+          keyword: 'contains',
+          dataPath: '/properties',
+          schemaPath: '#/allOf/1/allOf/8/then/properties/properties/contains',
+          params: {
+            minContains: 1
+          },
+          message: 'should contain at least 1 valid item(s)',
+          emUsed: true
+        }
+      ]
+    },
+    message: 'Binding with property=`bindingType` and value=`versionTag` must be set when using a binding with property=`versionTag`'
+  },
+  {
+    keyword: 'if',
+    dataPath: '',
+    schemaPath: '#/allOf/1/allOf/8/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: {
+      type: 'array'
+    },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: {
+      passingSchemas: null
+    },
+    message: 'should match exactly one schema in oneOf'
+  }
+];

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/form-definition/missing-property-versionTag.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/form-definition/missing-property-versionTag.js
@@ -1,0 +1,129 @@
+export const template = {
+  '$schema': 'https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json',
+  'name': 'Form Definition with FormId',
+  'id': 'formDefinitionWithFormId',
+  'appliesTo': [
+    'bpmn:Task'
+  ],
+  'elementType': {
+    'value': 'bpmn:UserTask'
+  },
+  'properties': [
+    {
+      'type': 'Hidden',
+      'binding': {
+        'type': 'zeebe:userTask',
+      }
+    },
+    {
+      'type': 'Hidden',
+      'value': 'aFormId',
+      'binding': {
+        'type': 'zeebe:formDefinition',
+        'property': 'formId'
+      }
+    },
+    {
+      'type': 'Hidden',
+      'value': 'versionTag',
+      'binding': {
+        'type': 'zeebe:formDefinition',
+        'property': 'bindingType'
+      }
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'errorMessage',
+    dataPath: '/properties',
+    schemaPath: '#/allOf/1/allOf/7/then/properties/properties/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'required',
+          dataPath: '/properties/0/binding',
+          schemaPath: '#/allOf/1/allOf/7/then/properties/properties/contains/properties/binding/required',
+          params: {
+            missingProperty: 'property'
+          },
+          message: "should have required property 'property'",
+          emUsed: true
+        },
+        {
+          keyword: 'enum',
+          dataPath: '/properties/0/binding/type',
+          schemaPath: '#/allOf/1/allOf/7/then/properties/properties/contains/properties/binding/properties/type/enum',
+          params: {
+            allowedValues: [
+              'zeebe:calledDecision',
+              'zeebe:formDefinition',
+              'zeebe:calledElement'
+            ]
+          },
+          message: 'should be equal to one of the allowed values',
+          emUsed: true
+        },
+        {
+          keyword: 'const',
+          dataPath: '/properties/1/binding/property',
+          schemaPath: '#/allOf/1/allOf/7/then/properties/properties/contains/properties/binding/properties/property/const',
+          params: {
+            allowedValue: 'versionTag'
+          },
+          message: 'should be equal to constant',
+          emUsed: true
+        },
+        {
+          keyword: 'const',
+          dataPath: '/properties/2/binding/property',
+          schemaPath: '#/allOf/1/allOf/7/then/properties/properties/contains/properties/binding/properties/property/const',
+          params: {
+            allowedValue: 'versionTag'
+          },
+          message: 'should be equal to constant',
+          emUsed: true
+        },
+        {
+          keyword: 'contains',
+          dataPath: '/properties',
+          schemaPath: '#/allOf/1/allOf/7/then/properties/properties/contains',
+          params: {
+            minContains: 1
+          },
+          message: 'should contain at least 1 valid item(s)',
+          emUsed: true
+        }
+      ]
+    },
+    message: 'Missing binding with `property`=`versionTag` as binding with `property`=`bindingType` and `value`=`versionTag` is set'
+  },
+  {
+    keyword: 'if',
+    dataPath: '',
+    schemaPath: '#/allOf/1/allOf/7/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: {
+      type: 'array'
+    },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: {
+      passingSchemas: null
+    },
+    message: 'should match exactly one schema in oneOf'
+  }
+];

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/form-definition/missing-property-versionTag.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/form-definition/missing-property-versionTag.js
@@ -38,13 +38,13 @@ export const errors = [
   {
     keyword: 'errorMessage',
     dataPath: '/properties',
-    schemaPath: '#/allOf/1/allOf/7/then/properties/properties/errorMessage',
+    schemaPath: '#/allOf/1/allOf/7/allOf/0/then/properties/properties/errorMessage',
     params: {
       errors: [
         {
           keyword: 'required',
           dataPath: '/properties/0/binding',
-          schemaPath: '#/allOf/1/allOf/7/then/properties/properties/contains/properties/binding/required',
+          schemaPath: '#/allOf/1/allOf/7/allOf/0/then/properties/properties/contains/properties/binding/required',
           params: {
             missingProperty: 'property'
           },
@@ -54,7 +54,7 @@ export const errors = [
         {
           keyword: 'enum',
           dataPath: '/properties/0/binding/type',
-          schemaPath: '#/allOf/1/allOf/7/then/properties/properties/contains/properties/binding/properties/type/enum',
+          schemaPath: '#/allOf/1/allOf/7/allOf/0/then/properties/properties/contains/properties/binding/properties/type/enum',
           params: {
             allowedValues: [
               'zeebe:calledDecision',
@@ -68,7 +68,7 @@ export const errors = [
         {
           keyword: 'const',
           dataPath: '/properties/1/binding/property',
-          schemaPath: '#/allOf/1/allOf/7/then/properties/properties/contains/properties/binding/properties/property/const',
+          schemaPath: '#/allOf/1/allOf/7/allOf/0/then/properties/properties/contains/properties/binding/properties/property/const',
           params: {
             allowedValue: 'versionTag'
           },
@@ -78,7 +78,7 @@ export const errors = [
         {
           keyword: 'const',
           dataPath: '/properties/2/binding/property',
-          schemaPath: '#/allOf/1/allOf/7/then/properties/properties/contains/properties/binding/properties/property/const',
+          schemaPath: '#/allOf/1/allOf/7/allOf/0/then/properties/properties/contains/properties/binding/properties/property/const',
           params: {
             allowedValue: 'versionTag'
           },
@@ -88,7 +88,7 @@ export const errors = [
         {
           keyword: 'contains',
           dataPath: '/properties',
-          schemaPath: '#/allOf/1/allOf/7/then/properties/properties/contains',
+          schemaPath: '#/allOf/1/allOf/7/allOf/0/then/properties/properties/contains',
           params: {
             minContains: 1
           },
@@ -102,7 +102,7 @@ export const errors = [
   {
     keyword: 'if',
     dataPath: '',
-    schemaPath: '#/allOf/1/allOf/7/if',
+    schemaPath: '#/allOf/1/allOf/7/allOf/0/if',
     params: {
       failingKeyword: 'then'
     },

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/form-definition/versionTag-invalid-feel.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/form-definition/versionTag-invalid-feel.js
@@ -1,7 +1,7 @@
 export const template = {
   '$schema': 'https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json',
-  'name': 'Form Definition with external reference',
-  'id': 'formDefinitionWithExternalReference',
+  'name': 'Form Definition with FormId',
+  'id': 'formDefinitionWithFormId',
   'appliesTo': [
     'bpmn:Task'
   ],
@@ -17,18 +17,27 @@ export const template = {
     },
     {
       'type': 'Hidden',
-      'value': 'aReference',
+      'value': 'aFormId',
       'binding': {
         'type': 'zeebe:formDefinition',
-        'property': 'externalReference'
+        'property': 'formId'
       }
     },
     {
       'type': 'Hidden',
-      'value': 'anId',
+      'value': 'versionTag',
       'binding': {
         'type': 'zeebe:formDefinition',
-        'property': 'formId'
+        'property': 'bindingType'
+      }
+    },
+    {
+      'type': 'String',
+      'feel': 'optional',
+      'value': 'vers-1',
+      'binding': {
+        'type': 'zeebe:formDefinition',
+        'property': 'versionTag'
       }
     }
   ]
@@ -37,26 +46,26 @@ export const template = {
 export const errors = [
   {
     keyword: 'errorMessage',
-    dataPath: '/properties',
-    schemaPath: '#/allOf/1/allOf/11/then/properties/properties/errorMessage',
+    dataPath: '/properties/3',
+    schemaPath: '#/allOf/1/items/allOf/20/allOf/1/then/allOf/1/errorMessage',
     params: {
       errors: [
         {
           keyword: 'not',
-          dataPath: '/properties',
-          schemaPath: '#/allOf/1/allOf/11/then/properties/properties/not',
+          dataPath: '/properties/3',
+          schemaPath: '#/allOf/1/items/allOf/20/allOf/1/then/allOf/1/not',
           params: {},
           message: 'should NOT be valid',
           emUsed: true
         }
       ]
     },
-    message: '"formId" and "externalReference" cannot be used together'
+    message: 'Binding with `property`=`versionTag` does not support `feel`'
   },
   {
     keyword: 'if',
-    dataPath: '',
-    schemaPath: '#/allOf/1/allOf/11/if',
+    dataPath: '/properties/3',
+    schemaPath: '#/allOf/1/items/allOf/20/allOf/1/if',
     params: {
       failingKeyword: 'then'
     },

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/form-definition/versionTag-invalid-input-type.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/form-definition/versionTag-invalid-input-type.js
@@ -1,0 +1,141 @@
+export const template = {
+  '$schema': 'https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json',
+  'name': 'Form Definition with FormId',
+  'id': 'formDefinitionWithFormId',
+  'appliesTo': [
+    'bpmn:Task'
+  ],
+  'elementType': {
+    'value': 'bpmn:UserTask'
+  },
+  'properties': [
+    {
+      'type': 'Hidden',
+      'binding': {
+        'type': 'zeebe:userTask',
+      }
+    },
+    {
+      'type': 'Hidden',
+      'value': 'aFormId',
+      'binding': {
+        'type': 'zeebe:formDefinition',
+        'property': 'formId'
+      }
+    },
+    {
+      'type': 'Hidden',
+      'value': 'versionTag',
+      'binding': {
+        'type': 'zeebe:formDefinition',
+        'property': 'bindingType'
+      }
+    },
+    {
+      'type': 'Number',
+      'value': 1,
+      'binding': {
+        'type': 'zeebe:formDefinition',
+        'property': 'versionTag'
+      }
+    },
+    {
+      'type': 'Boolean',
+      'value': true,
+      'binding': {
+        'type': 'zeebe:formDefinition',
+        'property': 'versionTag'
+      }
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'errorMessage',
+    dataPath: '/properties/3/type',
+    schemaPath: '#/allOf/1/items/allOf/20/allOf/1/then/allOf/0/properties/type/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'enum',
+          dataPath: '/properties/3/type',
+          schemaPath: '#/allOf/1/items/allOf/20/allOf/1/then/allOf/0/properties/type/enum',
+          params: {
+            allowedValues: [
+              'Hidden',
+              'Dropdown',
+              'String',
+              'Text'
+            ]
+          },
+          message: 'should be equal to one of the allowed values',
+          emUsed: true
+        }
+      ]
+    },
+    message: 'Incorrect type "Number". Must be one of { String, Text, Hidden, Dropdown } for binding with `property`=`versionTag`'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/3',
+    schemaPath: '#/allOf/1/items/allOf/20/allOf/1/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'errorMessage',
+    dataPath: '/properties/4/type',
+    schemaPath: '#/allOf/1/items/allOf/20/allOf/1/then/allOf/0/properties/type/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'enum',
+          dataPath: '/properties/4/type',
+          schemaPath: '#/allOf/1/items/allOf/20/allOf/1/then/allOf/0/properties/type/enum',
+          params: {
+            allowedValues: [
+              'Hidden',
+              'Dropdown',
+              'String',
+              'Text'
+            ]
+          },
+          message: 'should be equal to one of the allowed values',
+          emUsed: true
+        }
+      ]
+    },
+    message: 'Incorrect type "Boolean". Must be one of { String, Text, Hidden, Dropdown } for binding with `property`=`versionTag`'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/4',
+    schemaPath: '#/allOf/1/items/allOf/20/allOf/1/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: {
+      type: 'array'
+    },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: {
+      passingSchemas: null
+    },
+    message: 'should match exactly one schema in oneOf'
+  }
+]
+;

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/form-definition/versionTag-invalid-unconditional.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/form-definition/versionTag-invalid-unconditional.js
@@ -1,36 +1,51 @@
 export const template = {
   '$schema': 'https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json',
-  'id': 'io.camunda.examples.Payment',
-  'name': 'Payment',
-  'description': 'Payment process call activity',
+  'name': 'Form Definition with FormId',
+  'id': 'formDefinitionWithFormId',
   'appliesTo': [
     'bpmn:Task'
   ],
   'elementType': {
-    'value': 'bpmn:CallActivity'
+    'value': 'bpmn:UserTask'
   },
-  'properties':[
+  'properties': [
     {
-      'label': 'Payment ID',
+      'type': 'Hidden',
+      'binding': {
+        'type': 'zeebe:userTask',
+      }
+    },
+    {
+      'type': 'Hidden',
+      'value': 'aFormId',
+      'binding': {
+        'type': 'zeebe:formDefinition',
+        'property': 'formId'
+      }
+    },
+    {
+      'type': 'Dropdown',
+      'value': 'versionTag',
+      'choices': [
+        {
+          'name': 'versionTag',
+          'value': 'versionTag'
+        },
+        {
+          'name': 'deployment',
+          'value': 'deployment'
+        }
+      ],
+      'binding': {
+        'type': 'zeebe:formDefinition',
+        'property': 'bindingType'
+      }
+    },
+    {
       'type': 'String',
-      'binding': {
-        'type': 'zeebe:input',
-        'name': 'paymentID'
-      }
-    },
-    {
-      'type': 'Hidden',
-      'value': 'paymentProcess',
-      'binding': {
-        'type': 'zeebe:calledElement',
-        'property': 'processId'
-      }
-    },
-    {
-      'type': 'Hidden',
       'value': 'vers-1',
       'binding': {
-        'type': 'zeebe:calledElement',
+        'type': 'zeebe:formDefinition',
         'property': 'versionTag'
       }
     }
@@ -65,16 +80,6 @@ export const errors = [
           emUsed: true
         },
         {
-          dataPath: '/properties/0/type',
-          emUsed: true,
-          keyword: 'const',
-          message: 'should be equal to constant',
-          params: {
-            allowedValue: 'Hidden'
-          },
-          schemaPath: '#/allOf/1/allOf/7/allOf/1/then/properties/properties/contains/properties/type/const'
-        },
-        {
           keyword: 'const',
           dataPath: '/properties/1/binding/property',
           schemaPath: '#/allOf/1/allOf/7/allOf/1/then/properties/properties/contains/properties/binding/properties/property/const',
@@ -96,7 +101,17 @@ export const errors = [
         },
         {
           keyword: 'const',
-          dataPath: '/properties/2/binding/property',
+          dataPath: '/properties/2/type',
+          schemaPath: '#/allOf/1/allOf/7/allOf/1/then/properties/properties/contains/properties/type/const',
+          params: {
+            allowedValue: 'Hidden'
+          },
+          message: 'should be equal to constant',
+          emUsed: true
+        },
+        {
+          keyword: 'const',
+          dataPath: '/properties/3/binding/property',
           schemaPath: '#/allOf/1/allOf/7/allOf/1/then/properties/properties/contains/properties/binding/properties/property/const',
           params: {
             allowedValue: 'bindingType'
@@ -106,10 +121,20 @@ export const errors = [
         },
         {
           keyword: 'const',
-          dataPath: '/properties/2/value',
+          dataPath: '/properties/3/value',
           schemaPath: '#/allOf/1/allOf/7/allOf/1/then/properties/properties/contains/properties/value/const',
           params: {
             allowedValue: 'versionTag'
+          },
+          message: 'should be equal to constant',
+          emUsed: true
+        },
+        {
+          keyword: 'const',
+          dataPath: '/properties/3/type',
+          schemaPath: '#/allOf/1/allOf/7/allOf/1/then/properties/properties/contains/properties/type/const',
+          params: {
+            allowedValue: 'Hidden'
           },
           message: 'should be equal to constant',
           emUsed: true

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/form-definition/versionTag.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/binding-type/form-definition/versionTag.js
@@ -1,0 +1,45 @@
+export const template = {
+  '$schema': 'https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json',
+  'name': 'Form Definition with FormId',
+  'id': 'formDefinitionWithFormId',
+  'appliesTo': [
+    'bpmn:Task'
+  ],
+  'elementType': {
+    'value': 'bpmn:UserTask'
+  },
+  'properties': [
+    {
+      'type': 'Hidden',
+      'binding': {
+        'type': 'zeebe:userTask',
+      }
+    },
+    {
+      'type': 'Hidden',
+      'value': 'aFormId',
+      'binding': {
+        'type': 'zeebe:formDefinition',
+        'property': 'formId'
+      }
+    },
+    {
+      'type': 'Hidden',
+      'value': 'versionTag',
+      'binding': {
+        'type': 'zeebe:formDefinition',
+        'property': 'bindingType'
+      }
+    },
+    {
+      'type': 'String',
+      'value': 'vers-1',
+      'binding': {
+        'type': 'zeebe:formDefinition',
+        'property': 'versionTag'
+      }
+    }
+  ]
+};
+
+export const errors = null;

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/called-decision-invalid-property.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/called-decision-invalid-property.js
@@ -87,7 +87,7 @@ export const errors = [
     keyword: 'enum',
     dataPath: '/properties/0/binding/property',
     schemaPath: '#/allOf/1/items/properties/binding/allOf/8/then/properties/property/enum',
-    params: { allowedValues: [ 'decisionId', 'resultVariable' ] },
+    params: { allowedValues: [ 'decisionId', 'resultVariable', 'versionTag' , 'bindingType' ] },
     message: 'should be equal to one of the allowed values',
   },
   {

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/called-element-missing-processId.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/called-element-missing-processId.js
@@ -1,0 +1,82 @@
+export const template = {
+  '$schema': 'https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json',
+  'id': 'io.camunda.examples.Payment',
+  'name': 'Payment',
+  'description': 'Payment process call activity',
+  'appliesTo': [
+    'bpmn:Task'
+  ],
+  'elementType': {
+    'value': 'bpmn:CallActivity'
+  },
+  'properties':[
+    {
+      'type': 'Hidden',
+      'value': 'deployment',
+      'binding': {
+        'type': 'zeebe:calledElement',
+        'property': 'bindingType'
+      }
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'errorMessage',
+    dataPath: '/properties',
+    schemaPath: '#/allOf/1/allOf/10/then/properties/properties/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'const',
+          dataPath: '/properties/0/binding/property',
+          schemaPath: '#/allOf/1/allOf/10/then/properties/properties/contains/properties/binding/properties/property/const',
+          params: {
+            allowedValue: 'processId'
+          },
+          message: 'should be equal to constant',
+          emUsed: true
+        },
+        {
+          keyword: 'contains',
+          dataPath: '/properties',
+          schemaPath: '#/allOf/1/allOf/10/then/properties/properties/contains',
+          params: {
+            minContains: 1
+          },
+          message: 'should contain at least 1 valid item(s)',
+          emUsed: true
+        }
+      ]
+    },
+    message: 'Binding with `property`=`processId` and `type`=`zeebe:calledElement` is required, when using a binding with `type`=`zeebe:calledElement`'
+  },
+  {
+    keyword: 'if',
+    dataPath: '',
+    schemaPath: '#/allOf/1/allOf/10/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: {
+      type: 'array'
+    },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: {
+      passingSchemas: null
+    },
+    message: 'should match exactly one schema in oneOf'
+  }
+];

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/called-element-missing-processId.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/called-element-missing-processId.js
@@ -25,13 +25,13 @@ export const errors = [
   {
     keyword: 'errorMessage',
     dataPath: '/properties',
-    schemaPath: '#/allOf/1/allOf/10/then/properties/properties/errorMessage',
+    schemaPath: '#/allOf/1/allOf/2/then/properties/properties/errorMessage',
     params: {
       errors: [
         {
           keyword: 'const',
           dataPath: '/properties/0/binding/property',
-          schemaPath: '#/allOf/1/allOf/10/then/properties/properties/contains/properties/binding/properties/property/const',
+          schemaPath: '#/allOf/1/allOf/2/then/properties/properties/contains/properties/binding/properties/property/const',
           params: {
             allowedValue: 'processId'
           },
@@ -41,7 +41,7 @@ export const errors = [
         {
           keyword: 'contains',
           dataPath: '/properties',
-          schemaPath: '#/allOf/1/allOf/10/then/properties/properties/contains',
+          schemaPath: '#/allOf/1/allOf/2/then/properties/properties/contains',
           params: {
             minContains: 1
           },
@@ -55,7 +55,7 @@ export const errors = [
   {
     keyword: 'if',
     dataPath: '',
-    schemaPath: '#/allOf/1/allOf/10/if',
+    schemaPath: '#/allOf/1/allOf/2/if',
     params: {
       failingKeyword: 'then'
     },

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/called-element-missing-property.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/called-element-missing-property.js
@@ -49,31 +49,138 @@ export const template = {
 
 export const errors = [
   {
+    keyword: 'errorMessage',
+    dataPath: '/properties',
+    schemaPath: '#/allOf/1/allOf/10/then/properties/properties/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'required',
+          dataPath: '/properties/0/binding',
+          schemaPath: '#/allOf/1/allOf/10/then/properties/properties/contains/properties/binding/required',
+          params: {
+            missingProperty: 'property'
+          },
+          message: "should have required property 'property'",
+          emUsed: true
+        },
+        {
+          keyword: 'required',
+          dataPath: '/properties/1/binding',
+          schemaPath: '#/allOf/1/allOf/10/then/properties/properties/contains/properties/binding/required',
+          params: {
+            missingProperty: 'property'
+          },
+          message: "should have required property 'property'",
+          emUsed: true
+        },
+        {
+          keyword: 'const',
+          dataPath: '/properties/1/binding/type',
+          schemaPath: '#/allOf/1/allOf/10/then/properties/properties/contains/properties/binding/properties/type/const',
+          params: {
+            allowedValue: 'zeebe:calledElement'
+          },
+          message: 'should be equal to constant',
+          emUsed: true
+        },
+        {
+          keyword: 'required',
+          dataPath: '/properties/2/binding',
+          schemaPath: '#/allOf/1/allOf/10/then/properties/properties/contains/properties/binding/required',
+          params: {
+            missingProperty: 'property'
+          },
+          message: "should have required property 'property'",
+          emUsed: true
+        },
+        {
+          keyword: 'const',
+          dataPath: '/properties/2/binding/type',
+          schemaPath: '#/allOf/1/allOf/10/then/properties/properties/contains/properties/binding/properties/type/const',
+          params: {
+            allowedValue: 'zeebe:calledElement'
+          },
+          message: 'should be equal to constant',
+          emUsed: true
+        },
+        {
+          keyword: 'required',
+          dataPath: '/properties/3/binding',
+          schemaPath: '#/allOf/1/allOf/10/then/properties/properties/contains/properties/binding/required',
+          params: {
+            missingProperty: 'property'
+          },
+          message: "should have required property 'property'",
+          emUsed: true
+        },
+        {
+          keyword: 'const',
+          dataPath: '/properties/3/binding/type',
+          schemaPath: '#/allOf/1/allOf/10/then/properties/properties/contains/properties/binding/properties/type/const',
+          params: {
+            allowedValue: 'zeebe:calledElement'
+          },
+          message: 'should be equal to constant',
+          emUsed: true
+        },
+        {
+          keyword: 'contains',
+          dataPath: '/properties',
+          schemaPath: '#/allOf/1/allOf/10/then/properties/properties/contains',
+          params: {
+            minContains: 1
+          },
+          message: 'should contain at least 1 valid item(s)',
+          emUsed: true
+        }
+      ]
+    },
+    message: 'Binding with `property`=`processId` and `type`=`zeebe:calledElement` is required, when using a binding with `type`=`zeebe:calledElement`'
+  },
+  {
+    keyword: 'if',
+    dataPath: '',
+    schemaPath: '#/allOf/1/allOf/10/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
     keyword: 'required',
     dataPath: '/properties/0/binding',
     schemaPath: '#/allOf/1/items/properties/binding/allOf/5/then/required',
-    params: { missingProperty: 'property' },
-    message: 'should have required property \'property\''
+    params: {
+      missingProperty: 'property'
+    },
+    message: "should have required property 'property'"
   },
   {
     keyword: 'if',
     dataPath: '/properties/0/binding',
     schemaPath: '#/allOf/1/items/properties/binding/allOf/5/if',
-    params: { failingKeyword: 'then' },
+    params: {
+      failingKeyword: 'then'
+    },
     message: 'should match "then" schema'
   },
   {
     keyword: 'type',
     dataPath: '',
     schemaPath: '#/oneOf/1/type',
-    params: { type: 'array' },
+    params: {
+      type: 'array'
+    },
     message: 'should be array'
   },
   {
     keyword: 'oneOf',
     dataPath: '',
     schemaPath: '#/oneOf',
-    params: { passingSchemas: null },
+    params: {
+      passingSchemas: null
+    },
     message: 'should match exactly one schema in oneOf'
   }
 ];

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/called-element-missing-property.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/called-element-missing-property.js
@@ -51,13 +51,13 @@ export const errors = [
   {
     keyword: 'errorMessage',
     dataPath: '/properties',
-    schemaPath: '#/allOf/1/allOf/10/then/properties/properties/errorMessage',
+    schemaPath: '#/allOf/1/allOf/2/then/properties/properties/errorMessage',
     params: {
       errors: [
         {
           keyword: 'required',
           dataPath: '/properties/0/binding',
-          schemaPath: '#/allOf/1/allOf/10/then/properties/properties/contains/properties/binding/required',
+          schemaPath: '#/allOf/1/allOf/2/then/properties/properties/contains/properties/binding/required',
           params: {
             missingProperty: 'property'
           },
@@ -67,7 +67,7 @@ export const errors = [
         {
           keyword: 'required',
           dataPath: '/properties/1/binding',
-          schemaPath: '#/allOf/1/allOf/10/then/properties/properties/contains/properties/binding/required',
+          schemaPath: '#/allOf/1/allOf/2/then/properties/properties/contains/properties/binding/required',
           params: {
             missingProperty: 'property'
           },
@@ -77,7 +77,7 @@ export const errors = [
         {
           keyword: 'const',
           dataPath: '/properties/1/binding/type',
-          schemaPath: '#/allOf/1/allOf/10/then/properties/properties/contains/properties/binding/properties/type/const',
+          schemaPath: '#/allOf/1/allOf/2/then/properties/properties/contains/properties/binding/properties/type/const',
           params: {
             allowedValue: 'zeebe:calledElement'
           },
@@ -87,7 +87,7 @@ export const errors = [
         {
           keyword: 'required',
           dataPath: '/properties/2/binding',
-          schemaPath: '#/allOf/1/allOf/10/then/properties/properties/contains/properties/binding/required',
+          schemaPath: '#/allOf/1/allOf/2/then/properties/properties/contains/properties/binding/required',
           params: {
             missingProperty: 'property'
           },
@@ -97,7 +97,7 @@ export const errors = [
         {
           keyword: 'const',
           dataPath: '/properties/2/binding/type',
-          schemaPath: '#/allOf/1/allOf/10/then/properties/properties/contains/properties/binding/properties/type/const',
+          schemaPath: '#/allOf/1/allOf/2/then/properties/properties/contains/properties/binding/properties/type/const',
           params: {
             allowedValue: 'zeebe:calledElement'
           },
@@ -107,7 +107,7 @@ export const errors = [
         {
           keyword: 'required',
           dataPath: '/properties/3/binding',
-          schemaPath: '#/allOf/1/allOf/10/then/properties/properties/contains/properties/binding/required',
+          schemaPath: '#/allOf/1/allOf/2/then/properties/properties/contains/properties/binding/required',
           params: {
             missingProperty: 'property'
           },
@@ -117,7 +117,7 @@ export const errors = [
         {
           keyword: 'const',
           dataPath: '/properties/3/binding/type',
-          schemaPath: '#/allOf/1/allOf/10/then/properties/properties/contains/properties/binding/properties/type/const',
+          schemaPath: '#/allOf/1/allOf/2/then/properties/properties/contains/properties/binding/properties/type/const',
           params: {
             allowedValue: 'zeebe:calledElement'
           },
@@ -127,7 +127,7 @@ export const errors = [
         {
           keyword: 'contains',
           dataPath: '/properties',
-          schemaPath: '#/allOf/1/allOf/10/then/properties/properties/contains',
+          schemaPath: '#/allOf/1/allOf/2/then/properties/properties/contains',
           params: {
             minContains: 1
           },
@@ -141,7 +141,7 @@ export const errors = [
   {
     keyword: 'if',
     dataPath: '',
-    schemaPath: '#/allOf/1/allOf/10/if',
+    schemaPath: '#/allOf/1/allOf/2/if',
     params: {
       failingKeyword: 'then'
     },

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/called-element-with-io-mapping.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/called-element-with-io-mapping.js
@@ -11,6 +11,14 @@ export const template = {
   },
   'properties':[
     {
+      'type': 'Hidden',
+      'value': 'paymentProcess',
+      'binding': {
+        'type': 'zeebe:calledElement',
+        'property': 'processId'
+      }
+    },
+    {
       'label': 'Payment ID',
       'type': 'String',
       'binding': {
@@ -19,11 +27,21 @@ export const template = {
       }
     },
     {
-      'type': 'Hidden',
-      'value': 'paymentProcess',
+      'label': 'Amount',
+      'type': 'String',
       'binding': {
-        'type': 'zeebe:calledElement',
-        'property': 'processId'
+        'type': 'zeebe:input',
+        'name': 'amount'
+      }
+    },
+    {
+      'label': 'Outcome',
+      'type': 'String',
+      'description': 'Name of variable to store the result data in.',
+      'value': 'paymentOutcome',
+      'binding': {
+        'type': 'zeebe:output',
+        'source': '=outcome'
       }
     }
   ]

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/form-definition-invalid-external-reference-and-formId.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/form-definition-invalid-external-reference-and-formId.js
@@ -38,13 +38,13 @@ export const errors = [
   {
     keyword: 'errorMessage',
     dataPath: '/properties',
-    schemaPath: '#/allOf/1/allOf/11/then/properties/properties/errorMessage',
+    schemaPath: '#/allOf/1/allOf/8/then/properties/properties/errorMessage',
     params: {
       errors: [
         {
           keyword: 'not',
           dataPath: '/properties',
-          schemaPath: '#/allOf/1/allOf/11/then/properties/properties/not',
+          schemaPath: '#/allOf/1/allOf/8/then/properties/properties/not',
           params: {},
           message: 'should NOT be valid',
           emUsed: true
@@ -56,7 +56,7 @@ export const errors = [
   {
     keyword: 'if',
     dataPath: '',
-    schemaPath: '#/allOf/1/allOf/11/if',
+    schemaPath: '#/allOf/1/allOf/8/if',
     params: {
       failingKeyword: 'then'
     },

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/form-definition-with-external-reference-invalid-property-bindingType.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/form-definition-with-external-reference-invalid-property-bindingType.js
@@ -1,0 +1,126 @@
+export const template = {
+  '$schema': 'https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json',
+  'name': 'Form Definition with external reference',
+  'id': 'formDefinitionWithExternalReference',
+  'appliesTo': [
+    'bpmn:Task'
+  ],
+  'elementType': {
+    'value': 'bpmn:UserTask'
+  },
+  'properties': [
+    {
+      'type': 'Hidden',
+      'binding': {
+        'type': 'zeebe:userTask',
+      }
+    },
+    {
+      'type': 'Hidden',
+      'value': 'aReference',
+      'binding': {
+        'type': 'zeebe:formDefinition',
+        'property': 'externalReference'
+      }
+    },
+    {
+      'type': 'Hidden',
+      'value': 'deployment',
+      'binding': {
+        'type': 'zeebe:formDefinition',
+        'property': 'bindingType'
+      }
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'errorMessage',
+    dataPath: '/properties',
+    schemaPath: '#/allOf/1/allOf/9/then/properties/properties/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'required',
+          dataPath: '/properties/0/binding',
+          schemaPath: '#/allOf/1/allOf/9/then/properties/properties/contains/properties/binding/required',
+          params: {
+            missingProperty: 'property'
+          },
+          message: "should have required property 'property'",
+          emUsed: true
+        },
+        {
+          keyword: 'const',
+          dataPath: '/properties/0/binding/type',
+          schemaPath: '#/allOf/1/allOf/9/then/properties/properties/contains/properties/binding/properties/type/const',
+          params: {
+            allowedValue: 'zeebe:formDefinition'
+          },
+          message: 'should be equal to constant',
+          emUsed: true
+        },
+        {
+          keyword: 'const',
+          dataPath: '/properties/1/binding/property',
+          schemaPath: '#/allOf/1/allOf/9/then/properties/properties/contains/properties/binding/properties/property/const',
+          params: {
+            allowedValue: 'formId'
+          },
+          message: 'should be equal to constant',
+          emUsed: true
+        },
+        {
+          keyword: 'const',
+          dataPath: '/properties/2/binding/property',
+          schemaPath: '#/allOf/1/allOf/9/then/properties/properties/contains/properties/binding/properties/property/const',
+          params: {
+            allowedValue: 'formId'
+          },
+          message: 'should be equal to constant',
+          emUsed: true
+        },
+        {
+          keyword: 'contains',
+          dataPath: '/properties',
+          schemaPath: '#/allOf/1/allOf/9/then/properties/properties/contains',
+          params: {
+            minContains: 1
+          },
+          message: 'should contain at least 1 valid item(s)',
+          emUsed: true
+        }
+      ]
+    },
+    message: '`property`=`bindingType` is not supported when using `property`=`externalReference`. Use `formId` with `bindingType`'
+  },
+  {
+    keyword: 'if',
+    dataPath: '',
+    schemaPath: '#/allOf/1/allOf/9/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: {
+      type: 'array'
+    },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: {
+      passingSchemas: null
+    },
+    message: 'should match exactly one schema in oneOf'
+  }
+]
+;

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/form-definition-with-external-reference-invalid-property-bindingType.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/form-definition-with-external-reference-invalid-property-bindingType.js
@@ -38,13 +38,13 @@ export const errors = [
   {
     keyword: 'errorMessage',
     dataPath: '/properties',
-    schemaPath: '#/allOf/1/allOf/9/then/properties/properties/errorMessage',
+    schemaPath: '#/allOf/1/allOf/7/allOf/2/then/properties/properties/errorMessage',
     params: {
       errors: [
         {
           keyword: 'required',
           dataPath: '/properties/0/binding',
-          schemaPath: '#/allOf/1/allOf/9/then/properties/properties/contains/properties/binding/required',
+          schemaPath: '#/allOf/1/allOf/7/allOf/2/then/properties/properties/contains/properties/binding/required',
           params: {
             missingProperty: 'property'
           },
@@ -54,7 +54,7 @@ export const errors = [
         {
           keyword: 'const',
           dataPath: '/properties/0/binding/type',
-          schemaPath: '#/allOf/1/allOf/9/then/properties/properties/contains/properties/binding/properties/type/const',
+          schemaPath: '#/allOf/1/allOf/7/allOf/2/then/properties/properties/contains/properties/binding/properties/type/const',
           params: {
             allowedValue: 'zeebe:formDefinition'
           },
@@ -64,7 +64,7 @@ export const errors = [
         {
           keyword: 'const',
           dataPath: '/properties/1/binding/property',
-          schemaPath: '#/allOf/1/allOf/9/then/properties/properties/contains/properties/binding/properties/property/const',
+          schemaPath: '#/allOf/1/allOf/7/allOf/2/then/properties/properties/contains/properties/binding/properties/property/const',
           params: {
             allowedValue: 'formId'
           },
@@ -74,7 +74,7 @@ export const errors = [
         {
           keyword: 'const',
           dataPath: '/properties/2/binding/property',
-          schemaPath: '#/allOf/1/allOf/9/then/properties/properties/contains/properties/binding/properties/property/const',
+          schemaPath: '#/allOf/1/allOf/7/allOf/2/then/properties/properties/contains/properties/binding/properties/property/const',
           params: {
             allowedValue: 'formId'
           },
@@ -84,7 +84,7 @@ export const errors = [
         {
           keyword: 'contains',
           dataPath: '/properties',
-          schemaPath: '#/allOf/1/allOf/9/then/properties/properties/contains',
+          schemaPath: '#/allOf/1/allOf/7/allOf/2/then/properties/properties/contains',
           params: {
             minContains: 1
           },
@@ -98,7 +98,7 @@ export const errors = [
   {
     keyword: 'if',
     dataPath: '',
-    schemaPath: '#/allOf/1/allOf/9/if',
+    schemaPath: '#/allOf/1/allOf/7/allOf/2/if',
     params: {
       failingKeyword: 'then'
     },
@@ -122,5 +122,4 @@ export const errors = [
     },
     message: 'should match exactly one schema in oneOf'
   }
-]
-;
+];

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/linked-resource-invalid-bindingType.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/linked-resource-invalid-bindingType.js
@@ -1,0 +1,52 @@
+export const template = {
+  '$schema': 'https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json',
+  'name': 'linkedResource',
+  'id': 'linkedResource',
+  'version': 1,
+  'appliesTo': [
+    'bpmn:Task'
+  ],
+  'elementType': {
+    'value': 'bpmn:ServiceTask'
+  },
+  'properties': [
+    {
+      'type': 'String',
+      'value': 'RPA',
+      'binding': {
+        'type': 'zeebe:linkedResource',
+        'linkName': 'persistedLink',
+        'property': 'resourceType'
+      }
+    },
+    {
+      'type': 'String',
+      'feel': 'optional',
+      'binding': {
+        'type': 'zeebe:linkedResource',
+        'linkName': 'persistedLink',
+        'property': 'resourceId'
+      }
+    },
+    {
+      'type': 'String',
+      'value': 'youShallNotPass',
+      'binding': {
+        'type': 'zeebe:linkedResource',
+        'linkName': 'persistedLink',
+        'property': 'bindingType'
+      }
+    },
+    {
+      'type': 'String',
+      'value': 'RPA',
+      'binding': {
+        'type': 'zeebe:linkedResource',
+        'linkName': 'removedLink',
+        'property': 'resourceType'
+      }
+    }
+  ]
+};
+
+export const errors = [ {} ];

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/linked-resource-missing-versionTag.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/linked-resource-missing-versionTag.js
@@ -1,0 +1,52 @@
+export const template = {
+  '$schema': 'https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json',
+  'name': 'linkedResource',
+  'id': 'linkedResource',
+  'version': 1,
+  'appliesTo': [
+    'bpmn:Task'
+  ],
+  'elementType': {
+    'value': 'bpmn:ServiceTask'
+  },
+  'properties': [
+    {
+      'type': 'String',
+      'value': 'RPA',
+      'binding': {
+        'type': 'zeebe:linkedResource',
+        'linkName': 'persistedLink',
+        'property': 'resourceType'
+      }
+    },
+    {
+      'type': 'String',
+      'feel': 'optional',
+      'binding': {
+        'type': 'zeebe:linkedResource',
+        'linkName': 'persistedLink',
+        'property': 'resourceId'
+      }
+    },
+    {
+      'type': 'String',
+      'value': 'versionTag',
+      'binding': {
+        'type': 'zeebe:linkedResource',
+        'linkName': 'persistedLink',
+        'property': 'bindingType'
+      }
+    },
+    {
+      'type': 'String',
+      'value': 'RPA',
+      'binding': {
+        'type': 'zeebe:linkedResource',
+        'linkName': 'removedLink',
+        'property': 'resourceType'
+      }
+    }
+  ]
+};
+
+export const errors = [ {} ];

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/linked-resource.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/linked-resource.js
@@ -29,7 +29,7 @@ export const template = {
       }
     },
     {
-      'type': 'String',
+      'type': 'Hidden',
       'value': 'versionTag',
       'binding': {
         'type': 'zeebe:linkedResource',

--- a/packages/zeebe-element-templates-json-schema/test/spec/validationSpec.js
+++ b/packages/zeebe-element-templates-json-schema/test/spec/validationSpec.js
@@ -68,7 +68,6 @@ describe('validation', function() {
     return createTest(name, file, iit.skip);
   };
 
-
   describe('should validate single template', function() {
 
     it('cloud-rest-connector');
@@ -408,7 +407,11 @@ describe('validation', function() {
 
       it('called-element-invalid-property');
 
+      it('called-element-missing-processId');
+
       it('called-element-missing-property');
+
+      it('called-element-with-io-mapping');
     });
 
     describe('zeebe:script', function() {
@@ -448,6 +451,10 @@ describe('validation', function() {
       it('linked-resource-invalid-property');
 
       it('linked-resource-missing-linkName');
+
+      it.skip('linked-resource-missing-versionTag');
+
+      it.skip('linked-resource-invalid-bindingType');
 
     });
 
@@ -508,6 +515,8 @@ describe('validation', function() {
 
       it('form-definition-with-external-reference-feel');
 
+      it('form-definition-with-external-reference-invalid-property-bindingType');
+
       it('form-definition-with-formId');
 
       it('form-definition-invalid-type-number');
@@ -521,13 +530,13 @@ describe('validation', function() {
 
       it('called-decision');
 
-      it('called-decision-incorrect-property');
-
       it('called-decision-missing-decisionId');
 
       it('called-decision-missing-resultVariable');
 
       it('called-decision-missing-element-type');
+
+      it('called-decision-invalid-property');
 
       it('called-decision-invalid-element-type');
 
@@ -557,6 +566,46 @@ describe('validation', function() {
 
       it('property/invalid-missing-feel-condition-expression');
     });
+
+
+    describe('property bindingType', function() {
+
+      const testCases = [
+        'deployment',
+        'dropdown',
+        'invalid-feel',
+        'invalid-input-type',
+        'invalid-value',
+        'latest',
+        'missing-property-binding-type',
+        'missing-property-versionTag',
+        'versionTag',
+        'versionTag-invalid-feel',
+        'versionTag-invalid-input-type'
+      ];
+
+      describe('called decision', function() {
+
+        for (const testCase of testCases) {
+          it(`binding-type/called-decision/${testCase}`);
+        }
+      });
+
+
+      describe('form definition', function() {
+        for (const testCase of testCases) {
+          it(`binding-type/form-definition/${testCase}`);
+        }
+      });
+
+
+      describe('called element', function() {
+        for (const testCase of testCases) {
+          it(`binding-type/called-element/${testCase}`);
+        }
+      });
+
+    });
   });
 
 });
@@ -572,3 +621,4 @@ function printNested(object) {
     colors: true
   }));
 }
+

--- a/packages/zeebe-element-templates-json-schema/test/spec/validationSpec.js
+++ b/packages/zeebe-element-templates-json-schema/test/spec/validationSpec.js
@@ -582,6 +582,7 @@ describe('validation', function() {
         'missing-property-versionTag',
         'versionTag',
         'versionTag-invalid-feel',
+        'versionTag-invalid-unconditional',
         'versionTag-invalid-input-type'
       ];
 

--- a/packages/zeebe-element-templates-json-schema/test/spec/validationSpec.js
+++ b/packages/zeebe-element-templates-json-schema/test/spec/validationSpec.js
@@ -586,6 +586,11 @@ describe('validation', function() {
         'versionTag-invalid-input-type'
       ];
 
+      describe('additional property', function() {
+
+        it('binding-type/additional-property');
+      });
+
       describe('called decision', function() {
 
         for (const testCase of testCases) {

--- a/packages/zeebe-element-templates-json-schema/test/spec/validationSpec.js
+++ b/packages/zeebe-element-templates-json-schema/test/spec/validationSpec.js
@@ -573,6 +573,7 @@ describe('validation', function() {
       const testCases = [
         'deployment',
         'dropdown',
+        'dropdown-invalid-choices',
         'invalid-feel',
         'invalid-input-type',
         'invalid-value',


### PR DESCRIPTION
### Proposed Changes
Add support `bindingType` property for `calledDecision`, `calledElement`, and `formDefinition`

- [x] property `#bindingType` supports "latest", "deployment", and "versionTag" as a value and can be templated in
  - [x] `zeebe:CalledDecision`  
  - [x] `zeebe:CalledElement`  
  - [x] `zeebe:FormDefinition`  
      - [x] Only if this is set via `formId`. not possible for `externalReference`  
- [x]  the property `#versionTag` is a String, Hidden, Text, or Dropdown and can be templated in 
  - [x] `zeebe:CalledDecision`  
  - [x] `zeebe:CalledElement`  
  - [x] `zeebe:FormDefinition`  
- [x] the property `#versionTag` can only be templated if #bindingType is "versionTag" and MUST be present in that case.

`linkedResource` excluded from this PR. See [issue comment for more details.](https://github.com/camunda/camunda-modeler/issues/5027#issuecomment-3000716091)
related to https://github.com/camunda/camunda-modeler/issues/5027
<!--
Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.
--> 

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->