### PR TITLE
feat: add zeebe:taskSchedule

### DIFF
--- a/packages/zeebe-element-templates-json-schema/src/defs/properties.json
+++ b/packages/zeebe-element-templates-json-schema/src/defs/properties.json
@@ -64,7 +64,8 @@
                     "zeebe:script",
                     "zeebe:assignmentDefinition",
                     "zeebe:priorityDefinition",
-                    "zeebe:adHoc"
+                    "zeebe:adHoc",
+                    "zeebe:taskSchedule"
                   ]
                 }
               },
@@ -623,6 +624,9 @@
       },
       {
         "$ref": "./properties/adHoc.json"
+      },
+      {
+        "$ref": "./properties/taskSchedule.json"
       }
     ],
     "properties": {
@@ -846,6 +850,9 @@
             "$ref": "./properties/binding/adHoc.json"
           },
           {
+            "$ref": "./properties/binding/taskSchedule.json"
+          },
+          {
             "$ref": "examples.json#/binding"
           }
         ],
@@ -872,7 +879,8 @@
               "zeebe:script",
               "zeebe:assignmentDefinition",
               "zeebe:priorityDefinition",
-              "zeebe:adHoc"
+              "zeebe:adHoc",
+              "zeebe:taskSchedule"
             ]
           },
           "name": {

--- a/packages/zeebe-element-templates-json-schema/src/defs/properties/binding/taskSchedule.json
+++ b/packages/zeebe-element-templates-json-schema/src/defs/properties/binding/taskSchedule.json
@@ -1,0 +1,25 @@
+{
+  "if": {
+    "properties": {
+      "type": {
+        "const": "zeebe:taskSchedule"
+      }
+    },
+    "required": [
+      "type"
+    ]
+  },
+  "then": {
+    "properties": {
+      "property": {
+        "enum": [
+          "dueDate",
+          "followUpDate"
+        ]
+      }
+    },
+    "required": [
+      "property"
+    ]
+  }
+}

--- a/packages/zeebe-element-templates-json-schema/src/defs/properties/taskSchedule.json
+++ b/packages/zeebe-element-templates-json-schema/src/defs/properties/taskSchedule.json
@@ -1,0 +1,88 @@
+{
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "binding": {
+            "properties": {
+              "type": {
+                "const": "zeebe:taskSchedule"
+              },
+              "property": {
+                "enum": [
+                  "dueDate",
+                  "followUpDate"
+                ]
+              }
+            },
+            "required": [
+              "type",
+              "property"
+            ]
+          }
+        },
+        "required": [
+          "binding"
+        ]
+      },
+      "then": {
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "enum": [
+              "Hidden",
+              "String",
+              "Dropdown",
+              "Text"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "binding": {
+            "properties": {
+              "type": {
+                "const": "zeebe:taskSchedule"
+              },
+              "property": {
+                "enum": [
+                  "dueDate",
+                  "followUpDate"
+                ]
+              }
+            },
+            "required": [
+              "type",
+              "property"
+            ]
+          }
+
+        },
+        "required": [
+          "binding",
+          "value"
+        ],
+        "not": {
+          "required": ["feel"]
+        }
+      },
+      "then": {
+        "properties": {
+          "value": {
+            "type": "string",
+            "pattern": "^(?<date>\\d{4}-(?<month>0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01]))T(0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](Z|([+-](0[0-9]|1[0-3]):[0-5][0-9](\\[[^\\]]+\\])?))$",
+            "description": "The value must be conforming to an ISO 8601 combined date and time representation."
+          }
+        },
+        "required": [
+          "value"
+        ]
+      }
+    }
+  ]
+}

--- a/packages/zeebe-element-templates-json-schema/src/defs/template.json
+++ b/packages/zeebe-element-templates-json-schema/src/defs/template.json
@@ -301,7 +301,8 @@
                       "enum": [
                         "zeebe:formDefinition",
                         "zeebe:assignmentDefinition",
-                        "zeebe:priorityDefinition"
+                        "zeebe:priorityDefinition",
+                        "zeebe:taskSchedule"
                       ]
                     }
                   },

--- a/packages/zeebe-element-templates-json-schema/src/error-messages.json
+++ b/packages/zeebe-element-templates-json-schema/src/error-messages.json
@@ -149,7 +149,7 @@
       "properties",
       "type"
     ],
-    "errorMessage": "invalid property.binding type ${0}; must be any of { property, zeebe:taskDefinition:type, zeebe:input, zeebe:output, zeebe:property, zeebe:taskHeader, bpmn:Message#property, bpmn:Message#zeebe:subscription#property, zeebe:taskDefinition, zeebe:calledElement, zeebe:linkedResource, zeebe:userTask, zeebe:formDefinition, zeebe:calledDecision, zeebe:script, zeebe:assignmentDefinition, zeebe:priorityDefinition, zeebe:adHoc }"
+    "errorMessage": "invalid property.binding type ${0}; must be any of { property, zeebe:taskDefinition:type, zeebe:input, zeebe:output, zeebe:property, zeebe:taskHeader, bpmn:Message#property, bpmn:Message#zeebe:subscription#property, zeebe:taskDefinition, zeebe:calledElement, zeebe:linkedResource, zeebe:userTask, zeebe:formDefinition, zeebe:calledDecision, zeebe:script, zeebe:assignmentDefinition, zeebe:priorityDefinition, zeebe:adHoc, zeebe:taskSchedule }"
   },
   {
     "path": [
@@ -551,5 +551,22 @@
       2
     ],
     "errorMessage": "When using \"zeebe:adHoc\" with properties \"outputCollection\" and \"outputElement\", \"zeebe:taskDefinition\" with property=\"type\" must be set on the same element"
+  },
+  {
+    "path": [
+      "definitions",
+      "properties",
+      "allOf",
+      1,
+      "items",
+      "allOf",
+      24,
+      "allOf",
+      1,
+      "then",
+      "properties",
+      "value"
+    ],
+    "errorMessage": "Must be conforming to an ISO 8601 combined date and time representation"
   }
 ]

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/invalid-binding-type.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/invalid-binding-type.js
@@ -54,7 +54,8 @@ export const errors = [
               'zeebe:script',
               'zeebe:assignmentDefinition',
               'zeebe:priorityDefinition',
-              'zeebe:adHoc'
+              'zeebe:adHoc',
+              'zeebe:taskSchedule'
             ]
           },
           message: 'should be equal to one of the allowed values',
