### PR TITLE
feat: add support for `priority-definition`

### DIFF
--- a/packages/zeebe-element-templates-json-schema/src/defs/properties.json
+++ b/packages/zeebe-element-templates-json-schema/src/defs/properties.json
@@ -62,7 +62,8 @@
                     "zeebe:formDefinition",
                     "zeebe:calledDecision",
                     "zeebe:script",
-                    "zeebe:assignmentDefinition"
+                    "zeebe:assignmentDefinition",
+                    "zeebe:priorityDefinition"
                   ]
                 }
               },
@@ -615,6 +616,9 @@
       },
       {
         "$ref": "./properties/assignmentDefinition.json"
+      },
+      {
+        "$ref": "./properties/priorityDefinition.json"
       }
     ],
     "properties": {
@@ -832,6 +836,9 @@
             "$ref": "./properties/binding/assignmentDefinition.json"
           },
           {
+            "$ref": "./properties/binding/priorityDefinition.json"
+          },
+          {
             "$ref": "examples.json#/binding"
           }
         ],
@@ -856,7 +863,8 @@
               "zeebe:formDefinition",
               "zeebe:calledDecision",
               "zeebe:script",
-              "zeebe:assignmentDefinition"
+              "zeebe:assignmentDefinition",
+              "zeebe:priorityDefinition"
             ]
           },
           "name": {

--- a/packages/zeebe-element-templates-json-schema/src/defs/properties/binding/priorityDefinition.json
+++ b/packages/zeebe-element-templates-json-schema/src/defs/properties/binding/priorityDefinition.json
@@ -1,0 +1,22 @@
+{
+  "if": {
+    "properties": {
+      "type": {
+        "const": "zeebe:priorityDefinition"
+      }
+    },
+    "required": [
+      "type"
+    ]
+  },
+  "then": {
+    "properties": {
+      "property": {
+        "const": "priority"
+      }
+    },
+    "required": [
+      "property"
+    ]
+  }
+}

--- a/packages/zeebe-element-templates-json-schema/src/defs/properties/priorityDefinition.json
+++ b/packages/zeebe-element-templates-json-schema/src/defs/properties/priorityDefinition.json
@@ -1,0 +1,185 @@
+{
+  "allOf": [
+    {
+      "if": {
+        "type": "object",
+        "properties": {
+          "binding": {
+            "properties": {
+              "type": {
+                "const": "zeebe:priorityDefinition"
+              },
+              "property": {
+                "const": "priority"
+              }
+            },
+            "required": [
+              "type",
+              "property"
+            ]
+          }
+        },
+        "required": [
+          "binding"
+        ]
+      },
+      "then": {
+        "anyOf": [
+          {
+            "required": [
+              "type"
+            ],
+            "properties": {
+              "type": {
+                "enum": [
+                  "Hidden",
+                  "Number",
+                  "Dropdown"
+                ]
+              }
+            }
+          },
+          {
+            "required": [
+              "type",
+              "feel"
+            ],
+            "properties": {
+              "type": {
+                "enum": [
+                  "String",
+                  "Text"
+                ]
+              },
+              "feel": {
+                "const": "required"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "if": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "const": "Number"
+          },
+          "binding": {
+            "properties": {
+              "type": {
+                "const": "zeebe:priorityDefinition"
+              },
+              "property": {
+                "const": "priority"
+              }
+            },
+            "required": [
+              "type",
+              "property"
+            ]
+          }
+        },
+        "required": [
+          "binding",
+          "value",
+          "type"
+        ]
+      },
+      "then": {
+        "properties": {
+          "value": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 100
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "enum": [
+              "Hidden",
+              "Dropdown"
+            ]
+          },
+          "binding": {
+            "properties": {
+              "type": {
+                "const": "zeebe:priorityDefinition"
+              },
+              "property": {
+                "const": "priority"
+              }
+            },
+            "required": [
+              "type",
+              "property"
+            ]
+          }
+        },
+        "required": [
+          "binding",
+          "value",
+          "type"
+        ]
+      },
+      "then": {
+        "properties": {
+          "value": {
+            "type": "string",
+            "pattern": "^(100|[1-9]?[0-9])$"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "const": "Dropdown"
+          },
+          "binding": {
+            "properties": {
+              "type": {
+                "const": "zeebe:priorityDefinition"
+              },
+              "property": {
+                "const": "priority"
+              }
+            },
+            "required": [
+              "type",
+              "property"
+            ]
+          },
+          "choices": {}
+        },
+        "required": [
+          "binding",
+          "type",
+          "choices"
+        ]
+      },
+      "then": {
+        "properties": {
+          "choices": {
+            "items": {
+              "properties": {
+                "value": {
+                  "type": "string",
+                  "pattern": "^(100|[1-9]?[0-9])$"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/packages/zeebe-element-templates-json-schema/src/defs/template.json
+++ b/packages/zeebe-element-templates-json-schema/src/defs/template.json
@@ -300,7 +300,8 @@
                     "type": {
                       "enum": [
                         "zeebe:formDefinition",
-                        "zeebe:assignmentDefinition"
+                        "zeebe:assignmentDefinition",
+                        "zeebe:priorityDefinition"
                       ]
                     }
                   },

--- a/packages/zeebe-element-templates-json-schema/src/error-messages.json
+++ b/packages/zeebe-element-templates-json-schema/src/error-messages.json
@@ -149,7 +149,7 @@
       "properties",
       "type"
     ],
-    "errorMessage": "invalid property.binding type ${0}; must be any of { property, zeebe:taskDefinition:type, zeebe:input, zeebe:output, zeebe:property, zeebe:taskHeader, bpmn:Message#property, bpmn:Message#zeebe:subscription#property, zeebe:taskDefinition, zeebe:calledElement, zeebe:linkedResource, zeebe:userTask, zeebe:formDefinition, zeebe:calledDecision, zeebe:script, zeebe:assignmentDefinition }"
+    "errorMessage": "invalid property.binding type ${0}; must be any of { property, zeebe:taskDefinition:type, zeebe:input, zeebe:output, zeebe:property, zeebe:taskHeader, bpmn:Message#property, bpmn:Message#zeebe:subscription#property, zeebe:taskDefinition, zeebe:calledElement, zeebe:linkedResource, zeebe:userTask, zeebe:formDefinition, zeebe:calledDecision, zeebe:script, zeebe:assignmentDefinition, zeebe:priorityDefinition }"
   },
   {
     "path": [
@@ -218,7 +218,7 @@
       "properties",
       "properties"
     ],
-    "errorMessage": "When using \"zeebe:formDefinition\" or \"zeebe:assignmentDefinition\", \"zeebe:userTask\" must be set on the same element"
+    "errorMessage": "When using ${0/0/binding/type}, \"zeebe:userTask\" must be set on the same element"
   },
   {
     "path": [
@@ -444,5 +444,42 @@
       "properties"
     ],
     "errorMessage": "\"formId\" and \"externalReference\" cannot be used together"
+  },
+  {
+    "path": [
+      "definitions",
+      "properties",
+      "allOf",
+      1,
+      "items",
+      "allOf",
+      22,
+      "allOf",
+      2,
+      "then",
+      "properties",
+      "value"
+    ],
+    "errorMessage": "Invalid value for priority. Must be between 0 and 100."
+  },
+  {
+    "path": [
+      "definitions",
+      "properties",
+      "allOf",
+      1,
+      "items",
+      "allOf",
+      22,
+      "allOf",
+      3,
+      "then",
+      "properties",
+      "choices",
+      "items",
+      "properties",
+      "value"
+    ],
+    "errorMessage": "Invalid value for priority. Must be between 0 and 100."
   }
 ]

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/assignment-definition/missing-zeebe-user-task.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/assignment-definition/missing-zeebe-user-task.js
@@ -84,7 +84,7 @@ export const errors = [
         }
       ]
     },
-    message: 'When using "zeebe:formDefinition" or "zeebe:assignmentDefinition", "zeebe:userTask" must be set on the same element'
+    message: 'When using "zeebe:assignmentDefinition", "zeebe:userTask" must be set on the same element'
   },
   {
     keyword: 'if',

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/invalid-binding-type.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/invalid-binding-type.js
@@ -52,7 +52,8 @@ export const errors = [
               'zeebe:formDefinition',
               'zeebe:calledDecision',
               'zeebe:script',
-              'zeebe:assignmentDefinition'
+              'zeebe:assignmentDefinition',
+              'zeebe:priorityDefinition'
             ]
           },
           message: 'should be equal to one of the allowed values',
@@ -60,7 +61,7 @@ export const errors = [
         }
       ]
     },
-    message: 'invalid property.binding type "foo"; must be any of { property, zeebe:taskDefinition:type, zeebe:input, zeebe:output, zeebe:property, zeebe:taskHeader, bpmn:Message#property, bpmn:Message#zeebe:subscription#property, zeebe:taskDefinition, zeebe:calledElement, zeebe:linkedResource, zeebe:userTask, zeebe:formDefinition, zeebe:calledDecision, zeebe:script, zeebe:assignmentDefinition }'
+    message: 'invalid property.binding type "foo"; must be any of { property, zeebe:taskDefinition:type, zeebe:input, zeebe:output, zeebe:property, zeebe:taskHeader, bpmn:Message#property, bpmn:Message#zeebe:subscription#property, zeebe:taskDefinition, zeebe:calledElement, zeebe:linkedResource, zeebe:userTask, zeebe:formDefinition, zeebe:calledDecision, zeebe:script, zeebe:assignmentDefinition, zeebe:priorityDefinition }'
   },
   {
     keyword: 'type',

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/priority-definition/invalid-element-type.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/priority-definition/invalid-element-type.js
@@ -1,0 +1,87 @@
+export const template = {
+  'name': 'Priority Definition',
+  'id': 'priority-definition',
+  'description': 'A template to define task priority based on a variable.',
+  'version': 1,
+  'appliesTo': [
+    'bpmn:Task'
+  ],
+  'elementType': {
+    'value': 'bpmn:Task'
+  },
+  'properties': [
+    {
+      'type': 'Hidden',
+      'binding': {
+        'type': 'zeebe:userTask',
+      }
+    },
+    {
+      'label': 'Prio',
+      'value': '100',
+      'description': 'Prio for task',
+      'constraints': {
+        'notEmpty': true
+      },
+      'type': 'Dropdown',
+      'binding': {
+        'type': 'zeebe:priorityDefinition',
+        'property': 'priority'
+      },
+      'choices': [
+        {
+          'name': 'High',
+          'value': '100'
+        },
+        {
+          'name': 'Medium',
+          'value': '50'
+        },
+        {
+          'name': 'Low',
+          'value': '0'
+        }
+      ]
+    }
+  ]
+};
+
+// This is transitively caught by `zeebe:userTask` requiring `bpmn:UserTask`
+export const errors = [
+  {
+    keyword: 'const',
+    dataPath: '/elementType/value',
+    schemaPath: '#/allOf/1/allOf/3/then/properties/elementType/properties/value/const',
+    params: {
+      allowedValue: 'bpmn:UserTask'
+    },
+    message: 'should be equal to constant'
+  },
+  {
+    keyword: 'if',
+    dataPath: '',
+    schemaPath: '#/allOf/1/allOf/3/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: {
+      type: 'array'
+    },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: {
+      passingSchemas: null
+    },
+    message: 'should match exactly one schema in oneOf'
+  }
+];

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/priority-definition/invalid-input-types.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/priority-definition/invalid-input-types.js
@@ -1,0 +1,242 @@
+export const template = {
+  'name': 'Priority Definition',
+  'id': 'priority-definition',
+  'description': 'A template to define task priority based on a variable.',
+  'version': 1,
+  'appliesTo': [
+    'bpmn:Task'
+  ],
+  'elementType': {
+    'value': 'bpmn:UserTask'
+  },
+  'properties': [
+    {
+      'type': 'Hidden',
+      'binding': {
+        'type': 'zeebe:userTask',
+      }
+    },
+    {
+      'label': 'Prio',
+      'value': '1',
+      'type': 'String',
+      'binding': {
+        'type': 'zeebe:priorityDefinition',
+        'property': 'priority'
+      }
+    },
+    {
+      'label': 'Prio 2',
+      'value': '1',
+      'type': 'String',
+      'feel': 'optional',
+      'binding': {
+        'type': 'zeebe:priorityDefinition',
+        'property': 'priority'
+      }
+    },
+    {
+      'label': 'Prio 3',
+      'value': true,
+      'type': 'Boolean',
+      'binding': {
+        'type': 'zeebe:priorityDefinition',
+        'property': 'priority'
+      }
+    },
+    {
+      'label': 'Prio 4',
+      'value': '1',
+      'type': 'Text',
+      'binding': {
+        'type': 'zeebe:priorityDefinition',
+        'property': 'priority'
+      }
+    },
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'enum',
+    dataPath: '/properties/1/type',
+    schemaPath: '#/allOf/1/items/allOf/22/allOf/0/then/anyOf/0/properties/type/enum',
+    params: {
+      allowedValues: [
+        'Hidden',
+        'Number',
+        'Dropdown'
+      ]
+    },
+    message: 'should be equal to one of the allowed values'
+  },
+  {
+    keyword: 'required',
+    dataPath: '/properties/1',
+    schemaPath: '#/allOf/1/items/allOf/22/allOf/0/then/anyOf/1/required',
+    params: {
+      missingProperty: 'feel'
+    },
+    message: "should have required property 'feel'"
+  },
+  {
+    keyword: 'anyOf',
+    dataPath: '/properties/1',
+    schemaPath: '#/allOf/1/items/allOf/22/allOf/0/then/anyOf',
+    params: {},
+    message: 'should match some schema in anyOf'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/1',
+    schemaPath: '#/allOf/1/items/allOf/22/allOf/0/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'enum',
+    dataPath: '/properties/2/type',
+    schemaPath: '#/allOf/1/items/allOf/22/allOf/0/then/anyOf/0/properties/type/enum',
+    params: {
+      allowedValues: [
+        'Hidden',
+        'Number',
+        'Dropdown'
+      ]
+    },
+    message: 'should be equal to one of the allowed values'
+  },
+  {
+    keyword: 'const',
+    dataPath: '/properties/2/feel',
+    schemaPath: '#/allOf/1/items/allOf/22/allOf/0/then/anyOf/1/properties/feel/const',
+    params: {
+      allowedValue: 'required'
+    },
+    message: 'should be equal to constant'
+  },
+  {
+    keyword: 'anyOf',
+    dataPath: '/properties/2',
+    schemaPath: '#/allOf/1/items/allOf/22/allOf/0/then/anyOf',
+    params: {},
+    message: 'should match some schema in anyOf'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/2',
+    schemaPath: '#/allOf/1/items/allOf/22/allOf/0/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'enum',
+    dataPath: '/properties/3/type',
+    schemaPath: '#/allOf/1/items/allOf/22/allOf/0/then/anyOf/0/properties/type/enum',
+    params: {
+      allowedValues: [
+        'Hidden',
+        'Number',
+        'Dropdown'
+      ]
+    },
+    message: 'should be equal to one of the allowed values'
+  },
+  {
+    keyword: 'required',
+    dataPath: '/properties/3',
+    schemaPath: '#/allOf/1/items/allOf/22/allOf/0/then/anyOf/1/required',
+    params: {
+      missingProperty: 'feel'
+    },
+    message: "should have required property 'feel'"
+  },
+  {
+    keyword: 'enum',
+    dataPath: '/properties/3/type',
+    schemaPath: '#/allOf/1/items/allOf/22/allOf/0/then/anyOf/1/properties/type/enum',
+    params: {
+      allowedValues: [
+        'String',
+        'Text'
+      ]
+    },
+    message: 'should be equal to one of the allowed values'
+  },
+  {
+    keyword: 'anyOf',
+    dataPath: '/properties/3',
+    schemaPath: '#/allOf/1/items/allOf/22/allOf/0/then/anyOf',
+    params: {},
+    message: 'should match some schema in anyOf'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/3',
+    schemaPath: '#/allOf/1/items/allOf/22/allOf/0/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'enum',
+    dataPath: '/properties/4/type',
+    schemaPath: '#/allOf/1/items/allOf/22/allOf/0/then/anyOf/0/properties/type/enum',
+    params: {
+      allowedValues: [
+        'Hidden',
+        'Number',
+        'Dropdown'
+      ]
+    },
+    message: 'should be equal to one of the allowed values'
+  },
+  {
+    keyword: 'required',
+    dataPath: '/properties/4',
+    schemaPath: '#/allOf/1/items/allOf/22/allOf/0/then/anyOf/1/required',
+    params: {
+      missingProperty: 'feel'
+    },
+    message: "should have required property 'feel'"
+  },
+  {
+    keyword: 'anyOf',
+    dataPath: '/properties/4',
+    schemaPath: '#/allOf/1/items/allOf/22/allOf/0/then/anyOf',
+    params: {},
+    message: 'should match some schema in anyOf'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/4',
+    schemaPath: '#/allOf/1/items/allOf/22/allOf/0/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: {
+      type: 'array'
+    },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: {
+      passingSchemas: null
+    },
+    message: 'should match exactly one schema in oneOf'
+  }
+];

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/priority-definition/invalid-property.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/priority-definition/invalid-property.js
@@ -1,0 +1,72 @@
+export const template = {
+  'name': 'Priority Definition',
+  'id': 'priority-definition',
+  'description': 'A template to define task priority based on a variable.',
+  'version': 1,
+  'appliesTo': [
+    'bpmn:Task'
+  ],
+  'elementType': {
+    'value': 'bpmn:UserTask'
+  },
+  'properties': [
+    {
+      'type': 'Hidden',
+      'binding': {
+        'type': 'zeebe:userTask',
+      }
+    },
+    {
+      'label': 'Prio',
+      'value': '100',
+      'description': 'Prio for task',
+      'constraints': {
+        'notEmpty': true
+      },
+      'type': 'String',
+      'binding': {
+        'type': 'zeebe:priorityDefinition',
+        'property': 'youShallNotPass'
+      }
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'const',
+    dataPath: '/properties/1/binding/property',
+    schemaPath: '#/allOf/1/items/properties/binding/allOf/10/then/properties/property/const',
+    params: {
+      allowedValue: 'priority'
+    },
+    message: 'should be equal to constant'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/1/binding',
+    schemaPath: '#/allOf/1/items/properties/binding/allOf/10/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: {
+      type: 'array'
+    },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: {
+      passingSchemas: null
+    },
+    message: 'should match exactly one schema in oneOf'
+  }
+];

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/priority-definition/invalid-values.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/priority-definition/invalid-values.js
@@ -1,0 +1,300 @@
+export const template = {
+  name: 'Priority Definition',
+  id: 'priority-definition',
+  description: 'A template to define task priority based on a variable.',
+  version: 1,
+  appliesTo: [
+    'bpmn:Task'
+  ],
+  elementType: {
+    value: 'bpmn:UserTask'
+  },
+  properties: [
+    {
+      type: 'Hidden',
+      binding: {
+        type: 'zeebe:userTask',
+      }
+    },
+    {
+      label: 'Prio',
+      value: -1,
+      description: 'Prio for task',
+      type: 'Number',
+      binding: {
+        type: 'zeebe:priorityDefinition',
+        property: 'priority'
+      }
+    },
+    {
+      label: 'Prio',
+      value: 101,
+      description: 'Prio for task',
+      type: 'Number',
+      binding: {
+        type: 'zeebe:priorityDefinition',
+        property: 'priority'
+      }
+    },
+    {
+      value: '101',
+      type: 'Hidden',
+      binding: {
+        type: 'zeebe:priorityDefinition',
+        property: 'priority'
+      }
+    },
+    {
+      value: '-1',
+      type: 'Hidden',
+      binding: {
+        type: 'zeebe:priorityDefinition',
+        property: 'priority'
+      }
+    },
+    {
+      'label': 'Prio',
+      'value': '101',
+      'description': 'Prio for task',
+      'constraints': {
+        'notEmpty': true
+      },
+      'type': 'Dropdown',
+      'binding': {
+        'type': 'zeebe:priorityDefinition',
+        'property': 'priority'
+      },
+      'choices': [
+        {
+          'name': 'Too High',
+          'value': '101'
+        },
+        {
+          'name': 'Not a number',
+          'value': 'abcd'
+        },
+        {
+          'name': 'Too Low',
+          'value': '-1'
+        }
+      ]
+    }
+
+
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'minimum',
+    dataPath: '/properties/1/value',
+    schemaPath: '#/allOf/1/items/allOf/22/allOf/1/then/properties/value/minimum',
+    params: {
+      comparison: '>=',
+      limit: 0
+    },
+    message: 'should be >= 0'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/1',
+    schemaPath: '#/allOf/1/items/allOf/22/allOf/1/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'maximum',
+    dataPath: '/properties/2/value',
+    schemaPath: '#/allOf/1/items/allOf/22/allOf/1/then/properties/value/maximum',
+    params: {
+      comparison: '<=',
+      limit: 100
+    },
+    message: 'should be <= 100'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/2',
+    schemaPath: '#/allOf/1/items/allOf/22/allOf/1/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'errorMessage',
+    dataPath: '/properties/3/value',
+    schemaPath: '#/allOf/1/items/allOf/22/allOf/2/then/properties/value/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'pattern',
+          dataPath: '/properties/3/value',
+          schemaPath: '#/allOf/1/items/allOf/22/allOf/2/then/properties/value/pattern',
+          params: {
+            pattern: '^(100|[1-9]?[0-9])$'
+          },
+          message: 'should match pattern "^(100|[1-9]?[0-9])$"',
+          emUsed: true
+        }
+      ]
+    },
+    message: 'Invalid value for priority. Must be between 0 and 100.'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/3',
+    schemaPath: '#/allOf/1/items/allOf/22/allOf/2/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'errorMessage',
+    dataPath: '/properties/4/value',
+    schemaPath: '#/allOf/1/items/allOf/22/allOf/2/then/properties/value/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'pattern',
+          dataPath: '/properties/4/value',
+          schemaPath: '#/allOf/1/items/allOf/22/allOf/2/then/properties/value/pattern',
+          params: {
+            pattern: '^(100|[1-9]?[0-9])$'
+          },
+          message: 'should match pattern "^(100|[1-9]?[0-9])$"',
+          emUsed: true
+        }
+      ]
+    },
+    message: 'Invalid value for priority. Must be between 0 and 100.'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/4',
+    schemaPath: '#/allOf/1/items/allOf/22/allOf/2/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'errorMessage',
+    dataPath: '/properties/5/value',
+    schemaPath: '#/allOf/1/items/allOf/22/allOf/2/then/properties/value/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'pattern',
+          dataPath: '/properties/5/value',
+          schemaPath: '#/allOf/1/items/allOf/22/allOf/2/then/properties/value/pattern',
+          params: {
+            pattern: '^(100|[1-9]?[0-9])$'
+          },
+          message: 'should match pattern "^(100|[1-9]?[0-9])$"',
+          emUsed: true
+        }
+      ]
+    },
+    message: 'Invalid value for priority. Must be between 0 and 100.'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/5',
+    schemaPath: '#/allOf/1/items/allOf/22/allOf/2/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'errorMessage',
+    dataPath: '/properties/5/choices/0/value',
+    schemaPath: '#/allOf/1/items/allOf/22/allOf/3/then/properties/choices/items/properties/value/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'pattern',
+          dataPath: '/properties/5/choices/0/value',
+          schemaPath: '#/allOf/1/items/allOf/22/allOf/3/then/properties/choices/items/properties/value/pattern',
+          params: {
+            pattern: '^(100|[1-9]?[0-9])$'
+          },
+          message: 'should match pattern "^(100|[1-9]?[0-9])$"',
+          emUsed: true
+        }
+      ]
+    },
+    message: 'Invalid value for priority. Must be between 0 and 100.'
+  },
+  {
+    keyword: 'errorMessage',
+    dataPath: '/properties/5/choices/1/value',
+    schemaPath: '#/allOf/1/items/allOf/22/allOf/3/then/properties/choices/items/properties/value/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'pattern',
+          dataPath: '/properties/5/choices/1/value',
+          schemaPath: '#/allOf/1/items/allOf/22/allOf/3/then/properties/choices/items/properties/value/pattern',
+          params: {
+            pattern: '^(100|[1-9]?[0-9])$'
+          },
+          message: 'should match pattern "^(100|[1-9]?[0-9])$"',
+          emUsed: true
+        }
+      ]
+    },
+    message: 'Invalid value for priority. Must be between 0 and 100.'
+  },
+  {
+    keyword: 'errorMessage',
+    dataPath: '/properties/5/choices/2/value',
+    schemaPath: '#/allOf/1/items/allOf/22/allOf/3/then/properties/choices/items/properties/value/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'pattern',
+          dataPath: '/properties/5/choices/2/value',
+          schemaPath: '#/allOf/1/items/allOf/22/allOf/3/then/properties/choices/items/properties/value/pattern',
+          params: {
+            pattern: '^(100|[1-9]?[0-9])$'
+          },
+          message: 'should match pattern "^(100|[1-9]?[0-9])$"',
+          emUsed: true
+        }
+      ]
+    },
+    message: 'Invalid value for priority. Must be between 0 and 100.'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/5',
+    schemaPath: '#/allOf/1/items/allOf/22/allOf/3/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: {
+      type: 'array'
+    },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: {
+      passingSchemas: null
+    },
+    message: 'should match exactly one schema in oneOf'
+  }
+];

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/priority-definition/missing-zeebe-user-task.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/priority-definition/missing-zeebe-user-task.js
@@ -1,21 +1,41 @@
 export const template = {
-  '$schema': 'https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json',
-  'name': 'Form Definition with external reference',
-  'id': 'formDefinitionWithExternalReference',
+  'name': 'Priority Definition',
+  'id': 'priority-definition',
+  'description': 'A template to define task priority based on a variable.',
+  'version': 1,
   'appliesTo': [
     'bpmn:Task'
   ],
   'elementType': {
-    'value': 'bpmn:UserTask'
+    'value': 'bpmn:Task'
   },
   'properties': [
     {
-      'type': 'Hidden',
-      'value': 'aReference',
+      'label': 'Prio',
+      'value': '100',
+      'description': 'Prio for task',
+      'constraints': {
+        'notEmpty': true
+      },
+      'type': 'Dropdown',
       'binding': {
-        'type': 'zeebe:formDefinition',
-        'property': 'externalReference'
-      }
+        'type': 'zeebe:priorityDefinition',
+        'property': 'priority'
+      },
+      'choices': [
+        {
+          'name': 'High',
+          'value': '100'
+        },
+        {
+          'name': 'Medium',
+          'value': '50'
+        },
+        {
+          'name': 'Low',
+          'value': '0'
+        }
+      ]
     }
   ]
 };
