### PR TITLE
feat: add `steps` and `presets` to zeebe schema

### DIFF
--- a/packages/zeebe-element-templates-json-schema/src/defs/template/presets.json
+++ b/packages/zeebe-element-templates-json-schema/src/defs/template/presets.json
@@ -1,0 +1,26 @@
+{
+  "$id": "#/presets",
+  "type": "array",
+  "description": "Predefined property value-mappings for the template. Referenced by leaf steps via presetId.",
+  "items": {
+    "$id": "#/presets/preset",
+    "type": "object",
+    "required": [
+      "id",
+      "properties"
+    ],
+    "properties": {
+      "id": {
+        "$id": "#/presets/preset/id",
+        "type": "string",
+        "description": "Unique identifier for the preset. Referenced by a step's presetId. Required."
+      },
+      "properties": {
+        "$id": "#/presets/preset/properties",
+        "type": "object",
+        "description": "Map of template property names to values applied on top of template defaults. Required.",
+        "additionalProperties": true
+      }
+    }
+  }
+}

--- a/packages/zeebe-element-templates-json-schema/src/defs/template/steps.json
+++ b/packages/zeebe-element-templates-json-schema/src/defs/template/steps.json
@@ -1,0 +1,72 @@
+{
+  "$id": "#/steps",
+  "type": "array",
+  "description": "Hierarchical menu exposed by this template. Each step is either a category (has nested steps) or a leaf (references a preset via presetId).",
+  "items": {
+    "$ref": "#/definitions/step"
+  },
+  "definitions": {
+    "step": {
+      "$id": "#/steps/step",
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "$id": "#/steps/step/name",
+          "type": "string",
+          "description": "Step name. Shown in the popup menu. Required."
+        },
+        "description": {
+          "$id": "#/steps/step/description",
+          "type": "string",
+          "description": "Optional description shown alongside the step name."
+        },
+        "keywords": {
+          "$id": "#/steps/step/keywords",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Keywords used to match the step in search."
+        },
+        "steps": {
+          "$id": "#/steps/step/steps",
+          "type": "array",
+          "description": "Child steps. Present on category steps.",
+          "items": {
+            "$ref": "#/definitions/step"
+          }
+        },
+        "presetId": {
+          "$id": "#/steps/step/presetId",
+          "type": "string",
+          "description": "Reference to a preset id defined in the template's presets array. Present on leaf steps."
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "steps"
+          ],
+          "not": {
+            "required": [
+              "presetId"
+            ]
+          }
+        },
+        {
+          "required": [
+            "presetId"
+          ],
+          "not": {
+            "required": [
+              "steps"
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/packages/zeebe-element-templates-json-schema/src/schema.json
+++ b/packages/zeebe-element-templates-json-schema/src/schema.json
@@ -50,6 +50,12 @@
         "groups": {
           "$ref": "src/defs/groups.json"
         },
+        "steps": {
+          "$ref": "src/defs/template/steps.json"
+        },
+        "presets": {
+          "$ref": "src/defs/template/presets.json"
+        },
         "entriesVisible": {
           "$id": "#/entriesVisible",
           "oneOf": [

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/preset-missing-properties.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/preset-missing-properties.js
@@ -1,0 +1,37 @@
+export const template = {
+  'name': 'Invalid preset',
+  'id': 'example.com.presetMissingProperties',
+  'appliesTo': [
+    'bpmn:ServiceTask'
+  ],
+  'properties': [],
+  'presets': [
+    {
+      'id': 'doIt'
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'required',
+    dataPath: '/presets/0',
+    schemaPath: '#/properties/presets/items/required',
+    params: { missingProperty: 'properties' },
+    message: "should have required property 'properties'"
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: { type: 'array' },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: { passingSchemas: null },
+    message: 'should match exactly one schema in oneOf'
+  }
+];

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/step-both-children-and-presetId.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/step-both-children-and-presetId.js
@@ -1,0 +1,68 @@
+export const template = {
+  'name': 'Invalid step',
+  'id': 'example.com.stepBothChildrenAndPresetId',
+  'appliesTo': [
+    'bpmn:ServiceTask'
+  ],
+  'properties': [],
+  'steps': [
+    {
+      'name': 'Bad step',
+      'presetId': 'doIt',
+      'steps': [
+        {
+          'name': 'Nested',
+          'presetId': 'nested'
+        }
+      ]
+    }
+  ],
+  'presets': [
+    {
+      'id': 'doIt',
+      'properties': {}
+    },
+    {
+      'id': 'nested',
+      'properties': {}
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'not',
+    dataPath: '/steps/0',
+    schemaPath: '#/oneOf/0/not',
+    params: {},
+    message: 'should NOT be valid'
+  },
+  {
+    keyword: 'not',
+    dataPath: '/steps/0',
+    schemaPath: '#/oneOf/1/not',
+    params: {},
+    message: 'should NOT be valid'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '/steps/0',
+    schemaPath: '#/oneOf',
+    params: { passingSchemas: null },
+    message: 'should match exactly one schema in oneOf'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: { type: 'array' },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: { passingSchemas: null },
+    message: 'should match exactly one schema in oneOf'
+  }
+];

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/step-missing-name.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/step-missing-name.js
@@ -1,0 +1,43 @@
+export const template = {
+  'name': 'Invalid step',
+  'id': 'example.com.stepMissingName',
+  'appliesTo': [
+    'bpmn:ServiceTask'
+  ],
+  'properties': [],
+  'steps': [
+    {
+      'presetId': 'doIt'
+    }
+  ],
+  'presets': [
+    {
+      'id': 'doIt',
+      'properties': {}
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'required',
+    dataPath: '/steps/0',
+    schemaPath: '#/required',
+    params: { missingProperty: 'name' },
+    message: "should have required property 'name'"
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: { type: 'array' },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: { passingSchemas: null },
+    message: 'should match exactly one schema in oneOf'
+  }
+];

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/step-neither.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/step-neither.js
@@ -1,0 +1,51 @@
+export const template = {
+  'name': 'Invalid step',
+  'id': 'example.com.stepNeither',
+  'appliesTo': [
+    'bpmn:ServiceTask'
+  ],
+  'properties': [],
+  'steps': [
+    {
+      'name': 'Empty step'
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'required',
+    dataPath: '/steps/0',
+    schemaPath: '#/oneOf/0/required',
+    params: { missingProperty: 'steps' },
+    message: "should have required property 'steps'"
+  },
+  {
+    keyword: 'required',
+    dataPath: '/steps/0',
+    schemaPath: '#/oneOf/1/required',
+    params: { missingProperty: 'presetId' },
+    message: "should have required property 'presetId'"
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '/steps/0',
+    schemaPath: '#/oneOf',
+    params: { passingSchemas: null },
+    message: 'should match exactly one schema in oneOf'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: { type: 'array' },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: { passingSchemas: null },
+    message: 'should match exactly one schema in oneOf'
+  }
+];

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/steps-flat.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/steps-flat.js
@@ -1,0 +1,45 @@
+export const template = {
+  'name': 'GitHub Connector',
+  'id': 'example.com.githubConnector',
+  'appliesTo': [
+    'bpmn:ServiceTask'
+  ],
+  'properties': [
+    {
+      'label': 'Operation',
+      'type': 'String',
+      'binding': {
+        'type': 'zeebe:input',
+        'name': 'operation'
+      }
+    }
+  ],
+  'steps': [
+    {
+      'name': 'Create issue',
+      'description': 'Create a GitHub issue',
+      'keywords': [ 'create', 'issue' ],
+      'presetId': 'createIssue'
+    },
+    {
+      'name': 'Close issue',
+      'presetId': 'closeIssue'
+    }
+  ],
+  'presets': [
+    {
+      'id': 'createIssue',
+      'properties': {
+        'operation': 'createIssue'
+      }
+    },
+    {
+      'id': 'closeIssue',
+      'properties': {
+        'operation': 'closeIssue'
+      }
+    }
+  ]
+};
+
+export const errors = null;

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/steps-nested.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/steps-nested.js
@@ -1,0 +1,58 @@
+export const template = {
+  'name': 'GitHub Connector',
+  'id': 'example.com.githubConnectorNested',
+  'appliesTo': [
+    'bpmn:ServiceTask'
+  ],
+  'properties': [
+    {
+      'label': 'Operation',
+      'type': 'String',
+      'binding': {
+        'type': 'zeebe:input',
+        'name': 'operation'
+      }
+    }
+  ],
+  'steps': [
+    {
+      'name': 'Issues',
+      'description': 'Manage GitHub issues',
+      'steps': [
+        {
+          'name': 'Create issue',
+          'presetId': 'createIssue'
+        },
+        {
+          'name': 'Close issue',
+          'presetId': 'closeIssue'
+        }
+      ]
+    },
+    {
+      'name': 'Pull requests',
+      'steps': [
+        {
+          'name': 'Open PR',
+          'presetId': 'openPr'
+        }
+      ]
+    }
+  ],
+  'presets': [
+    {
+      'id': 'createIssue',
+      'properties': { 'operation': 'createIssue' }
+    },
+    {
+      'id': 'closeIssue',
+      'properties': { 'operation': 'closeIssue' }
+    },
+    {
+      'id': 'openPr',
+      'properties': { 'operation': 'openPr' }
+    }
+  ]
+};
+
+export const errors = null;

--- a/packages/zeebe-element-templates-json-schema/test/spec/validationSpec.js
+++ b/packages/zeebe-element-templates-json-schema/test/spec/validationSpec.js
@@ -774,6 +774,23 @@ describe('validation', function() {
 
     });
 
+    describe('steps and presets', function() {
+
+      it('steps-flat');
+
+      it('steps-nested');
+
+      it('step-both-children-and-presetId');
+
+      it('step-neither');
+
+      it('step-missing-name');
+
+      it('preset-missing-properties');
+
+    });
+
+
     describe('zeebe:adHoc', function() {
 
       it('ad-hoc/invalid-bpmn-ad-hoc-impl-properties');


### PR DESCRIPTION
Related to https://github.com/bpmn-io/internal-docs/issues/1315

### Proposed Changes

Adds schema support for the new steps and presets fields. 

Enables template authors to declare a hierarchical (recursive) menu of operations and a flat list of value-mapping presets referenced by leaf steps. 

Both fields are optional and additive — no breaking change.

### Steps

<p>Recursive array of menu entries on a template. A step is either a category (has child <code>steps</code>) or a leaf (has <code>presetId</code>).</p>

Field | Type | Required | Description
-- | -- | -- | --
name | string | yes | Step label shown in the popup menu.
description | string | no | Secondary line shown alongside the name.
keywords | string[] | no | Extra terms used to match the step in search.
steps | step[] | one of steps / presetId | Nested child steps. Marks this step as a category.
presetId | string | one of steps / presetId | Reference to a presets[].id. Marks this step as a leaf.

### Presets

<p>Flat array of value mappings referenced by leaf steps.</p>

Field | Type | Required | Description
-- | -- | -- | --
id | string | yes | Unique preset identifier. Referenced by a leaf step's presetId.
properties | object | yes | Map of template property names to values applied on top of template defaults. Free-form.

### Example schema

```json
{
  "steps": [
    {
      "name": "Issues",
      "description": "Manage GitHub Issues",
      "steps": [
        {
          "name": "Create Issue",
          "description": "Create a new GitHub issue",
          "keywords": ["create issue", "open ticket"],
          "presetId": "createIssue"
        }
      ]
    }
  ],
  "presets": [
    {
      "id": "createIssue",
      "properties": {
        "operationGroup": "issues",
        "issueOperationType": "createIssue"
      }
    }
  ]
}
```


### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->