### PR TITLE
feat: require `feel` for bpmn:Expression properties

### DIFF
--- a/packages/zeebe-element-templates-json-schema/src/defs/feel-required.json
+++ b/packages/zeebe-element-templates-json-schema/src/defs/feel-required.json
@@ -1,0 +1,226 @@
+{
+  "allOf": [
+    {
+      "if": {
+        "anyOf": [
+          {
+            "required": [
+              "elementType"
+            ],
+            "properties": {
+              "elementType": {
+                "required": [
+                  "value"
+                ],
+                "properties": {
+                  "value": {
+                    "const": "bpmn:AdHocSubProcess"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "required": [
+              "appliesTo"
+            ],
+            "properties": {
+              "appliesTo": {
+                "const": [
+                  "bpmn:AdHocSubProcess"
+                ]
+              }
+            }
+          }
+        ]
+      },
+      "then": {
+        "properties": {
+          "properties": {
+            "items": {
+              "if": {
+                "properties": {
+                  "binding": {
+                    "properties": {
+                      "type": {
+                        "const": "property"
+                      },
+                      "name": {
+                        "const": "completionCondition"
+                      }
+                    },
+                    "required": [
+                      "type",
+                      "name"
+                    ]
+                  }
+                },
+                "required": [
+                  "binding"
+                ]
+              },
+              "then": {
+                "properties": {
+                  "feel": {
+                    "const": "required"
+                  }
+                },
+                "required": [
+                  "feel"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "anyOf": [
+          {
+            "required": [
+              "elementType"
+            ],
+            "properties": {
+              "elementType": {
+                "required": [
+                  "value"
+                ],
+                "properties": {
+                  "value": {
+                    "const": "bpmn:SequenceFlow"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "required": [
+              "appliesTo"
+            ],
+            "properties": {
+              "appliesTo": {
+                "const": [
+                  "bpmn:SequenceFlow"
+                ]
+              }
+            }
+          }
+        ]
+      },
+      "then": {
+        "properties": {
+          "properties": {
+            "items": {
+              "if": {
+                "properties": {
+                  "binding": {
+                    "properties": {
+                      "type": {
+                        "const": "property"
+                      },
+                      "name": {
+                        "const": "conditionExpression"
+                      }
+                    },
+                    "required": [
+                      "type",
+                      "name"
+                    ]
+                  }
+                },
+                "required": [
+                  "binding"
+                ]
+              },
+              "then": {
+                "properties": {
+                  "feel": {
+                    "const": "required"
+                  }
+                },
+                "required": [
+                  "feel"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "anyOf": [
+          {
+            "required": [
+              "elementType"
+            ],
+            "properties": {
+              "elementType": {
+                "required": [
+                  "value"
+                ],
+                "properties": {
+                  "value": {
+                    "const": "bpmn:ComplexGateway"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "required": [
+              "appliesTo"
+            ],
+            "properties": {
+              "appliesTo": {
+                "const": [
+                  "bpmn:ComplexGateway"
+                ]
+              }
+            }
+          }
+        ]
+      },
+      "then": {
+        "properties": {
+          "properties": {
+            "items": {
+              "if": {
+                "properties": {
+                  "binding": {
+                    "properties": {
+                      "type": {
+                        "const": "property"
+                      },
+                      "name": {
+                        "const": "activationCondition"
+                      }
+                    },
+                    "required": [
+                      "type",
+                      "name"
+                    ]
+                  }
+                },
+                "required": [
+                  "binding"
+                ]
+              },
+              "then": {
+                "properties": {
+                  "feel": {
+                    "const": "required"
+                  }
+                },
+                "required": [
+                  "feel"
+                ]
+              }
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/packages/zeebe-element-templates-json-schema/src/schema.json
+++ b/packages/zeebe-element-templates-json-schema/src/schema.json
@@ -21,6 +21,9 @@
         },
         {
           "$ref": "src/defs/template.json"
+        },
+        {
+          "$ref": "src/defs/feel-required.json"
         }
       ],
       "properties": {

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/property/invalid-missing-feel-activation-condition.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/property/invalid-missing-feel-activation-condition.js
@@ -1,0 +1,63 @@
+export const template = {
+  'name': 'Activation condition',
+  'id': 'com.camunda.example.activationCondition',
+  'appliesTo': [
+    'bpmn:ComplexGateway',
+  ],
+  'properties': [
+    {
+      'binding': {
+        'type': 'property',
+        'name': 'activationCondition'
+      }
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'required',
+    dataPath: '/properties/0',
+    schemaPath: '#/allOf/2/allOf/2/then/properties/properties/items/then/required',
+    params: {
+      missingProperty: 'feel'
+    },
+    message: "should have required property 'feel'"
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/0',
+    schemaPath: '#/allOf/2/allOf/2/then/properties/properties/items/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'if',
+    dataPath: '',
+    schemaPath: '#/allOf/2/allOf/2/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: {
+      type: 'array'
+    },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: {
+      passingSchemas: null
+    },
+    message: 'should match exactly one schema in oneOf'
+  }
+];

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/property/invalid-missing-feel-completion-condition.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/property/invalid-missing-feel-completion-condition.js
@@ -1,0 +1,63 @@
+export const template = {
+  'name': 'Completion condition',
+  'id': 'com.camunda.example.completionCondition',
+  'appliesTo': [
+    'bpmn:AdHocSubProcess',
+  ],
+  'properties': [
+    {
+      'binding': {
+        'type': 'property',
+        'name': 'completionCondition'
+      }
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'required',
+    dataPath: '/properties/0',
+    schemaPath: '#/allOf/2/allOf/0/then/properties/properties/items/then/required',
+    params: {
+      missingProperty: 'feel'
+    },
+    message: "should have required property 'feel'"
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/0',
+    schemaPath: '#/allOf/2/allOf/0/then/properties/properties/items/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'if',
+    dataPath: '',
+    schemaPath: '#/allOf/2/allOf/0/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: {
+      type: 'array'
+    },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: {
+      passingSchemas: null
+    },
+    message: 'should match exactly one schema in oneOf'
+  }
+];

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/property/invalid-missing-feel-condition-expression.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/property/invalid-missing-feel-condition-expression.js
@@ -1,0 +1,63 @@
+export const template = {
+  'name': 'Condition expression',
+  'id': 'com.camunda.example.conditionExpression',
+  'appliesTo': [
+    'bpmn:SequenceFlow',
+  ],
+  'properties': [
+    {
+      'binding': {
+        'type': 'property',
+        'name': 'conditionExpression'
+      }
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'required',
+    dataPath: '/properties/0',
+    schemaPath: '#/allOf/2/allOf/1/then/properties/properties/items/then/required',
+    params: {
+      missingProperty: 'feel'
+    },
+    message: "should have required property 'feel'"
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/0',
+    schemaPath: '#/allOf/2/allOf/1/then/properties/properties/items/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'if',
+    dataPath: '',
+    schemaPath: '#/allOf/2/allOf/1/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: {
+      type: 'array'
+    },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: {
+      passingSchemas: null
+    },
+    message: 'should match exactly one schema in oneOf'
+  }
+];

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/property/valid-feel-required.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/property/valid-feel-required.js
@@ -1,0 +1,55 @@
+export const template = [
+  {
+    'name': 'Activation condition',
+    'id': 'com.camunda.example.activationCondition',
+    'appliesTo': [
+      'bpmn:ComplexGateway',
+    ],
+    'properties': [
+      {
+        'type': 'String',
+        'feel': 'required',
+        'binding': {
+          'type': 'property',
+          'name': 'activationCondition'
+        }
+      }
+    ]
+  },
+  {
+    'name': 'Completion condition',
+    'id': 'com.camunda.example.completionCondition',
+    'appliesTo': [
+      'bpmn:AdHocSubProcess',
+    ],
+    'properties': [
+      {
+        'type': 'String',
+        'feel': 'required',
+        'binding': {
+          'type': 'property',
+          'name': 'completionCondition'
+        }
+      }
+    ]
+  },
+  {
+    'name': 'Condition expression',
+    'id': 'com.camunda.example.conditionExpression',
+    'appliesTo': [
+      'bpmn:SequenceFlow',
+    ],
+    'properties': [
+      {
+        'type': 'String',
+        'feel': 'required',
+        'binding': {
+          'type': 'property',
+          'name': 'conditionExpression'
+        }
+      }
+    ]
+  }
+];
+
+export const errors = null;

--- a/packages/zeebe-element-templates-json-schema/test/spec/validationSpec.js
+++ b/packages/zeebe-element-templates-json-schema/test/spec/validationSpec.js
@@ -487,6 +487,7 @@ describe('validation', function() {
 
     });
 
+
     describe('zeebe:formDefinition', function() {
 
       it('form-definition-invalid-element-type');
@@ -507,6 +508,7 @@ describe('validation', function() {
 
     });
 
+
     describe('zeebe:calledDecision', function() {
 
       it('called-decision');
@@ -524,6 +526,7 @@ describe('validation', function() {
       it('called-decision-invalid-feel-resultVariable');
     });
 
+
     describe('bpmn:businessRuleTask', function() {
       it('business-rule-task-task-definition');
 
@@ -532,6 +535,20 @@ describe('validation', function() {
       it('business-rule-task-conflicting-deprecated-bindings');
     });
 
+
+    describe('property', function() {
+
+      it('property/valid-feel-required');
+
+
+      it('property/invalid-missing-feel-completion-condition');
+
+
+      it('property/invalid-missing-feel-activation-condition');
+
+
+      it('property/invalid-missing-feel-condition-expression');
+    });
   });
 
 });


### PR DESCRIPTION
Related to https://github.com/bpmn-io/bpmn-js-element-templates/pull/161

### Proposed Changes

This PR makes sure that the `bpmn:Expression` properties use always `feel: required`.

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->