@@ -49,7 +69,7 @@ export const errors = [
         }
       ]
     },
-    message: 'When using "zeebe:formDefinition", "zeebe:userTask" must be set on the same element'
+    message: 'When using "zeebe:priorityDefinition", "zeebe:userTask" must be set on the same element'
   },
   {
     keyword: 'if',

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/priority-definition/valid-with-feel.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/priority-definition/valid-with-feel.js
@@ -1,0 +1,33 @@
+export const template = {
+  name: 'Priority Definition',
+  id: 'priority-definition',
+  description: 'A template to define task priority based on a variable.',
+  version: 1,
+  appliesTo: [
+    'bpmn:Task'
+  ],
+  elementType: {
+    value: 'bpmn:UserTask'
+  },
+  properties: [
+    {
+      type: 'Hidden',
+      binding: {
+        type: 'zeebe:userTask',
+      }
+    },
+    {
+      label: 'Prio',
+      value: '= 1',
+      description: 'Prio for task',
+      type: 'String',
+      feel: 'required',
+      binding: {
+        type: 'zeebe:priorityDefinition',
+        property: 'priority'
+      }
+    }
+  ]
+};
+
+export const errors = null;

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/priority-definition/valid.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/priority-definition/valid.js
@@ -1,0 +1,49 @@
+export const template = {
+  'name': 'Priority Definition',
+  'id': 'priority-definition',
+  'description': 'A template to define task priority based on a variable.',
+  'version': 1,
+  'appliesTo': [
+    'bpmn:Task'
+  ],
+  'elementType': {
+    'value': 'bpmn:UserTask'
+  },
+  'properties': [
+    {
+      'type': 'Hidden',
+      'binding': {
+        'type': 'zeebe:userTask',
+      }
+    },
+    {
+      'label': 'Prio',
+      'value': '100',
+      'description': 'Prio for task',
+      'constraints': {
+        'notEmpty': true
+      },
+      'type': 'Dropdown',
+      'binding': {
+        'type': 'zeebe:priorityDefinition',
+        'property': 'priority'
+      },
+      'choices': [
+        {
+          'name': 'High',
+          'value': '100'
+        },
+        {
+          'name': 'Medium',
+          'value': '50'
+        },
+        {
+          'name': 'Low',
+          'value': '0'
+        }
+      ]
+    }
+  ]
+};
+
+export const errors = null;

--- a/packages/zeebe-element-templates-json-schema/test/spec/validationSpec.js
+++ b/packages/zeebe-element-templates-json-schema/test/spec/validationSpec.js
@@ -643,6 +643,25 @@ describe('validation', function() {
     });
   });
 
+
+  describe('zeebe:priorityDefinition', function() {
+
+    it('priority-definition/invalid-element-type');
+
+    it('priority-definition/invalid-input-types');
+
+    it('priority-definition/invalid-property');
+
+    it('priority-definition/invalid-values');
+
+    it('priority-definition/missing-zeebe-user-task');
+
+    it('priority-definition/valid');
+
+    it('priority-definition/valid-with-feel');
+
+  });
+
 });
 
 


### PR DESCRIPTION
### Proposed Changes

<!--
Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.
--> 
- [x] Element `zeebe:priorityDefinition` can be templated
- [x] Property `zeebe:priorityDefinition#priority` can be templated and must be set
- [x] The property value must be an integer between 0 and 100 if the type is Number
- [x] The property value must be a string between 0 and 100  if the type is not Number
- [x] The property must be FEEL required if the type is String or Text
- [x] `zeebe:priorityDefinition` can only be set if `zeebe:UserTask` is set. 
- [x] `zeebe:priorityDefinition` can only exist in a `bpmn:UserTask`

related to https://github.com/camunda/camunda-modeler/issues/5092


### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->