### PR TITLE
ci: fail integration part if cannot fetch templates

### DIFF
--- a/tasks/fetch-connector-templates.js
+++ b/tasks/fetch-connector-templates.js
@@ -75,6 +75,6 @@ async function fetchTemplate(templateMetadata, id) {
 
     return templateJson;
   } catch (error) {
-    throw new Error(`Failed to parse template ${ id } version ${ templateMetadata.version } fetched from ${ ref }`, { cause: error });
+    throw new Error(`Failed to parse template ${ id } version ${ templateMetadata.version } fetched from ${ ref } (error: ${error.message})`);
   }
 }


### PR DESCRIPTION
Related to https://github.com/camunda/element-templates-json-schema/pull/182#discussion_r2222732500

### Proposed Changes

We will fail early if marketplace endpoint is unreachable, and collect individual errors so that we can report all unavailable templates.

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->