@@ -62,7 +63,7 @@ export const errors = [
         }
       ]
     },
-    message: 'invalid property.binding type "foo"; must be any of { property, zeebe:taskDefinition:type, zeebe:input, zeebe:output, zeebe:property, zeebe:taskHeader, bpmn:Message#property, bpmn:Message#zeebe:subscription#property, zeebe:taskDefinition, zeebe:calledElement, zeebe:linkedResource, zeebe:userTask, zeebe:formDefinition, zeebe:calledDecision, zeebe:script, zeebe:assignmentDefinition, zeebe:priorityDefinition, zeebe:adHoc }'
+    message: 'invalid property.binding type "foo"; must be any of { property, zeebe:taskDefinition:type, zeebe:input, zeebe:output, zeebe:property, zeebe:taskHeader, bpmn:Message#property, bpmn:Message#zeebe:subscription#property, zeebe:taskDefinition, zeebe:calledElement, zeebe:linkedResource, zeebe:userTask, zeebe:formDefinition, zeebe:calledDecision, zeebe:script, zeebe:assignmentDefinition, zeebe:priorityDefinition, zeebe:adHoc, zeebe:taskSchedule }'
   },
   {
     keyword: 'type',

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/task-schedule/invalid-element-type.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/task-schedule/invalid-element-type.js
@@ -1,4 +1,3 @@
-
 export const template = {
   'name': 'task schedule',
   'id': 'task-schedule-1',

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/task-schedule/invalid-element-type.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/task-schedule/invalid-element-type.js
@@ -1,0 +1,73 @@
+
+export const template = {
+  'name': 'task schedule',
+  'id': 'task-schedule-1',
+  'appliesTo': [
+    'bpmn:Task'
+  ],
+  'elementType': {
+    'value': 'bpmn:ServiceTask'
+  },
+  'properties': [
+    {
+      'type': 'Hidden',
+      'binding': {
+        'type': 'zeebe:userTask',
+      }
+    },
+    {
+      'type': 'Text',
+      'binding': {
+        'type': 'zeebe:taskSchedule',
+        'property': 'dueDate'
+      }
+    },
+    {
+      'type': 'String',
+      'binding': {
+        'type': 'zeebe:taskSchedule',
+        'property': 'followUpDate'
+      }
+    }
+  ]
+};
+
+// This is caught transitively by requiring `zeebe:userTask`
+export const errors = [
+  {
+    keyword: 'const',
+    dataPath: '/elementType/value',
+    schemaPath: '#/allOf/1/allOf/3/then/properties/elementType/properties/value/const',
+    params: {
+      allowedValue: 'bpmn:UserTask'
+    },
+    message: 'should be equal to constant'
+  },
+  {
+    keyword: 'if',
+    dataPath: '',
+    schemaPath: '#/allOf/1/allOf/3/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: {
+      type: 'array'
+    },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: {
+      passingSchemas: null
+    },
+    message: 'should match exactly one schema in oneOf'
+  }
+];

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/task-schedule/invalid-input-type.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/task-schedule/invalid-input-type.js
@@ -1,0 +1,161 @@
+export const template = {
+  'name': 'task schedule',
+  'id': 'task-schedule-1',
+  'appliesTo': [
+    'bpmn:Task'
+  ],
+  'elementType': {
+    'value': 'bpmn:UserTask'
+  },
+  'properties': [
+    {
+      'type': 'Hidden',
+      'binding': {
+        'type': 'zeebe:userTask',
+      }
+    },
+    {
+      'type': 'Number',
+      'binding': {
+        'type': 'zeebe:taskSchedule',
+        'property': 'dueDate'
+      }
+    },
+    {
+      'type': 'Number',
+      'binding': {
+        'type': 'zeebe:taskSchedule',
+        'property': 'followUpDate'
+      }
+    },
+    {
+      'type': 'Boolean',
+      'binding': {
+        'type': 'zeebe:taskSchedule',
+        'property': 'dueDate'
+      }
+    }
+    ,
+    {
+      'type': 'Boolean',
+      'binding': {
+        'type': 'zeebe:taskSchedule',
+        'property': 'followUpDate'
+      }
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'enum',
+    dataPath: '/properties/1/type',
+    schemaPath: '#/allOf/1/items/allOf/24/allOf/0/then/properties/type/enum',
+    params: {
+      allowedValues: [
+        'Hidden',
+        'String',
+        'Dropdown',
+        'Text'
+      ]
+    },
+    message: 'should be equal to one of the allowed values'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/1',
+    schemaPath: '#/allOf/1/items/allOf/24/allOf/0/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'enum',
+    dataPath: '/properties/2/type',
+    schemaPath: '#/allOf/1/items/allOf/24/allOf/0/then/properties/type/enum',
+    params: {
+      allowedValues: [
+        'Hidden',
+        'String',
+        'Dropdown',
+        'Text'
+      ]
+    },
+    message: 'should be equal to one of the allowed values'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/2',
+    schemaPath: '#/allOf/1/items/allOf/24/allOf/0/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'enum',
+    dataPath: '/properties/3/type',
+    schemaPath: '#/allOf/1/items/allOf/24/allOf/0/then/properties/type/enum',
+    params: {
+      allowedValues: [
+        'Hidden',
+        'String',
+        'Dropdown',
+        'Text'
+      ]
+    },
+    message: 'should be equal to one of the allowed values'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/3',
+    schemaPath: '#/allOf/1/items/allOf/24/allOf/0/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'enum',
+    dataPath: '/properties/4/type',
+    schemaPath: '#/allOf/1/items/allOf/24/allOf/0/then/properties/type/enum',
+    params: {
+      allowedValues: [
+        'Hidden',
+        'String',
+        'Dropdown',
+        'Text'
+      ]
+    },
+    message: 'should be equal to one of the allowed values'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/4',
+    schemaPath: '#/allOf/1/items/allOf/24/allOf/0/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: {
+      type: 'array'
+    },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: {
+      passingSchemas: null
+    },
+    message: 'should match exactly one schema in oneOf'
+  }
+]
+;

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/task-schedule/invalid-iso-date-value.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/task-schedule/invalid-iso-date-value.js
@@ -1,0 +1,390 @@
+export const template = {
+  'name': 'task schedule',
+  'id': 'task-schedule-1',
+  'appliesTo': [
+    'bpmn:Task'
+  ],
+  'elementType': {
+    'value': 'bpmn:UserTask'
+  },
+  'properties': [
+    {
+      'type': 'Hidden',
+      'binding': {
+        'type': 'zeebe:userTask',
+      }
+    },
+    {
+      'type': 'String',
+      'value': '2025-08-11_14:30:00Z',
+      'description': 'Uses "_" instead of "T" as date-time separator',
+      'binding': {
+        'type': 'zeebe:taskSchedule',
+        'property': 'dueDate'
+      }
+    },
+    {
+      'type': 'String',
+      'value': '2025-13-05T10:15:30Z',
+      'description': 'Month value is out of range (13)',
+      'binding': {
+        'type': 'zeebe:taskSchedule',
+        'property': 'dueDate'
+      }
+    },
+    {
+      'type': 'String',
+      'value': '2025-08-11T14:30:00.1234567890Z',
+      'description': 'Too many fractional second digits',
+      'binding': {
+        'type': 'zeebe:taskSchedule',
+        'property': 'dueDate'
+      }
+    },
+    {
+      'type': 'String',
+      'value': '2025-08-11t14:30:00Z',
+      'description': 'Lowercase "t" instead of uppercase "T" separator',
+      'binding': {
+        'type': 'zeebe:taskSchedule',
+        'property': 'dueDate'
+      }
+    },
+    {
+      'type': 'String',
+      'value': '2025-08-11T14:30:00+05',
+      'description': 'Timezone offset missing minutes component',
+      'binding': {
+        'type': 'zeebe:taskSchedule',
+        'property': 'dueDate'
+      }
+    },
+    {
+      'type': 'String',
+      'value': '2025-02-30T09:00:00Z',
+      'description': 'Invalid day for February (30)',
+      'binding': {
+        'type': 'zeebe:taskSchedule',
+        'property': 'dueDate'
+      }
+    },
+    {
+      'type': 'String',
+      'value': '2025-8-11T14:30:00Z',
+      'description': 'Month missing leading zero (should be 08)',
+      'binding': {
+        'type': 'zeebe:taskSchedule',
+        'property': 'dueDate'
+      }
+    },
+    {
+      'type': 'String',
+      'value': '2025-08-11 14:30:00Z',
+      'description': 'Uses space instead of "T" as date-time separator',
+      'binding': {
+        'type': 'zeebe:taskSchedule',
+        'property': 'dueDate'
+      }
+    },
+    {
+      'type': 'String',
+      'value': '2025-08-11T14:30:00+05:',
+      'description': 'Incomplete timezone offset (missing minutes)',
+      'binding': {
+        'type': 'zeebe:taskSchedule',
+        'property': 'dueDate'
+      }
+    },
+    {
+      'type': 'String',
+      'value': '2025-06-30T23:59:60Z',
+      'description': 'Leap second value (60 seconds) not widely supported',
+      'binding': {
+        'type': 'zeebe:taskSchedule',
+        'property': 'dueDate'
+      }
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'errorMessage',
+    dataPath: '/properties/1/value',
+    schemaPath: '#/allOf/1/items/allOf/24/allOf/1/then/properties/value/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'pattern',
+          dataPath: '/properties/1/value',
+          schemaPath: '#/allOf/1/items/allOf/24/allOf/1/then/properties/value/pattern',
+          params: {
+            pattern: '^(?<date>\\d{4}-(?<month>0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01]))T(0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](Z|([+-](0[0-9]|1[0-3]):[0-5][0-9](\\[[^\\]]+\\])?))$'
+          },
+          message: 'should match pattern "^(?<date>\\d{4}-(?<month>0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01]))T(0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](Z|([+-](0[0-9]|1[0-3]):[0-5][0-9](\\[[^\\]]+\\])?))$"',
+          emUsed: true
+        }
+      ]
+    },
+    message: 'Must be conforming to an ISO 8601 combined date and time representation'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/1',
+    schemaPath: '#/allOf/1/items/allOf/24/allOf/1/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'errorMessage',
+    dataPath: '/properties/2/value',
+    schemaPath: '#/allOf/1/items/allOf/24/allOf/1/then/properties/value/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'pattern',
+          dataPath: '/properties/2/value',
+          schemaPath: '#/allOf/1/items/allOf/24/allOf/1/then/properties/value/pattern',
+          params: {
+            pattern: '^(?<date>\\d{4}-(?<month>0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01]))T(0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](Z|([+-](0[0-9]|1[0-3]):[0-5][0-9](\\[[^\\]]+\\])?))$'
+          },
+          message: 'should match pattern "^(?<date>\\d{4}-(?<month>0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01]))T(0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](Z|([+-](0[0-9]|1[0-3]):[0-5][0-9](\\[[^\\]]+\\])?))$"',
+          emUsed: true
+        }
+      ]
+    },
+    message: 'Must be conforming to an ISO 8601 combined date and time representation'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/2',
+    schemaPath: '#/allOf/1/items/allOf/24/allOf/1/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'errorMessage',
+    dataPath: '/properties/3/value',
+    schemaPath: '#/allOf/1/items/allOf/24/allOf/1/then/properties/value/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'pattern',
+          dataPath: '/properties/3/value',
+          schemaPath: '#/allOf/1/items/allOf/24/allOf/1/then/properties/value/pattern',
+          params: {
+            pattern: '^(?<date>\\d{4}-(?<month>0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01]))T(0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](Z|([+-](0[0-9]|1[0-3]):[0-5][0-9](\\[[^\\]]+\\])?))$'
+          },
+          message: 'should match pattern "^(?<date>\\d{4}-(?<month>0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01]))T(0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](Z|([+-](0[0-9]|1[0-3]):[0-5][0-9](\\[[^\\]]+\\])?))$"',
+          emUsed: true
+        }
+      ]
+    },
+    message: 'Must be conforming to an ISO 8601 combined date and time representation'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/3',
+    schemaPath: '#/allOf/1/items/allOf/24/allOf/1/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'errorMessage',
+    dataPath: '/properties/4/value',
+    schemaPath: '#/allOf/1/items/allOf/24/allOf/1/then/properties/value/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'pattern',
+          dataPath: '/properties/4/value',
+          schemaPath: '#/allOf/1/items/allOf/24/allOf/1/then/properties/value/pattern',
+          params: {
+            pattern: '^(?<date>\\d{4}-(?<month>0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01]))T(0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](Z|([+-](0[0-9]|1[0-3]):[0-5][0-9](\\[[^\\]]+\\])?))$'
+          },
+          message: 'should match pattern "^(?<date>\\d{4}-(?<month>0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01]))T(0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](Z|([+-](0[0-9]|1[0-3]):[0-5][0-9](\\[[^\\]]+\\])?))$"',
+          emUsed: true
+        }
+      ]
+    },
+    message: 'Must be conforming to an ISO 8601 combined date and time representation'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/4',
+    schemaPath: '#/allOf/1/items/allOf/24/allOf/1/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'errorMessage',
+    dataPath: '/properties/5/value',
+    schemaPath: '#/allOf/1/items/allOf/24/allOf/1/then/properties/value/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'pattern',
+          dataPath: '/properties/5/value',
+          schemaPath: '#/allOf/1/items/allOf/24/allOf/1/then/properties/value/pattern',
+          params: {
+            pattern: '^(?<date>\\d{4}-(?<month>0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01]))T(0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](Z|([+-](0[0-9]|1[0-3]):[0-5][0-9](\\[[^\\]]+\\])?))$'
+          },
+          message: 'should match pattern "^(?<date>\\d{4}-(?<month>0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01]))T(0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](Z|([+-](0[0-9]|1[0-3]):[0-5][0-9](\\[[^\\]]+\\])?))$"',
+          emUsed: true
+        }
+      ]
+    },
+    message: 'Must be conforming to an ISO 8601 combined date and time representation'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/5',
+    schemaPath: '#/allOf/1/items/allOf/24/allOf/1/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'errorMessage',
+    dataPath: '/properties/7/value',
+    schemaPath: '#/allOf/1/items/allOf/24/allOf/1/then/properties/value/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'pattern',
+          dataPath: '/properties/7/value',
+          schemaPath: '#/allOf/1/items/allOf/24/allOf/1/then/properties/value/pattern',
+          params: {
+            pattern: '^(?<date>\\d{4}-(?<month>0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01]))T(0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](Z|([+-](0[0-9]|1[0-3]):[0-5][0-9](\\[[^\\]]+\\])?))$'
+          },
+          message: 'should match pattern "^(?<date>\\d{4}-(?<month>0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01]))T(0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](Z|([+-](0[0-9]|1[0-3]):[0-5][0-9](\\[[^\\]]+\\])?))$"',
+          emUsed: true
+        }
+      ]
+    },
+    message: 'Must be conforming to an ISO 8601 combined date and time representation'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/7',
+    schemaPath: '#/allOf/1/items/allOf/24/allOf/1/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'errorMessage',
+    dataPath: '/properties/8/value',
+    schemaPath: '#/allOf/1/items/allOf/24/allOf/1/then/properties/value/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'pattern',
+          dataPath: '/properties/8/value',
+          schemaPath: '#/allOf/1/items/allOf/24/allOf/1/then/properties/value/pattern',
+          params: {
+            pattern: '^(?<date>\\d{4}-(?<month>0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01]))T(0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](Z|([+-](0[0-9]|1[0-3]):[0-5][0-9](\\[[^\\]]+\\])?))$'
+          },
+          message: 'should match pattern "^(?<date>\\d{4}-(?<month>0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01]))T(0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](Z|([+-](0[0-9]|1[0-3]):[0-5][0-9](\\[[^\\]]+\\])?))$"',
+          emUsed: true
+        }
+      ]
+    },
+    message: 'Must be conforming to an ISO 8601 combined date and time representation'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/8',
+    schemaPath: '#/allOf/1/items/allOf/24/allOf/1/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'errorMessage',
+    dataPath: '/properties/9/value',
+    schemaPath: '#/allOf/1/items/allOf/24/allOf/1/then/properties/value/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'pattern',
+          dataPath: '/properties/9/value',
+          schemaPath: '#/allOf/1/items/allOf/24/allOf/1/then/properties/value/pattern',
+          params: {
+            pattern: '^(?<date>\\d{4}-(?<month>0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01]))T(0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](Z|([+-](0[0-9]|1[0-3]):[0-5][0-9](\\[[^\\]]+\\])?))$'
+          },
+          message: 'should match pattern "^(?<date>\\d{4}-(?<month>0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01]))T(0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](Z|([+-](0[0-9]|1[0-3]):[0-5][0-9](\\[[^\\]]+\\])?))$"',
+          emUsed: true
+        }
+      ]
+    },
+    message: 'Must be conforming to an ISO 8601 combined date and time representation'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/9',
+    schemaPath: '#/allOf/1/items/allOf/24/allOf/1/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'errorMessage',
+    dataPath: '/properties/10/value',
+    schemaPath: '#/allOf/1/items/allOf/24/allOf/1/then/properties/value/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'pattern',
+          dataPath: '/properties/10/value',
+          schemaPath: '#/allOf/1/items/allOf/24/allOf/1/then/properties/value/pattern',
+          params: {
+            pattern: '^(?<date>\\d{4}-(?<month>0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01]))T(0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](Z|([+-](0[0-9]|1[0-3]):[0-5][0-9](\\[[^\\]]+\\])?))$'
+          },
+          message: 'should match pattern "^(?<date>\\d{4}-(?<month>0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01]))T(0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](Z|([+-](0[0-9]|1[0-3]):[0-5][0-9](\\[[^\\]]+\\])?))$"',
+          emUsed: true
+        }
+      ]
+    },
+    message: 'Must be conforming to an ISO 8601 combined date and time representation'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/10',
+    schemaPath: '#/allOf/1/items/allOf/24/allOf/1/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: {
+      type: 'array'
+    },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: {
+      passingSchemas: null
+    },
+    message: 'should match exactly one schema in oneOf'
+  }
+];

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/task-schedule/invalid-property.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/task-schedule/invalid-property.js
@@ -1,0 +1,67 @@
+export const template = {
+  'name': 'task schedule',
+  'id': 'task-schedule-1',
+  'appliesTo': [
+    'bpmn:Task'
+  ],
+  'elementType': {
+    'value': 'bpmn:UserTask'
+  },
+  'properties': [
+    {
+      'type': 'Hidden',
+      'binding': {
+        'type': 'zeebe:userTask',
+      }
+    },
+    {
+      'type': 'Text',
+      'binding': {
+        'type': 'zeebe:taskSchedule',
+        'property': 'youShallNotPass'
+      }
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'enum',
+    dataPath: '/properties/1/binding/property',
+    schemaPath: '#/allOf/1/items/properties/binding/allOf/12/then/properties/property/enum',
+    params: {
+      allowedValues: [
+        'dueDate',
+        'followUpDate'
+      ]
+    },
+    message: 'should be equal to one of the allowed values'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/1/binding',
+    schemaPath: '#/allOf/1/items/properties/binding/allOf/12/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: {
+      type: 'array'
+    },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: {
+      passingSchemas: null
+    },
+    message: 'should match exactly one schema in oneOf'
+  }
+];

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/task-schedule/invalid-value.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/task-schedule/invalid-value.js
@@ -1,0 +1,113 @@
+export const template = {
+  'name': 'task schedule',
+  'id': 'task-schedule-1',
+  'appliesTo': [
+    'bpmn:Task'
+  ],
+  'elementType': {
+    'value': 'bpmn:UserTask'
+  },
+  'properties': [
+    {
+      'type': 'Hidden',
+      'binding': {
+        'type': 'zeebe:userTask',
+      }
+    },
+    {
+      'type': 'String',
+      'value': 'tomorrow',
+      'binding': {
+        'type': 'zeebe:taskSchedule',
+        'property': 'dueDate'
+      }
+    },
+    {
+      'type': 'String',
+      'value': '2020/10/01T12:00:00Z',
+      'binding': {
+        'type': 'zeebe:taskSchedule',
+        'property': 'followUpDate'
+      }
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'errorMessage',
+    dataPath: '/properties/1/value',
+    schemaPath: '#/allOf/1/items/allOf/24/allOf/1/then/properties/value/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'pattern',
+          dataPath: '/properties/1/value',
+          schemaPath: '#/allOf/1/items/allOf/24/allOf/1/then/properties/value/pattern',
+          params: {
+            pattern: '^(?<date>\\d{4}-(?<month>0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01]))T(0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](Z|([+-](0[0-9]|1[0-3]):[0-5][0-9](\\[[^\\]]+\\])?))$'
+          },
+          message: 'should match pattern "^(?<date>\\d{4}-(?<month>0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01]))T(0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](Z|([+-](0[0-9]|1[0-3]):[0-5][0-9](\\[[^\\]]+\\])?))$"',
+          emUsed: true
+        }
+      ]
+    },
+    message: 'Must be conforming to an ISO 8601 combined date and time representation'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/1',
+    schemaPath: '#/allOf/1/items/allOf/24/allOf/1/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'errorMessage',
+    dataPath: '/properties/2/value',
+    schemaPath: '#/allOf/1/items/allOf/24/allOf/1/then/properties/value/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'pattern',
+          dataPath: '/properties/2/value',
+          schemaPath: '#/allOf/1/items/allOf/24/allOf/1/then/properties/value/pattern',
+          params: {
+            pattern: '^(?<date>\\d{4}-(?<month>0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01]))T(0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](Z|([+-](0[0-9]|1[0-3]):[0-5][0-9](\\[[^\\]]+\\])?))$'
+          },
+          message: 'should match pattern "^(?<date>\\d{4}-(?<month>0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01]))T(0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](Z|([+-](0[0-9]|1[0-3]):[0-5][0-9](\\[[^\\]]+\\])?))$"',
+          emUsed: true
+        }
+      ]
+    },
+    message: 'Must be conforming to an ISO 8601 combined date and time representation'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/2',
+    schemaPath: '#/allOf/1/items/allOf/24/allOf/1/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: {
+      type: 'array'
+    },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: {
+      passingSchemas: null
+    },
+    message: 'should match exactly one schema in oneOf'
+  }
+];

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/task-schedule/missing-property.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/task-schedule/missing-property.js
@@ -1,4 +1,3 @@
-
 export const template = {
   'name': 'task schedule',
   'id': 'task-schedule-1',

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/task-schedule/missing-property.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/task-schedule/missing-property.js
@@ -1,0 +1,66 @@
+
+export const template = {
+  'name': 'task schedule',
+  'id': 'task-schedule-1',
+  'appliesTo': [
+    'bpmn:Task'
+  ],
+  'elementType': {
+    'value': 'bpmn:UserTask'
+  },
+  'properties': [
+    {
+      'type': 'Hidden',
+      'binding': {
+        'type': 'zeebe:userTask',
+      }
+    },
+    {
+      'type': 'String',
+      'feel': 'optional',
+      'binding': {
+        'type': 'zeebe:taskSchedule',
+      }
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'required',
+    dataPath: '/properties/1/binding',
+    schemaPath: '#/allOf/1/items/properties/binding/allOf/12/then/required',
+    params: {
+      missingProperty: 'property'
+    },
+    message: "should have required property 'property'"
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/1/binding',
+    schemaPath: '#/allOf/1/items/properties/binding/allOf/12/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: {
+      type: 'array'
+    },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: {
+      passingSchemas: null
+    },
+    message: 'should match exactly one schema in oneOf'
+  }
+]
+;

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/task-schedule/missing-zeebe-user-task.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/task-schedule/missing-zeebe-user-task.js
@@ -1,4 +1,3 @@
-
 export const template = {
   'name': 'task schedule',
   'id': 'task-schedule-1',

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/task-schedule/missing-zeebe-user-task.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/task-schedule/missing-zeebe-user-task.js
@@ -1,0 +1,97 @@
+
+export const template = {
+  'name': 'task schedule',
+  'id': 'task-schedule-1',
+  'appliesTo': [
+    'bpmn:Task'
+  ],
+  'elementType': {
+    'value': 'bpmn:UserTask'
+  },
+  'properties': [
+    {
+      'type': 'String',
+      'binding': {
+        'type': 'zeebe:taskSchedule',
+        'property': 'dueDate'
+      }
+    },
+    {
+      'type': 'String',
+      'binding': {
+        'type': 'zeebe:taskSchedule',
+        'property': 'followUpDate'
+      }
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'errorMessage',
+    dataPath: '/properties',
+    schemaPath: '#/allOf/1/allOf/4/then/properties/properties/errorMessage',
+    params: {
+      errors: [
+        {
+          keyword: 'const',
+          dataPath: '/properties/0/binding/type',
+          schemaPath: '#/allOf/1/allOf/4/then/properties/properties/contains/properties/binding/properties/type/const',
+          params: {
+            allowedValue: 'zeebe:userTask'
+          },
+          message: 'should be equal to constant',
+          emUsed: true
+        },
+        {
+          keyword: 'const',
+          dataPath: '/properties/1/binding/type',
+          schemaPath: '#/allOf/1/allOf/4/then/properties/properties/contains/properties/binding/properties/type/const',
+          params: {
+            allowedValue: 'zeebe:userTask'
+          },
+          message: 'should be equal to constant',
+          emUsed: true
+        },
+        {
+          keyword: 'contains',
+          dataPath: '/properties',
+          schemaPath: '#/allOf/1/allOf/4/then/properties/properties/contains',
+          params: {
+            minContains: 1
+          },
+          message: 'should contain at least 1 valid item(s)',
+          emUsed: true
+        }
+      ]
+    },
+    message: 'When using "zeebe:taskSchedule", "zeebe:userTask" must be set on the same element'
+  },
+  {
+    keyword: 'if',
+    dataPath: '',
+    schemaPath: '#/allOf/1/allOf/4/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: {
+      type: 'array'
+    },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: {
+      passingSchemas: null
+    },
+    message: 'should match exactly one schema in oneOf'
+  }
+];

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/task-schedule/valid-feel.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/task-schedule/valid-feel.js
@@ -1,4 +1,3 @@
-
 export const template = {
   'name': 'task schedule',
   'id': 'task-schedule-1',

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/task-schedule/valid-feel.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/task-schedule/valid-feel.js
@@ -1,0 +1,39 @@
+
+export const template = {
+  'name': 'task schedule',
+  'id': 'task-schedule-1',
+  'appliesTo': [
+    'bpmn:Task'
+  ],
+  'elementType': {
+    'value': 'bpmn:UserTask'
+  },
+  'properties': [
+    {
+      'type': 'Hidden',
+      'binding': {
+        'type': 'zeebe:userTask',
+      }
+    },
+    {
+      'type': 'String',
+      'feel': 'optional',
+      'value': '2020-10-01T12:00:00Z',
+      'binding': {
+        'type': 'zeebe:taskSchedule',
+        'property': 'dueDate'
+      }
+    },
+    {
+      'type': 'String',
+      'feel': 'required',
+      'value': '= someDate',
+      'binding': {
+        'type': 'zeebe:taskSchedule',
+        'property': 'followUpDate'
+      }
+    }
+  ]
+};
+
+export const errors = null;

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/task-schedule/valid.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/task-schedule/valid.js
@@ -1,98 +1,99 @@
-export const template = [ {
-  'name': 'task schedule',
-  'id': 'task-schedule-1',
-  'appliesTo': [
-    'bpmn:Task'
-  ],
-  'elementType': {
-    'value': 'bpmn:UserTask'
+export const template = [
+  {
+    'name': 'task schedule',
+    'id': 'task-schedule-1',
+    'appliesTo': [
+      'bpmn:Task'
+    ],
+    'elementType': {
+      'value': 'bpmn:UserTask'
+    },
+    'properties': [
+      {
+        'type': 'Hidden',
+        'binding': {
+          'type': 'zeebe:userTask',
+        }
+      },
+      {
+        'type': 'Hidden',
+        'value': '2019-10-01T12:00:00Z',
+        'binding': {
+          'type': 'zeebe:taskSchedule',
+          'property': 'dueDate'
+        }
+      },
+      {
+        'type': 'Hidden',
+        'value': '2019-10-02T08:09:40+02:00',
+        'binding': {
+          'type': 'zeebe:taskSchedule',
+          'property': 'followUpDate'
+        }
+      }
+    ]
   },
-  'properties': [
-    {
-      'type': 'Hidden',
-      'binding': {
-        'type': 'zeebe:userTask',
-      }
+  {
+    'name': 'task schedule',
+    'id': 'task-schedule-2',
+    'appliesTo': [
+      'bpmn:Task'
+    ],
+    'elementType': {
+      'value': 'bpmn:UserTask'
     },
-    {
-      'type': 'Hidden',
-      'value': '2019-10-01T12:00:00Z',
-      'binding': {
-        'type': 'zeebe:taskSchedule',
-        'property': 'dueDate'
+    'properties': [
+      {
+        'type': 'Hidden',
+        'binding': {
+          'type': 'zeebe:userTask',
+        }
+      },
+      {
+        'type': 'Hidden',
+        'value': '2019-10-02T08:09:40+02:00[Europe/Berlin]',
+        'binding': {
+          'type': 'zeebe:taskSchedule',
+          'property': 'followUpDate'
+        }
       }
-    },
-    {
-      'type': 'Hidden',
-      'value': '2019-10-02T08:09:40+02:00',
-      'binding': {
-        'type': 'zeebe:taskSchedule',
-        'property': 'followUpDate'
-      }
-    }
-  ]
-},
-{
-  'name': 'task schedule',
-  'id': 'task-schedule-2',
-  'appliesTo': [
-    'bpmn:Task'
-  ],
-  'elementType': {
-    'value': 'bpmn:UserTask'
+    ]
   },
-  'properties': [
-    {
-      'type': 'Hidden',
-      'binding': {
-        'type': 'zeebe:userTask',
-      }
+  {
+    'name': 'task schedule',
+    'id': 'task-schedule-3',
+    'appliesTo': [
+      'bpmn:Task'
+    ],
+    'elementType': {
+      'value': 'bpmn:UserTask'
     },
-    {
-      'type': 'Hidden',
-      'value': '2019-10-02T08:09:40+02:00[Europe/Berlin]',
-      'binding': {
-        'type': 'zeebe:taskSchedule',
-        'property': 'followUpDate'
+    'properties': [
+      {
+        'type': 'Hidden',
+        'binding': {
+          'type': 'zeebe:userTask',
+        }
+      },
+      {
+        'type': 'Hidden',
+        'value': '2019-10-01T12:00:00Z',
+        'binding': {
+          'type': 'zeebe:taskSchedule',
+          'property': 'dueDate'
+        }
+      },
+      {
+        'type': 'String',
+        'value': '2025-08-11T14:30:00-03:30',
+        'description': 'Valid negative timezone offset with half-hour increment',
+        'binding': {
+          'type': 'zeebe:taskSchedule',
+          'property': 'dueDate'
+        }
       }
-    }
-  ]
-},
-{
-  'name': 'task schedule',
-  'id': 'task-schedule-3',
-  'appliesTo': [
-    'bpmn:Task'
-  ],
-  'elementType': {
-    'value': 'bpmn:UserTask'
-  },
-  'properties': [
-    {
-      'type': 'Hidden',
-      'binding': {
-        'type': 'zeebe:userTask',
-      }
-    },
-    {
-      'type': 'Hidden',
-      'value': '2019-10-01T12:00:00Z',
-      'binding': {
-        'type': 'zeebe:taskSchedule',
-        'property': 'dueDate'
-      }
-    },
-    {
-      'type': 'String',
-      'value': '2025-08-11T14:30:00-03:30',
-      'description': 'Valid negative timezone offset with half-hour increment',
-      'binding': {
-        'type': 'zeebe:taskSchedule',
-        'property': 'dueDate'
-      }
-    }
-  ]
-}
+    ]
+  }
 ];
 
 export const errors = null;

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/task-schedule/valid.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/task-schedule/valid.js
@@ -1,0 +1,98 @@
+export const template = [ {
+  'name': 'task schedule',
+  'id': 'task-schedule-1',
+  'appliesTo': [
+    'bpmn:Task'
+  ],
+  'elementType': {
+    'value': 'bpmn:UserTask'
+  },
+  'properties': [
+    {
+      'type': 'Hidden',
+      'binding': {
+        'type': 'zeebe:userTask',
+      }
+    },
+    {
+      'type': 'Hidden',
+      'value': '2019-10-01T12:00:00Z',
+      'binding': {
+        'type': 'zeebe:taskSchedule',
+        'property': 'dueDate'
+      }
+    },
+    {
+      'type': 'Hidden',
+      'value': '2019-10-02T08:09:40+02:00',
+      'binding': {
+        'type': 'zeebe:taskSchedule',
+        'property': 'followUpDate'
+      }
+    }
+  ]
+},
+{
+  'name': 'task schedule',
+  'id': 'task-schedule-2',
+  'appliesTo': [
+    'bpmn:Task'
+  ],
+  'elementType': {
+    'value': 'bpmn:UserTask'
+  },
+  'properties': [
+    {
+      'type': 'Hidden',
+      'binding': {
+        'type': 'zeebe:userTask',
+      }
+    },
+    {
+      'type': 'Hidden',
+      'value': '2019-10-02T08:09:40+02:00[Europe/Berlin]',
+      'binding': {
+        'type': 'zeebe:taskSchedule',
+        'property': 'followUpDate'
+      }
+    }
+  ]
+},
+{
+  'name': 'task schedule',
+  'id': 'task-schedule-3',
+  'appliesTo': [
+    'bpmn:Task'
+  ],
+  'elementType': {
+    'value': 'bpmn:UserTask'
+  },
+  'properties': [
+    {
+      'type': 'Hidden',
+      'binding': {
+        'type': 'zeebe:userTask',
+      }
+    },
+    {
+      'type': 'Hidden',
+      'value': '2019-10-01T12:00:00Z',
+      'binding': {
+        'type': 'zeebe:taskSchedule',
+        'property': 'dueDate'
+      }
+    },
+    {
+      'type': 'String',
+      'value': '2025-08-11T14:30:00-03:30',
+      'description': 'Valid negative timezone offset with half-hour increment',
+      'binding': {
+        'type': 'zeebe:taskSchedule',
+        'property': 'dueDate'
+      }
+    }
+  ]
+}
+];
+
+export const errors = null;

--- a/packages/zeebe-element-templates-json-schema/test/spec/validationSpec.js
+++ b/packages/zeebe-element-templates-json-schema/test/spec/validationSpec.js
@@ -689,6 +689,29 @@ describe('validation', function() {
 
   });
 
+
+  describe('zeebe:taskSchedule', function() {
+
+    it('task-schedule/invalid-element-type');
+
+    it('task-schedule/invalid-input-type');
+
+    it('task-schedule/invalid-iso-date-value');
+
+    it('task-schedule/invalid-property');
+
+    it('task-schedule/invalid-value');
+
+    it('task-schedule/missing-property');
+
+    it('task-schedule/missing-zeebe-user-task');
+
+    it('task-schedule/valid');
+
+    it('task-schedule/valid-feel');
+
+  });
+
 });
 
 


### PR DESCRIPTION
### Proposed Changes
<!--
Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.
--> 
- Element `zeebe:taskSchedule` can be templated
- Property `zeebe:taskSchedule#dueDate` can be templated
- Property `zeebe:taskSchedule#followUpDate` can be templated
- Both properties are String/Text typed with FEEL support or a Dropdown or Hidden. 
- the `value` set in the template for these properties can only be ISO 8601 date time
- `zeebe:taskSchedule` can only be set if `zeebe:UserTask` is set. 
- `zeebe:taskSchedule` can only exist in a `bpmn:UserTask`
- At least one of the properties needs to be set. 

related to https://github.com/camunda/camunda-modeler/issues/5093

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->