### PR TITLE
fix: add previously missing `canceling` task listener event type

### DIFF
--- a/packages/zeebe-element-templates-json-schema/CHANGELOG.md
+++ b/packages/zeebe-element-templates-json-schema/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to [@camunda/zeebe-element-templates-json-schema](https://gi
 
 ___Note:__ Yet to be released changes appear here._
 
+## 0.41.1
+
+* `FIX`: add previously missing `canceling` task listener event type ([#251](https://github.com/camunda/element-templates-json-schema/pull/251))
+
 ## 0.41.0
 
 * `FEAT`: add `steps` and `presets` to Zeebe schema ([#243](https://github.com/camunda/element-templates-json-schema/pull/243))

--- a/packages/zeebe-element-templates-json-schema/src/defs/properties/binding/listeners.json
+++ b/packages/zeebe-element-templates-json-schema/src/defs/properties/binding/listeners.json
@@ -43,7 +43,8 @@
               "creating",
               "assigning",
               "updating",
-              "completing"
+              "completing",
+              "canceling"
             ]
           }
         },

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/task-listener/invalid-event-type.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/task-listener/invalid-event-type.js
@@ -26,7 +26,8 @@ export const errors = [
         'creating',
         'assigning',
         'updating',
-        'completing'
+        'completing',
+        'canceling'
       ]
     },
     message: 'should be equal to one of the allowed values'

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/task-listener/valid.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/task-listener/valid.js
@@ -47,6 +47,16 @@ export const template = {
         'type': 'zeebe:taskListener',
         'eventType': 'updating'
       }
+    },
+    {
+      'type': 'Hidden',
+      'generatedValue': {
+        'type': 'uuid'
+      },
+      'binding': {
+        'type': 'zeebe:taskListener',
+        'eventType': 'canceling'
+      }
     }
   ]
 };


### PR DESCRIPTION
### Proposed Changes

Somehow we missed that event type in the PR and the review. Adding it now :)

Related to https://github.com/camunda/camunda-modeler/issues/6013

<!--
Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.
--> 

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->