### PR TITLE
fix: don't complain about incorrect binding type

### DIFF
--- a/packages/zeebe-element-templates-json-schema/src/defs/template.json
+++ b/packages/zeebe-element-templates-json-schema/src/defs/template.json
@@ -426,9 +426,9 @@
             }
           },
           {
-            "not": {
+            "properties": {
               "properties": {
-                "properties": {
+                "not": {
                   "contains": {
                     "properties": {
                       "binding": {
@@ -450,15 +450,12 @@
                     ]
                   }
                 }
-              },
-              "required": [
-                "properties"
-              ]
-            }
+              }
+            },
+            "required": [
+              "properties"
+            ]
           }
-        ],
-        "required": [
-          "properties"
         ]
       }
     },
@@ -569,9 +566,9 @@
             }
           },
           {
-            "not": {
+            "properties": {
               "properties": {
-                "properties": {
+                "not": {
                   "contains": {
                     "properties": {
                       "binding": {
@@ -593,15 +590,12 @@
                     ]
                   }
                 }
-              },
-              "required": [
-                "properties"
-              ]
-            }
+              }
+            },
+            "required": [
+              "properties"
+            ]
           }
-        ],
-        "required": [
-          "properties"
         ]
       }
     }

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/business-rule-task-conflicting-bindings.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/business-rule-task-conflicting-bindings.js
@@ -44,48 +44,48 @@ export const template = {
 
 export const errors = [
   {
-    'keyword': 'errorMessage',
-    'dataPath': '',
-    'schemaPath': '#/allOf/1/allOf/5/then/allOf/2/errorMessage',
-    'params': {
-      'errors': [
+    keyword: 'errorMessage',
+    dataPath: '',
+    schemaPath: '#/allOf/1/allOf/5/then/allOf/2/errorMessage',
+    params: {
+      errors: [
         {
-          'keyword': 'not',
-          'dataPath': '',
-          'schemaPath': '#/allOf/1/allOf/5/then/allOf/2/not',
-          'params': {},
-          'message': 'should NOT be valid',
-          'emUsed': true
+          keyword: 'not',
+          dataPath: '/properties',
+          schemaPath: '#/allOf/1/allOf/5/then/allOf/2/properties/properties/not',
+          params: {},
+          message: 'should NOT be valid',
+          emUsed: true
         }
       ]
     },
-    'message': 'Binding type "zeebe:taskDefinition" or "zeebe:taskDefinition:type" cannot be set when binding type "zeebe:calledDecision" is set.'
+    message: 'Binding type "zeebe:taskDefinition" or "zeebe:taskDefinition:type" cannot be set when binding type "zeebe:calledDecision" is set.'
   },
   {
-    'keyword': 'if',
-    'dataPath': '',
-    'schemaPath': '#/allOf/1/allOf/5/if',
-    'params': {
-      'failingKeyword': 'then'
+    keyword: 'if',
+    dataPath: '',
+    schemaPath: '#/allOf/1/allOf/5/if',
+    params: {
+      failingKeyword: 'then'
     },
-    'message': 'should match "then" schema'
+    message: 'should match "then" schema'
   },
   {
-    'keyword': 'type',
-    'dataPath': '',
-    'schemaPath': '#/oneOf/1/type',
-    'params': {
-      'type': 'array'
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: {
+      type: 'array'
     },
-    'message': 'should be array'
+    message: 'should be array'
   },
   {
-    'keyword': 'oneOf',
-    'dataPath': '',
-    'schemaPath': '#/oneOf',
-    'params': {
-      'passingSchemas': null
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: {
+      passingSchemas: null
     },
-    'message': 'should match exactly one schema in oneOf'
+    message: 'should match exactly one schema in oneOf'
   }
 ];

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/business-rule-task-conflicting-deprecated-bindings.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/business-rule-task-conflicting-deprecated-bindings.js
@@ -43,48 +43,48 @@ export const template = {
 
 export const errors = [
   {
-    'keyword': 'errorMessage',
-    'dataPath': '',
-    'schemaPath': '#/allOf/1/allOf/5/then/allOf/2/errorMessage',
-    'params': {
-      'errors': [
+    keyword: 'errorMessage',
+    dataPath: '',
+    schemaPath: '#/allOf/1/allOf/5/then/allOf/2/errorMessage',
+    params: {
+      errors: [
         {
-          'keyword': 'not',
-          'dataPath': '',
-          'schemaPath': '#/allOf/1/allOf/5/then/allOf/2/not',
-          'params': {},
-          'message': 'should NOT be valid',
-          'emUsed': true
+          keyword: 'not',
+          dataPath: '/properties',
+          schemaPath: '#/allOf/1/allOf/5/then/allOf/2/properties/properties/not',
+          params: {},
+          message: 'should NOT be valid',
+          emUsed: true
         }
       ]
     },
-    'message': 'Binding type "zeebe:taskDefinition" or "zeebe:taskDefinition:type" cannot be set when binding type "zeebe:calledDecision" is set.'
+    message: 'Binding type "zeebe:taskDefinition" or "zeebe:taskDefinition:type" cannot be set when binding type "zeebe:calledDecision" is set.'
   },
   {
-    'keyword': 'if',
-    'dataPath': '',
-    'schemaPath': '#/allOf/1/allOf/5/if',
-    'params': {
-      'failingKeyword': 'then'
+    keyword: 'if',
+    dataPath: '',
+    schemaPath: '#/allOf/1/allOf/5/if',
+    params: {
+      failingKeyword: 'then'
     },
-    'message': 'should match "then" schema'
+    message: 'should match "then" schema'
   },
   {
-    'keyword': 'type',
-    'dataPath': '',
-    'schemaPath': '#/oneOf/1/type',
-    'params': {
-      'type': 'array'
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: {
+      type: 'array'
     },
-    'message': 'should be array'
+    message: 'should be array'
   },
   {
-    'keyword': 'oneOf',
-    'dataPath': '',
-    'schemaPath': '#/oneOf',
-    'params': {
-      'passingSchemas': null
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: {
+      passingSchemas: null
     },
-    'message': 'should match exactly one schema in oneOf'
+    message: 'should match exactly one schema in oneOf'
   }
 ];

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/feel-missing-type-multiple-templates.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/feel-missing-type-multiple-templates.js
@@ -1,0 +1,58 @@
+export const template = [
+  {
+    name: 'Pattern Template',
+    id: 'com.example.PatternTemplate',
+    appliesTo: [
+      'bpmn:Task'
+    ],
+    properties: [
+      {
+        label: 'Text (static)',
+        binding: {
+          type: 'property',
+          name: 'prop'
+        },
+        feel: 'required'
+      }
+    ]
+  }
+];
+
+export const errors = [
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/type',
+    params: {
+      type: 'object'
+    },
+    message: 'should be object'
+  },
+  {
+    keyword: 'required',
+    dataPath: '/0/properties/0',
+    schemaPath: '#/allOf/1/items/allOf/4/then/required',
+    params: {
+      missingProperty: 'type'
+    },
+    message: "should have required property 'type'"
+  },
+  {
+    keyword: 'if',
+    dataPath: '/0/properties/0',
+    schemaPath: '#/allOf/1/items/allOf/4/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: {
+      passingSchemas: null
+    },
+    message: 'should match exactly one schema in oneOf'
+  }
+];

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/feel-missing-type.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/feel-missing-type.js
@@ -1,0 +1,56 @@
+export const template = {
+  name: 'Pattern Template',
+  id: 'com.example.PatternTemplate',
+  appliesTo: [
+    'bpmn:Task'
+  ],
+  properties: [
+    {
+      label: 'Text (static)',
+      binding: {
+        type: 'property',
+        name: 'prop'
+      },
+      feel: 'required'
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'required',
+    dataPath: '/properties/0',
+    schemaPath: '#/allOf/1/items/allOf/4/then/required',
+    params: {
+      missingProperty: 'type'
+    },
+    message: "should have required property 'type'"
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/0',
+    schemaPath: '#/allOf/1/items/allOf/4/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: {
+      type: 'array'
+    },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: {
+      passingSchemas: null
+    },
+    message: 'should match exactly one schema in oneOf'
+  }
+];

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/script-task-conflicting-bindings.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/script-task-conflicting-bindings.js
@@ -43,48 +43,48 @@ export const template = {
 
 export const errors = [
   {
-    'keyword': 'errorMessage',
-    'dataPath': '',
-    'schemaPath': '#/allOf/1/allOf/6/then/allOf/2/errorMessage',
-    'params': {
-      'errors': [
+    keyword: 'errorMessage',
+    dataPath: '',
+    schemaPath: '#/allOf/1/allOf/6/then/allOf/2/errorMessage',
+    params: {
+      errors: [
         {
-          'keyword': 'not',
-          'dataPath': '',
-          'schemaPath': '#/allOf/1/allOf/6/then/allOf/2/not',
-          'params': {},
-          'message': 'should NOT be valid',
-          'emUsed': true
+          keyword: 'not',
+          dataPath: '/properties',
+          schemaPath: '#/allOf/1/allOf/6/then/allOf/2/properties/properties/not',
+          params: {},
+          message: 'should NOT be valid',
+          emUsed: true
         }
       ]
     },
-    'message': 'Binding type "zeebe:taskDefinition" or "zeebe:taskDefinition:type" cannot be set when binding type "zeebe:script" is set.'
+    message: 'Binding type "zeebe:taskDefinition" or "zeebe:taskDefinition:type" cannot be set when binding type "zeebe:script" is set.'
   },
   {
-    'keyword': 'if',
-    'dataPath': '',
-    'schemaPath': '#/allOf/1/allOf/6/if',
-    'params': {
-      'failingKeyword': 'then'
+    keyword: 'if',
+    dataPath: '',
+    schemaPath: '#/allOf/1/allOf/6/if',
+    params: {
+      failingKeyword: 'then'
     },
-    'message': 'should match "then" schema'
+    message: 'should match "then" schema'
   },
   {
-    'keyword': 'type',
-    'dataPath': '',
-    'schemaPath': '#/oneOf/1/type',
-    'params': {
-      'type': 'array'
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: {
+      type: 'array'
     },
-    'message': 'should be array'
+    message: 'should be array'
   },
   {
-    'keyword': 'oneOf',
-    'dataPath': '',
-    'schemaPath': '#/oneOf',
-    'params': {
-      'passingSchemas': null
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: {
+      passingSchemas: null
     },
-    'message': 'should match exactly one schema in oneOf'
+    message: 'should match exactly one schema in oneOf'
   }
 ];

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/script-task-conflicting-deprecated-bindings.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/script-task-conflicting-deprecated-bindings.js
@@ -42,48 +42,48 @@ export const template = {
 
 export const errors = [
   {
-    'keyword': 'errorMessage',
-    'dataPath': '',
-    'schemaPath': '#/allOf/1/allOf/6/then/allOf/2/errorMessage',
-    'params': {
-      'errors': [
+    keyword: 'errorMessage',
+    dataPath: '',
+    schemaPath: '#/allOf/1/allOf/6/then/allOf/2/errorMessage',
+    params: {
+      errors: [
         {
-          'keyword': 'not',
-          'dataPath': '',
-          'schemaPath': '#/allOf/1/allOf/6/then/allOf/2/not',
-          'params': {},
-          'message': 'should NOT be valid',
-          'emUsed': true
+          keyword: 'not',
+          dataPath: '/properties',
+          schemaPath: '#/allOf/1/allOf/6/then/allOf/2/properties/properties/not',
+          params: {},
+          message: 'should NOT be valid',
+          emUsed: true
         }
       ]
     },
-    'message': 'Binding type "zeebe:taskDefinition" or "zeebe:taskDefinition:type" cannot be set when binding type "zeebe:script" is set.'
+    message: 'Binding type "zeebe:taskDefinition" or "zeebe:taskDefinition:type" cannot be set when binding type "zeebe:script" is set.'
   },
   {
-    'keyword': 'if',
-    'dataPath': '',
-    'schemaPath': '#/allOf/1/allOf/6/if',
-    'params': {
-      'failingKeyword': 'then'
+    keyword: 'if',
+    dataPath: '',
+    schemaPath: '#/allOf/1/allOf/6/if',
+    params: {
+      failingKeyword: 'then'
     },
-    'message': 'should match "then" schema'
+    message: 'should match "then" schema'
   },
   {
-    'keyword': 'type',
-    'dataPath': '',
-    'schemaPath': '#/oneOf/1/type',
-    'params': {
-      'type': 'array'
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: {
+      type: 'array'
     },
-    'message': 'should be array'
+    message: 'should be array'
   },
   {
-    'keyword': 'oneOf',
-    'dataPath': '',
-    'schemaPath': '#/oneOf',
-    'params': {
-      'passingSchemas': null
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: {
+      passingSchemas: null
     },
-    'message': 'should match exactly one schema in oneOf'
+    message: 'should match exactly one schema in oneOf'
   }
 ];

--- a/packages/zeebe-element-templates-json-schema/test/spec/validationSpec.js
+++ b/packages/zeebe-element-templates-json-schema/test/spec/validationSpec.js
@@ -158,6 +158,12 @@ describe('validation', function() {
     it('feel');
 
 
+    it('feel-missing-type');
+
+
+    it('feel-missing-type-multiple-templates');
+
+
     it('feel-type-mismatch');
 
 


### PR DESCRIPTION
### Proposed Changes
I made the "not" clauses less broadly applicable. However, i am still not sure what casuses the "then"clause to be evaluated in the first place as the properties array never contains an element with binding type `calledDecision` or `script`. 
Presumably, it's somehow not strict enough when evaluating an array of element templates, but I am a bit at a loss why. 
<!--
Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.
--> 

Related to https://github.com/camunda/element-templates-json-schema/pull/176#issuecomment-3019586270

### Checklist

To ensure you provided everything we need to look at your PR:

* [ ] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->