### PR TITLE
fix: deprecate 'optional' property for input mappings

### DIFF
--- a/packages/zeebe-element-templates-json-schema/CHANGELOG.md
+++ b/packages/zeebe-element-templates-json-schema/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to [@camunda/zeebe-element-templates-json-schema](https://gi
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FIX`: deprecate `optional` property for input mappings ([#235](https://github.com/camunda/element-templates-json-schema/pull/235))
+
 ## 0.39.2
 
 * `FIX`: deprecate `feel: optional` on non-editable properties ([#232](https://github.com/camunda/element-templates-json-schema/pull/232))

--- a/packages/zeebe-element-templates-json-schema/src/defs/properties.json
+++ b/packages/zeebe-element-templates-json-schema/src/defs/properties.json
@@ -786,6 +786,28 @@
           "deprecated": true,
           "deprecationWarning": "Using 'feel: optional' with 'editable: false' is invalid"
         }
+      },
+      {
+        "if": {
+          "properties": {
+            "optional": {
+              "const": true
+            },
+            "binding": {
+              "properties": {
+                "type": {
+                  "const": "zeebe:input"
+                }
+              },
+              "required": ["type"]
+            }
+          },
+          "required": ["optional", "binding"]
+        },
+        "then": {
+          "deprecated": true,
+          "deprecationWarning": "'optional' with 'zeebe:input' binding is deprecated; an empty input mapping (resolved to 'null') should be used for Camunda 8.8+"
+        }
       }
     ],
     "properties": {


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-modeler/issues/5840

### Proposed Changes

 Deprecate 'optional' property for input mappings
 
> Warning behavior will be validated into [element-templates-validator](https://github.com/bpmn-io/element-templates-validator) as follow up.

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->