### PR TITLE
feat: add zeebe:jobPriorityDefinition binding type

### DIFF
--- a/packages/zeebe-element-templates-json-schema/CHANGELOG.md
+++ b/packages/zeebe-element-templates-json-schema/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to [@camunda/zeebe-element-templates-json-schema](https://gi
 
 ___Note:__ Yet to be released changes appear here._
 
+## 0.43.0
+
+* `FEAT`: add `zeebe:jobPriorityDefinition` binding type
+
 ## 0.42.0
 
 * `FEAT`: support `isEmpty` condition ([#252](https://github.com/camunda/element-templates-json-schema/pull/252))

--- a/packages/zeebe-element-templates-json-schema/src/defs/properties.json
+++ b/packages/zeebe-element-templates-json-schema/src/defs/properties.json
@@ -64,6 +64,7 @@
                     "zeebe:script",
                     "zeebe:assignmentDefinition",
                     "zeebe:priorityDefinition",
+                    "zeebe:jobPriorityDefinition",
                     "zeebe:adHoc",
                     "zeebe:taskSchedule"
                   ]
@@ -808,6 +809,9 @@
           "deprecated": true,
           "deprecationWarning": "'optional' with 'zeebe:input' binding is deprecated; an empty input mapping (resolved to 'null') should be used for Camunda 8.8+"
         }
+      },
+      {
+        "$ref": "./properties/jobPriorityDefinition.json"
       }
     ],
     "properties": {
@@ -1053,6 +1057,9 @@
           },
           {
             "$ref": "examples.json#/binding"
+          },
+          {
+            "$ref": "./properties/binding/jobPriorityDefinition.json"
           }
         ],
         "properties": {
@@ -1078,6 +1085,7 @@
               "zeebe:script",
               "zeebe:assignmentDefinition",
               "zeebe:priorityDefinition",
+              "zeebe:jobPriorityDefinition",
               "zeebe:adHoc",
               "zeebe:taskSchedule",
               "zeebe:executionListener",

--- a/packages/zeebe-element-templates-json-schema/src/defs/properties/binding/jobPriorityDefinition.json
+++ b/packages/zeebe-element-templates-json-schema/src/defs/properties/binding/jobPriorityDefinition.json
@@ -1,0 +1,22 @@
+{
+  "if": {
+    "properties": {
+      "type": {
+        "const": "zeebe:jobPriorityDefinition"
+      }
+    },
+    "required": [
+      "type"
+    ]
+  },
+  "then": {
+    "properties": {
+      "property": {
+        "const": "priority"
+      }
+    },
+    "required": [
+      "property"
+    ]
+  }
+}

--- a/packages/zeebe-element-templates-json-schema/src/defs/properties/jobPriorityDefinition.json
+++ b/packages/zeebe-element-templates-json-schema/src/defs/properties/jobPriorityDefinition.json
@@ -1,0 +1,135 @@
+{
+  "allOf": [
+    {
+      "if": {
+        "type": "object",
+        "properties": {
+          "binding": {
+            "properties": {
+              "type": {
+                "const": "zeebe:jobPriorityDefinition"
+              },
+              "property": {
+                "const": "priority"
+              }
+            },
+            "required": [
+              "type",
+              "property"
+            ]
+          }
+        },
+        "required": [
+          "binding"
+        ]
+      },
+      "then": {
+        "properties": {
+          "type": {
+            "enum": [
+              "Hidden",
+              "Number",
+              "Dropdown"
+            ]
+          }
+        },
+        "required": [
+          "type"
+        ]
+      }
+    },
+    {
+      "if": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "const": "Number"
+          },
+          "binding": {
+            "properties": {
+              "type": {
+                "const": "zeebe:jobPriorityDefinition"
+              },
+              "property": {
+                "const": "priority"
+              }
+            },
+            "required": [
+              "type",
+              "property"
+            ]
+          }
+        },
+        "required": [
+          "binding",
+          "value",
+          "type"
+        ]
+      },
+      "then": {
+        "properties": {
+          "value": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "string",
+                "pattern": "^=.*"
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "enum": [
+              "Hidden",
+              "Dropdown"
+            ]
+          },
+          "binding": {
+            "properties": {
+              "type": {
+                "const": "zeebe:jobPriorityDefinition"
+              },
+              "property": {
+                "const": "priority"
+              }
+            },
+            "required": [
+              "type",
+              "property"
+            ]
+          }
+        },
+        "required": [
+          "binding",
+          "type"
+        ]
+      },
+      "then": {
+        "properties": {
+          "value": {
+            "type": "string",
+            "pattern": "^(=.*|-?[0-9]+)$"
+          },
+          "choices": {
+            "items": {
+              "properties": {
+                "value": {
+                  "type": "string",
+                  "pattern": "^(=.*|-?[0-9]+)$"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/packages/zeebe-element-templates-json-schema/src/defs/template.json
+++ b/packages/zeebe-element-templates-json-schema/src/defs/template.json
@@ -709,6 +709,109 @@
     },
     {
       "$ref": "./template/listeners.json"
+    },
+    {
+      "if": {
+        "properties": {
+          "properties": {
+            "contains": {
+              "properties": {
+                "binding": {
+                  "properties": {
+                    "type": {
+                      "const": "zeebe:jobPriorityDefinition"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ]
+                }
+              },
+              "required": [
+                "binding"
+              ]
+            }
+          }
+        },
+        "required": [
+          "properties"
+        ]
+      },
+      "then": {
+        "anyOf": [
+          {
+            "required": [
+              "elementType"
+            ],
+            "properties": {
+              "elementType": {
+                "required": [
+                  "value"
+                ],
+                "properties": {
+                  "value": {
+                    "enum": [
+                      "bpmn:ScriptTask",
+                      "bpmn:BusinessRuleTask",
+                      "bpmn:ServiceTask",
+                      "bpmn:SendTask",
+                      "bpmn:AdHocSubProcess",
+                      "bpmn:Process",
+                      "bpmn:IntermediateThrowEvent",
+                      "bpmn:EndEvent"
+                    ]
+                  }
+                },
+                "allOf": [
+                  {
+                    "if": {
+                      "properties": {
+                        "value": {
+                          "enum": [
+                            "bpmn:IntermediateThrowEvent",
+                            "bpmn:EndEvent"
+                          ]
+                        }
+                      }
+                    },
+                    "then": {
+                      "properties": {
+                        "eventDefinition": {
+                          "const": "bpmn:MessageEventDefinition"
+                        }
+                      },
+                      "required": [
+                        "eventDefinition"
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "required": [
+              "appliesTo"
+            ],
+            "properties": {
+              "appliesTo": {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "enum": [
+                    "bpmn:ScriptTask",
+                    "bpmn:BusinessRuleTask",
+                    "bpmn:ServiceTask",
+                    "bpmn:SendTask",
+                    "bpmn:AdHocSubProcess",
+                    "bpmn:Process"
+                  ]
+                }
+              }
+            }
+          }
+        ]
+      }
     }
   ]
 }

--- a/packages/zeebe-element-templates-json-schema/src/error-messages.json
+++ b/packages/zeebe-element-templates-json-schema/src/error-messages.json
@@ -182,7 +182,7 @@
       "properties",
       "type"
     ],
-    "errorMessage": "invalid property.binding type ${0}; must be any of { property, zeebe:taskDefinition:type, zeebe:input, zeebe:output, zeebe:property, zeebe:taskHeader, bpmn:Message#property, bpmn:Message#zeebe:subscription#property, zeebe:taskDefinition, zeebe:calledElement, zeebe:linkedResource, zeebe:userTask, zeebe:formDefinition, zeebe:calledDecision, zeebe:script, zeebe:assignmentDefinition, zeebe:priorityDefinition, zeebe:adHoc, zeebe:taskSchedule, zeebe:executionListener, zeebe:taskListener, bpmn:Signal#property, bpmn:TimerEventDefinition#property }"
+    "errorMessage": "invalid property.binding type ${0}; must be any of { property, zeebe:taskDefinition:type, zeebe:input, zeebe:output, zeebe:property, zeebe:taskHeader, bpmn:Message#property, bpmn:Message#zeebe:subscription#property, zeebe:taskDefinition, zeebe:calledElement, zeebe:linkedResource, zeebe:userTask, zeebe:formDefinition, zeebe:calledDecision, zeebe:script, zeebe:assignmentDefinition, zeebe:priorityDefinition, zeebe:jobPriorityDefinition, zeebe:adHoc, zeebe:taskSchedule, zeebe:executionListener, zeebe:taskListener, bpmn:Signal#property, bpmn:TimerEventDefinition#property }"
   },
   {
     "path": [

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/invalid-binding-type.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/invalid-binding-type.js
@@ -54,6 +54,7 @@ export const errors = [
               'zeebe:script',
               'zeebe:assignmentDefinition',
               'zeebe:priorityDefinition',
+              'zeebe:jobPriorityDefinition',
               'zeebe:adHoc',
               'zeebe:taskSchedule',
               'zeebe:executionListener',
@@ -69,7 +70,7 @@ export const errors = [
         }
       ]
     },
-    message: 'invalid property.binding type "foo"; must be any of { property, zeebe:taskDefinition:type, zeebe:input, zeebe:output, zeebe:property, zeebe:taskHeader, bpmn:Message#property, bpmn:Message#zeebe:subscription#property, zeebe:taskDefinition, zeebe:calledElement, zeebe:linkedResource, zeebe:userTask, zeebe:formDefinition, zeebe:calledDecision, zeebe:script, zeebe:assignmentDefinition, zeebe:priorityDefinition, zeebe:adHoc, zeebe:taskSchedule, zeebe:executionListener, zeebe:taskListener, bpmn:Signal#property, bpmn:TimerEventDefinition#property }'
+    message: 'invalid property.binding type "foo"; must be any of { property, zeebe:taskDefinition:type, zeebe:input, zeebe:output, zeebe:property, zeebe:taskHeader, bpmn:Message#property, bpmn:Message#zeebe:subscription#property, zeebe:taskDefinition, zeebe:calledElement, zeebe:linkedResource, zeebe:userTask, zeebe:formDefinition, zeebe:calledDecision, zeebe:script, zeebe:assignmentDefinition, zeebe:priorityDefinition, zeebe:jobPriorityDefinition, zeebe:adHoc, zeebe:taskSchedule, zeebe:executionListener, zeebe:taskListener, bpmn:Signal#property, bpmn:TimerEventDefinition#property }'
   },
   {
     keyword: 'type',

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/job-priority-definition/invalid-element-type.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/job-priority-definition/invalid-element-type.js
@@ -1,0 +1,92 @@
+export const template = {
+  name: 'Job Priority Definition',
+  id: 'job-priority-definition-invalid-element',
+  version: 1,
+  appliesTo: [
+    'bpmn:Task'
+  ],
+  elementType: {
+    value: 'bpmn:UserTask'
+  },
+  properties: [
+    {
+      value: '50',
+      type: 'Hidden',
+      binding: {
+        type: 'zeebe:jobPriorityDefinition',
+        property: 'priority'
+      }
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'enum',
+    dataPath: '/elementType/value',
+    schemaPath: '#/allOf/1/allOf/14/then/anyOf/0/properties/elementType/properties/value/enum',
+    params: {
+      allowedValues: [
+        'bpmn:ScriptTask',
+        'bpmn:BusinessRuleTask',
+        'bpmn:ServiceTask',
+        'bpmn:SendTask',
+        'bpmn:AdHocSubProcess',
+        'bpmn:Process',
+        'bpmn:IntermediateThrowEvent',
+        'bpmn:EndEvent'
+      ]
+    },
+    message: 'should be equal to one of the allowed values'
+  },
+  {
+    keyword: 'enum',
+    dataPath: '/appliesTo/0',
+    schemaPath: '#/allOf/1/allOf/14/then/anyOf/1/properties/appliesTo/items/enum',
+    params: {
+      allowedValues: [
+        'bpmn:ScriptTask',
+        'bpmn:BusinessRuleTask',
+        'bpmn:ServiceTask',
+        'bpmn:SendTask',
+        'bpmn:AdHocSubProcess',
+        'bpmn:Process'
+      ]
+    },
+    message: 'should be equal to one of the allowed values'
+  },
+  {
+    keyword: 'anyOf',
+    dataPath: '',
+    schemaPath: '#/allOf/1/allOf/14/then/anyOf',
+    params: {},
+    message: 'should match some schema in anyOf'
+  },
+  {
+    keyword: 'if',
+    dataPath: '',
+    schemaPath: '#/allOf/1/allOf/14/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: {
+      type: 'array'
+    },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: {
+      passingSchemas: null
+    },
+    message: 'should match exactly one schema in oneOf'
+  }
+];

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/job-priority-definition/invalid-hidden-dropdown-values.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/job-priority-definition/invalid-hidden-dropdown-values.js
@@ -1,0 +1,102 @@
+export const template = {
+  name: 'Job Priority Definition',
+  id: 'job-priority-definition',
+  description: 'A template to define job priority.',
+  version: 1,
+  appliesTo: [
+    'bpmn:Task'
+  ],
+  elementType: {
+    value: 'bpmn:ServiceTask'
+  },
+  properties: [
+    {
+      type: 'Hidden',
+      value: 'my-job-worker',
+      binding: {
+        type: 'zeebe:taskDefinition',
+        property: 'type'
+      }
+    },
+    {
+      value: 'not-a-priority',
+      type: 'Hidden',
+      binding: {
+        type: 'zeebe:jobPriorityDefinition',
+        property: 'priority'
+      }
+    },
+    {
+      label: 'Prio',
+      value: '50',
+      type: 'Dropdown',
+      binding: {
+        type: 'zeebe:jobPriorityDefinition',
+        property: 'priority'
+      },
+      choices: [
+        {
+          name: 'Invalid',
+          value: '3.5'
+        }
+      ]
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'pattern',
+    dataPath: '/properties/1/value',
+    schemaPath: '#/allOf/1/items/allOf/33/allOf/2/then/properties/value/pattern',
+    params: {
+      pattern: '^(=.*|-?[0-9]+)$'
+    },
+    message: 'should match pattern "^(=.*|-?[0-9]+)$"'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/1',
+    schemaPath: '#/allOf/1/items/allOf/33/allOf/2/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'pattern',
+    dataPath: '/properties/2/choices/0/value',
+    schemaPath: '#/allOf/1/items/allOf/33/allOf/2/then/properties/choices/items/properties/value/pattern',
+    params: {
+      pattern: '^(=.*|-?[0-9]+)$'
+    },
+    message: 'should match pattern "^(=.*|-?[0-9]+)$"'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/2',
+    schemaPath: '#/allOf/1/items/allOf/33/allOf/2/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: {
+      type: 'array'
+    },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: {
+      passingSchemas: null
+    },
+    message: 'should match exactly one schema in oneOf'
+  }
+];

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/job-priority-definition/invalid-input-types.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/job-priority-definition/invalid-input-types.js
@@ -1,0 +1,105 @@
+export const template = {
+  name: 'Job Priority Definition',
+  id: 'job-priority-definition',
+  description: 'A template to define job priority.',
+  version: 1,
+  appliesTo: [
+    'bpmn:Task'
+  ],
+  elementType: {
+    value: 'bpmn:ServiceTask'
+  },
+  properties: [
+    {
+      type: 'Hidden',
+      value: 'my-job-worker',
+      binding: {
+        type: 'zeebe:taskDefinition',
+        property: 'type'
+      }
+    },
+    {
+      label: 'Prio',
+      value: '1',
+      type: 'Text',
+      binding: {
+        type: 'zeebe:jobPriorityDefinition',
+        property: 'priority'
+      }
+    },
+    {
+      label: 'Prio 2',
+      value: true,
+      type: 'Boolean',
+      binding: {
+        type: 'zeebe:jobPriorityDefinition',
+        property: 'priority'
+      }
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'enum',
+    dataPath: '/properties/1/type',
+    schemaPath: '#/allOf/1/items/allOf/33/allOf/0/then/properties/type/enum',
+    params: {
+      allowedValues: [
+        'Hidden',
+        'Number',
+        'Dropdown'
+      ]
+    },
+    message: 'should be equal to one of the allowed values'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/1',
+    schemaPath: '#/allOf/1/items/allOf/33/allOf/0/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'enum',
+    dataPath: '/properties/2/type',
+    schemaPath: '#/allOf/1/items/allOf/33/allOf/0/then/properties/type/enum',
+    params: {
+      allowedValues: [
+        'Hidden',
+        'Number',
+        'Dropdown'
+      ]
+    },
+    message: 'should be equal to one of the allowed values'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/2',
+    schemaPath: '#/allOf/1/items/allOf/33/allOf/0/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: {
+      type: 'array'
+    },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: {
+      passingSchemas: null
+    },
+    message: 'should match exactly one schema in oneOf'
+  }
+];

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/job-priority-definition/invalid-missing-element-type.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/job-priority-definition/invalid-missing-element-type.js
@@ -1,0 +1,80 @@
+export const template = {
+  name: 'Job Priority Definition',
+  id: 'job-priority-definition-missing-element-type',
+  version: 1,
+  appliesTo: [
+    'bpmn:Task'
+  ],
+  properties: [
+    {
+      value: '50',
+      type: 'Hidden',
+      binding: {
+        type: 'zeebe:jobPriorityDefinition',
+        property: 'priority'
+      }
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'required',
+    dataPath: '',
+    schemaPath: '#/allOf/1/allOf/14/then/anyOf/0/required',
+    params: {
+      missingProperty: 'elementType'
+    },
+    message: 'should have required property \'elementType\''
+  },
+  {
+    keyword: 'enum',
+    dataPath: '/appliesTo/0',
+    schemaPath: '#/allOf/1/allOf/14/then/anyOf/1/properties/appliesTo/items/enum',
+    params: {
+      allowedValues: [
+        'bpmn:ScriptTask',
+        'bpmn:BusinessRuleTask',
+        'bpmn:ServiceTask',
+        'bpmn:SendTask',
+        'bpmn:AdHocSubProcess',
+        'bpmn:Process'
+      ]
+    },
+    message: 'should be equal to one of the allowed values'
+  },
+  {
+    keyword: 'anyOf',
+    dataPath: '',
+    schemaPath: '#/allOf/1/allOf/14/then/anyOf',
+    params: {},
+    message: 'should match some schema in anyOf'
+  },
+  {
+    keyword: 'if',
+    dataPath: '',
+    schemaPath: '#/allOf/1/allOf/14/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: {
+      type: 'array'
+    },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: {
+      passingSchemas: null
+    },
+    message: 'should match exactly one schema in oneOf'
+  }
+];

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/job-priority-definition/invalid-missing-event-definition.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/job-priority-definition/invalid-missing-event-definition.js
@@ -1,0 +1,92 @@
+export const template = {
+  name: 'Job Priority Definition',
+  id: 'job-priority-definition-missing-event-definition',
+  version: 1,
+  appliesTo: [
+    'bpmn:IntermediateThrowEvent'
+  ],
+  elementType: {
+    value: 'bpmn:IntermediateThrowEvent'
+  },
+  properties: [
+    {
+      value: '50',
+      type: 'Hidden',
+      binding: {
+        type: 'zeebe:jobPriorityDefinition',
+        property: 'priority'
+      }
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'required',
+    dataPath: '/elementType',
+    schemaPath: '#/allOf/1/allOf/14/then/anyOf/0/properties/elementType/allOf/0/then/required',
+    params: {
+      missingProperty: 'eventDefinition'
+    },
+    message: 'should have required property \'eventDefinition\''
+  },
+  {
+    keyword: 'if',
+    dataPath: '/elementType',
+    schemaPath: '#/allOf/1/allOf/14/then/anyOf/0/properties/elementType/allOf/0/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'enum',
+    dataPath: '/appliesTo/0',
+    schemaPath: '#/allOf/1/allOf/14/then/anyOf/1/properties/appliesTo/items/enum',
+    params: {
+      allowedValues: [
+        'bpmn:ScriptTask',
+        'bpmn:BusinessRuleTask',
+        'bpmn:ServiceTask',
+        'bpmn:SendTask',
+        'bpmn:AdHocSubProcess',
+        'bpmn:Process'
+      ]
+    },
+    message: 'should be equal to one of the allowed values'
+  },
+  {
+    keyword: 'anyOf',
+    dataPath: '',
+    schemaPath: '#/allOf/1/allOf/14/then/anyOf',
+    params: {},
+    message: 'should match some schema in anyOf'
+  },
+  {
+    keyword: 'if',
+    dataPath: '',
+    schemaPath: '#/allOf/1/allOf/14/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: {
+      type: 'array'
+    },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: {
+      passingSchemas: null
+    },
+    message: 'should match exactly one schema in oneOf'
+  }
+];

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/job-priority-definition/invalid-property.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/job-priority-definition/invalid-property.js
@@ -1,0 +1,74 @@
+export const template = {
+  'name': 'Job Priority Definition',
+  'id': 'job-priority-definition',
+  'description': 'A template to define job priority.',
+  'version': 1,
+  'appliesTo': [
+    'bpmn:Task'
+  ],
+  'elementType': {
+    'value': 'bpmn:ServiceTask'
+  },
+  'properties': [
+    {
+      'type': 'Hidden',
+      'value': 'my-job-worker',
+      'binding': {
+        'type': 'zeebe:taskDefinition',
+        'property': 'type'
+      }
+    },
+    {
+      'label': 'Prio',
+      'value': '90',
+      'description': 'Prio for job',
+      'constraints': {
+        'notEmpty': true
+      },
+      'type': 'String',
+      'binding': {
+        'type': 'zeebe:jobPriorityDefinition',
+        'property': 'youShallNotPass'
+      }
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'const',
+    dataPath: '/properties/1/binding/property',
+    schemaPath: '#/allOf/1/items/properties/binding/allOf/18/then/properties/property/const',
+    params: {
+      allowedValue: 'priority'
+    },
+    message: 'should be equal to constant'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/1/binding',
+    schemaPath: '#/allOf/1/items/properties/binding/allOf/18/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: {
+      type: 'array'
+    },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: {
+      passingSchemas: null
+    },
+    message: 'should match exactly one schema in oneOf'
+  }
+];

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/job-priority-definition/invalid-string-type.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/job-priority-definition/invalid-string-type.js
@@ -1,0 +1,76 @@
+export const template = {
+  name: 'Job Priority Definition',
+  id: 'job-priority-definition',
+  description: 'A template to define job priority.',
+  version: 1,
+  appliesTo: [
+    'bpmn:Task'
+  ],
+  elementType: {
+    value: 'bpmn:ServiceTask'
+  },
+  properties: [
+    {
+      type: 'Hidden',
+      value: 'my-job-worker',
+      binding: {
+        type: 'zeebe:taskDefinition',
+        property: 'type'
+      }
+    },
+    {
+      label: 'Prio',
+      value: '= 1',
+      description: 'Prio for job',
+      type: 'String',
+      feel: 'required',
+      binding: {
+        type: 'zeebe:jobPriorityDefinition',
+        property: 'priority'
+      }
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'enum',
+    dataPath: '/properties/1/type',
+    schemaPath: '#/allOf/1/items/allOf/33/allOf/0/then/properties/type/enum',
+    params: {
+      allowedValues: [
+        'Hidden',
+        'Number',
+        'Dropdown'
+      ]
+    },
+    message: 'should be equal to one of the allowed values'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/1',
+    schemaPath: '#/allOf/1/items/allOf/33/allOf/0/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: {
+      type: 'array'
+    },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: {
+      passingSchemas: null
+    },
+    message: 'should match exactly one schema in oneOf'
+  }
+];

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/job-priority-definition/invalid-values.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/job-priority-definition/invalid-values.js
@@ -1,0 +1,86 @@
+export const template = {
+  name: 'Job Priority Definition',
+  id: 'job-priority-definition',
+  description: 'A template to define job priority.',
+  version: 1,
+  appliesTo: [
+    'bpmn:Task'
+  ],
+  elementType: {
+    value: 'bpmn:ServiceTask'
+  },
+  properties: [
+    {
+      type: 'Hidden',
+      value: 'my-job-worker',
+      binding: {
+        type: 'zeebe:taskDefinition',
+        property: 'type'
+      }
+    },
+    {
+      label: 'Prio',
+      value: 50.5,
+      type: 'Number',
+      binding: {
+        type: 'zeebe:jobPriorityDefinition',
+        property: 'priority'
+      }
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'type',
+    dataPath: '/properties/1/value',
+    schemaPath: '#/allOf/1/items/allOf/33/allOf/1/then/properties/value/anyOf/0/type',
+    params: {
+      type: 'integer'
+    },
+    message: 'should be integer'
+  },
+  {
+    keyword: 'type',
+    dataPath: '/properties/1/value',
+    schemaPath: '#/allOf/1/items/allOf/33/allOf/1/then/properties/value/anyOf/1/type',
+    params: {
+      type: 'string'
+    },
+    message: 'should be string'
+  },
+  {
+    keyword: 'anyOf',
+    dataPath: '/properties/1/value',
+    schemaPath: '#/allOf/1/items/allOf/33/allOf/1/then/properties/value/anyOf',
+    params: {},
+    message: 'should match some schema in anyOf'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/1',
+    schemaPath: '#/allOf/1/items/allOf/33/allOf/1/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: {
+      type: 'array'
+    },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: {
+      passingSchemas: null
+    },
+    message: 'should match exactly one schema in oneOf'
+  }
+];

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/job-priority-definition/valid-applies-to.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/job-priority-definition/valid-applies-to.js
@@ -1,0 +1,23 @@
+export const template = {
+  name: 'Job Priority Definition',
+  id: 'job-priority-definition-applies-to',
+  description: 'A template to define job priority, applies to multiple task types.',
+  version: 1,
+  appliesTo: [
+    'bpmn:ScriptTask',
+    'bpmn:BusinessRuleTask',
+    'bpmn:ServiceTask'
+  ],
+  properties: [
+    {
+      value: '50',
+      type: 'Hidden',
+      binding: {
+        type: 'zeebe:jobPriorityDefinition',
+        property: 'priority'
+      }
+    }
+  ]
+};
+
+export const errors = null;

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/job-priority-definition/valid-feel.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/job-priority-definition/valid-feel.js
@@ -1,0 +1,72 @@
+export const template = {
+  name: 'Job Priority Definition',
+  id: 'job-priority-definition',
+  description: 'A template to define job priority.',
+  version: 1,
+  appliesTo: [
+    'bpmn:Task'
+  ],
+  elementType: {
+    value: 'bpmn:ServiceTask'
+  },
+  properties: [
+    {
+      type: 'Hidden',
+      value: 'my-job-worker',
+      binding: {
+        type: 'zeebe:taskDefinition',
+        property: 'type'
+      }
+    },
+    {
+      value: '= order.priority',
+      type: 'Hidden',
+      binding: {
+        type: 'zeebe:jobPriorityDefinition',
+        property: 'priority'
+      }
+    },
+    {
+      value: '-5',
+      type: 'Hidden',
+      binding: {
+        type: 'zeebe:jobPriorityDefinition',
+        property: 'priority'
+      }
+    },
+    {
+      value: '= order.priority',
+      type: 'Number',
+      feel: 'optional',
+      binding: {
+        type: 'zeebe:jobPriorityDefinition',
+        property: 'priority'
+      }
+    },
+    {
+      label: 'Prio',
+      value: '= order.priority',
+      type: 'Dropdown',
+      binding: {
+        type: 'zeebe:jobPriorityDefinition',
+        property: 'priority'
+      },
+      choices: [
+        {
+          name: 'Dynamic',
+          value: '= order.priority'
+        },
+        {
+          name: 'High',
+          value: '90'
+        },
+        {
+          name: 'Negative',
+          value: '-5'
+        }
+      ]
+    }
+  ]
+};
+
+export const errors = null;

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/job-priority-definition/valid-message-end-event.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/job-priority-definition/valid-message-end-event.js
@@ -1,0 +1,25 @@
+export const template = {
+  name: 'Job Priority Definition',
+  id: 'job-priority-definition-message-end',
+  description: 'A template to define job priority on a message end event.',
+  version: 1,
+  appliesTo: [
+    'bpmn:EndEvent'
+  ],
+  elementType: {
+    value: 'bpmn:EndEvent',
+    eventDefinition: 'bpmn:MessageEventDefinition'
+  },
+  properties: [
+    {
+      value: '50',
+      type: 'Hidden',
+      binding: {
+        type: 'zeebe:jobPriorityDefinition',
+        property: 'priority'
+      }
+    }
+  ]
+};
+
+export const errors = null;

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/job-priority-definition/valid-message-throw-event.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/job-priority-definition/valid-message-throw-event.js
@@ -1,0 +1,25 @@
+export const template = {
+  name: 'Job Priority Definition',
+  id: 'job-priority-definition-message-throw',
+  description: 'A template to define job priority on a message throw event.',
+  version: 1,
+  appliesTo: [
+    'bpmn:IntermediateThrowEvent'
+  ],
+  elementType: {
+    value: 'bpmn:IntermediateThrowEvent',
+    eventDefinition: 'bpmn:MessageEventDefinition'
+  },
+  properties: [
+    {
+      value: '50',
+      type: 'Hidden',
+      binding: {
+        type: 'zeebe:jobPriorityDefinition',
+        property: 'priority'
+      }
+    }
+  ]
+};
+
+export const errors = null;

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/job-priority-definition/valid-send-task.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/job-priority-definition/valid-send-task.js
@@ -1,0 +1,24 @@
+export const template = {
+  name: 'Job Priority Definition',
+  id: 'job-priority-definition-send-task',
+  description: 'A template to define job priority on a send task.',
+  version: 1,
+  appliesTo: [
+    'bpmn:Task'
+  ],
+  elementType: {
+    value: 'bpmn:SendTask'
+  },
+  properties: [
+    {
+      value: '50',
+      type: 'Hidden',
+      binding: {
+        type: 'zeebe:jobPriorityDefinition',
+        property: 'priority'
+      }
+    }
+  ]
+};
+
+export const errors = null;

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/job-priority-definition/valid.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/job-priority-definition/valid.js
@@ -1,0 +1,86 @@
+export const template = {
+  'name': 'Job Priority Definition',
+  'id': 'job-priority-definition',
+  'description': 'A template to define job priority.',
+  'version': 1,
+  'appliesTo': [
+    'bpmn:Task'
+  ],
+  'elementType': {
+    'value': 'bpmn:ServiceTask'
+  },
+  'properties': [
+    {
+      'type': 'Hidden',
+      'value': 'my-job-worker',
+      'binding': {
+        'type': 'zeebe:taskDefinition',
+        'property': 'type'
+      }
+    },
+    {
+      'value': '50',
+      'constraints': {
+        'notEmpty': true
+      },
+      'type': 'Hidden',
+      'binding': {
+        'type': 'zeebe:jobPriorityDefinition',
+        'property': 'priority'
+      }
+    },
+    {
+      'value': 90,
+      'constraints': {
+        'notEmpty': true
+      },
+      'type': 'Number',
+      'binding': {
+        'type': 'zeebe:jobPriorityDefinition',
+        'property': 'priority'
+      }
+    },
+    {
+      'value': -5,
+      'type': 'Number',
+      'binding': {
+        'type': 'zeebe:jobPriorityDefinition',
+        'property': 'priority'
+      }
+    },
+    {
+      'value': 200,
+      'type': 'Number',
+      'binding': {
+        'type': 'zeebe:jobPriorityDefinition',
+        'property': 'priority'
+      }
+    },
+    {
+      'label': 'Prio',
+      'value': '50',
+      'description': 'Prio for job',
+      'type': 'Dropdown',
+      'binding': {
+        'type': 'zeebe:jobPriorityDefinition',
+        'property': 'priority'
+      },
+      'choices': [
+        {
+          'name': 'High',
+          'value': '90'
+        },
+        {
+          'name': 'Medium',
+          'value': '50'
+        },
+        {
+          'name': 'Low',
+          'value': '10'
+        }
+      ]
+    }
+  ]
+};
+
+export const errors = null;

--- a/packages/zeebe-element-templates-json-schema/test/spec/validationSpec.js
+++ b/packages/zeebe-element-templates-json-schema/test/spec/validationSpec.js
@@ -837,6 +837,39 @@ describe('validation', function() {
   });
 
 
+  describe('zeebe:jobPriorityDefinition', function() {
+
+    it('job-priority-definition/invalid-element-type');
+
+    it('job-priority-definition/invalid-missing-element-type');
+
+    it('job-priority-definition/invalid-missing-event-definition');
+
+    it('job-priority-definition/invalid-property');
+
+    it('job-priority-definition/invalid-string-type');
+
+    it('job-priority-definition/invalid-input-types');
+
+    it('job-priority-definition/invalid-values');
+
+    it('job-priority-definition/invalid-hidden-dropdown-values');
+
+    it('job-priority-definition/valid');
+
+    it('job-priority-definition/valid-feel');
+
+    it('job-priority-definition/valid-applies-to');
+
+    it('job-priority-definition/valid-message-throw-event');
+
+    it('job-priority-definition/valid-message-end-event');
+
+    it('job-priority-definition/valid-send-task');
+
+  });
+
+
   describe('zeebe:taskSchedule', function() {
 
     it('task-schedule/invalid-element-type');


### PR DESCRIPTION
Adds the `zeebe:jobPriorityDefinition` element-template binding type (with element-type gate).

Part of camunda/camunda-modeler#5889.

> The `@bpmn-io/element-templates-validator` must be rebuilt against this schema before bpmn-js-element-templates can accept templates using the binding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)