### PR TITLE
fix: mark `feel: required` that does not start with `=` as `deprecated`

### DIFF
--- a/packages/zeebe-element-templates-json-schema/src/defs/properties.json
+++ b/packages/zeebe-element-templates-json-schema/src/defs/properties.json
@@ -277,7 +277,19 @@
         "then": {
           "properties": {
             "value": {
-              "type": "string"
+              "oneOf": [
+                {
+                  "type": "string",
+                  "pattern": "^="
+                },
+                {
+                  "type": "string",
+                  "not": {
+                    "pattern": "^="
+                  },
+                  "deprecated": true
+                }
+              ]
             }
           }
         }

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/feel-value-mismatch.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/feel-value-mismatch.js
@@ -39,9 +39,36 @@ export const errors = [
   {
     keyword: 'type',
     dataPath: '/properties/1/value',
-    schemaPath: '#/allOf/1/items/allOf/9/then/properties/value/type',
-    params: { type: 'string' },
+    schemaPath: '#/allOf/1/items/allOf/9/then/properties/value/oneOf/0/type',
+    params: {
+      type: 'string'
+    },
     message: 'should be string'
+  },
+  {
+    keyword: 'type',
+    dataPath: '/properties/1/value',
+    schemaPath: '#/allOf/1/items/allOf/9/then/properties/value/oneOf/1/type',
+    params: {
+      type: 'string'
+    },
+    message: 'should be string'
+  },
+  {
+    keyword: 'not',
+    dataPath: '/properties/1/value',
+    schemaPath: '#/allOf/1/items/allOf/9/then/properties/value/oneOf/1/not',
+    params: {},
+    message: 'should NOT be valid'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '/properties/1/value',
+    schemaPath: '#/allOf/1/items/allOf/9/then/properties/value/oneOf',
+    params: {
+      passingSchemas: null
+    },
+    message: 'should match exactly one schema in oneOf'
   },
   {
     keyword: 'if',
@@ -53,9 +80,36 @@ export const errors = [
   {
     keyword: 'type',
     dataPath: '/properties/2/value',
-    schemaPath: '#/allOf/1/items/allOf/9/then/properties/value/type',
-    params: { type: 'string' },
+    schemaPath: '#/allOf/1/items/allOf/9/then/properties/value/oneOf/0/type',
+    params: {
+      type: 'string'
+    },
     message: 'should be string'
+  },
+  {
+    keyword: 'type',
+    dataPath: '/properties/2/value',
+    schemaPath: '#/allOf/1/items/allOf/9/then/properties/value/oneOf/1/type',
+    params: {
+      type: 'string'
+    },
+    message: 'should be string'
+  },
+  {
+    keyword: 'not',
+    dataPath: '/properties/2/value',
+    schemaPath: '#/allOf/1/items/allOf/9/then/properties/value/oneOf/1/not',
+    params: {},
+    message: 'should NOT be valid'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '/properties/2/value',
+    schemaPath: '#/allOf/1/items/allOf/9/then/properties/value/oneOf',
+    params: {
+      passingSchemas: null
+    },
+    message: 'should match exactly one schema in oneOf'
   },
   {
     keyword: 'if',


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-modeler/issues/4967

### Proposed Changes

In a `feel: required` property, mark `value` as deprecated if it doesn't start with `=`.

<img width="495" height="236" alt="image" src="https://github.com/user-attachments/assets/7a4a680e-1f73-4f3a-9be0-ece1cdc10482" />

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [x] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->