### PR TITLE
Add `isEmpty` condition type

### DIFF
--- a/packages/element-templates-json-schema-shared/src/defs/condition.json
+++ b/packages/element-templates-json-schema-shared/src/defs/condition.json
@@ -61,6 +61,17 @@
           "required": [
             "isActive"
           ]
+        },
+        {
+          "properties": {
+            "isEmpty": {
+              "type": "boolean",
+              "description": "Checks if the referenced property's value is empty (true) or not empty (false)."
+            }
+          },
+          "required": [
+            "isEmpty"
+          ]
         }
       ]
     },

--- a/packages/element-templates-json-schema/test/fixtures/condition-default-type.js
+++ b/packages/element-templates-json-schema/test/fixtures/condition-default-type.js
@@ -51,6 +51,13 @@ export const errors = [
     message: "should have required property 'isActive'"
   },
   {
+    keyword: 'required',
+    dataPath: '/properties/1/condition',
+    schemaPath: '#/definitions/properties/allOf/0/items/allOf/1/definitions/condition/oneOf/3/required',
+    params: { missingProperty: 'isEmpty' },
+    message: "should have required property 'isEmpty'"
+  },
+  {
     keyword: 'oneOf',
     dataPath: '/properties/1/condition',
     schemaPath: '#/definitions/properties/allOf/0/items/allOf/1/definitions/condition/oneOf',

--- a/packages/element-templates-json-schema/test/fixtures/condition-missing-condition-keyword.js
+++ b/packages/element-templates-json-schema/test/fixtures/condition-missing-condition-keyword.js
@@ -52,6 +52,13 @@ export const errors = [
     message: "should have required property 'isActive'"
   },
   {
+    keyword: 'required',
+    dataPath: '/properties/1/condition',
+    schemaPath: '#/definitions/properties/allOf/0/items/allOf/1/definitions/condition/oneOf/3/required',
+    params: { missingProperty: 'isEmpty' },
+    message: "should have required property 'isEmpty'"
+  },
+  {
     keyword: 'oneOf',
     dataPath: '/properties/1/condition',
     schemaPath: '#/definitions/properties/allOf/0/items/allOf/1/definitions/condition/oneOf',

--- a/packages/element-templates-json-schema/test/fixtures/condition-wrong-types.js
+++ b/packages/element-templates-json-schema/test/fixtures/condition-wrong-types.js
@@ -66,6 +66,13 @@ export const errors = [
     message: "should have required property 'isActive'"
   },
   {
+    keyword: 'required',
+    dataPath: '/properties/1/condition',
+    schemaPath: '#/definitions/properties/allOf/0/items/allOf/1/definitions/condition/oneOf/3/required',
+    params: { missingProperty: 'isEmpty' },
+    message: "should have required property 'isEmpty'"
+  },
+  {
     keyword: 'oneOf',
     dataPath: '/properties/1/condition',
     schemaPath: '#/definitions/properties/allOf/0/items/allOf/1/definitions/condition/oneOf',
@@ -113,6 +120,13 @@ export const errors = [
     schemaPath: '#/definitions/properties/allOf/0/items/allOf/1/definitions/condition/oneOf/2/required',
     params: { missingProperty: 'isActive' },
     message: "should have required property 'isActive'"
+  },
+  {
+    keyword: 'required',
+    dataPath: '/properties/2/condition',
+    schemaPath: '#/definitions/properties/allOf/0/items/allOf/1/definitions/condition/oneOf/3/required',
+    params: { missingProperty: 'isEmpty' },
+    message: "should have required property 'isEmpty'"
   },
   {
     keyword: 'oneOf',

--- a/packages/element-templates-json-schema/test/fixtures/condition.js
+++ b/packages/element-templates-json-schema/test/fixtures/condition.js
@@ -102,6 +102,30 @@ export const template = {
         'type': 'property',
         'name': 'input4'
       }
+    },
+    {
+      'label': 'isEmpty (true)',
+      'type': 'String',
+      'condition': {
+        property: 'myId',
+        isEmpty: true
+      },
+      'binding': {
+        'type': 'property',
+        'name': 'input5'
+      }
+    },
+    {
+      'label': 'isEmpty (false)',
+      'type': 'String',
+      'condition': {
+        property: 'myId',
+        isEmpty: false
+      },
+      'binding': {
+        'type': 'property',
+        'name': 'input6'
+      }
     }
   ]
 };

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/condition-default-type.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/condition-default-type.js
@@ -51,6 +51,13 @@ export const errors = [
     message: "should have required property 'isActive'"
   },
   {
+    keyword: 'required',
+    dataPath: '/properties/1/condition',
+    schemaPath: '#/definitions/properties/allOf/0/items/allOf/1/definitions/condition/oneOf/3/required',
+    params: { missingProperty: 'isEmpty' },
+    message: "should have required property 'isEmpty'"
+  },
+  {
     keyword: 'oneOf',
     dataPath: '/properties/1/condition',
     schemaPath: '#/definitions/properties/allOf/0/items/allOf/1/definitions/condition/oneOf',

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/condition-empty-allMatch.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/condition-empty-allMatch.js
@@ -61,6 +61,13 @@ export const errors = [
     'message': "should have required property 'isActive'"
   },
   {
+    keyword: 'required',
+    dataPath: '/properties/2/condition',
+    schemaPath: '#/definitions/properties/allOf/0/items/allOf/1/definitions/condition/oneOf/3/required',
+    params: { missingProperty: 'isEmpty' },
+    message: "should have required property 'isEmpty'"
+  },
+  {
     keyword: 'oneOf',
     dataPath: '/properties/2/condition',
     schemaPath: '#/definitions/properties/allOf/0/items/allOf/1/definitions/condition/oneOf',

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/condition-missing-condition-keyword.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/condition-missing-condition-keyword.js
@@ -52,6 +52,13 @@ export const errors = [
     message: "should have required property 'isActive'"
   },
   {
+    keyword: 'required',
+    dataPath: '/properties/1/condition',
+    schemaPath: '#/definitions/properties/allOf/0/items/allOf/1/definitions/condition/oneOf/3/required',
+    params: { missingProperty: 'isEmpty' },
+    message: "should have required property 'isEmpty'"
+  },
+  {
     keyword: 'oneOf',
     dataPath: '/properties/1/condition',
     schemaPath: '#/definitions/properties/allOf/0/items/allOf/1/definitions/condition/oneOf',

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/condition-wrong-types.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/condition-wrong-types.js
@@ -66,6 +66,13 @@ export const errors = [
     message: "should have required property 'isActive'"
   },
   {
+    keyword: 'required',
+    dataPath: '/properties/1/condition',
+    schemaPath: '#/definitions/properties/allOf/0/items/allOf/1/definitions/condition/oneOf/3/required',
+    params: { missingProperty: 'isEmpty' },
+    message: "should have required property 'isEmpty'"
+  },
+  {
     keyword: 'oneOf',
     dataPath: '/properties/1/condition',
     schemaPath: '#/definitions/properties/allOf/0/items/allOf/1/definitions/condition/oneOf',
@@ -113,6 +120,13 @@ export const errors = [
     schemaPath: '#/definitions/properties/allOf/0/items/allOf/1/definitions/condition/oneOf/2/required',
     params: { missingProperty: 'isActive' },
     message: "should have required property 'isActive'"
+  },
+  {
+    keyword: 'required',
+    dataPath: '/properties/2/condition',
+    schemaPath: '#/definitions/properties/allOf/0/items/allOf/1/definitions/condition/oneOf/3/required',
+    params: { missingProperty: 'isEmpty' },
+    message: "should have required property 'isEmpty'"
   },
   {
     keyword: 'oneOf',

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/condition.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/condition.js
@@ -103,6 +103,30 @@ export const template = {
         'type': 'property',
         'name': 'input4'
       }
+    },
+    {
+      'label': 'isEmpty (true)',
+      'type': 'String',
+      'condition': {
+        property: 'myId',
+        isEmpty: true
+      },
+      'binding': {
+        'type': 'property',
+        'name': 'input5'
+      }
+    },
+    {
+      'label': 'isEmpty (false)',
+      'type': 'String',
+      'condition': {
+        property: 'myId',
+        isEmpty: false
+      },
+      'binding': {
+        'type': 'property',
+        'name': 'input6'
+      }
     }
   ]
 };


### PR DESCRIPTION
### Proposed Changes

Add `isEmpty` as a new condition type that checks whether a referenced property has no value configured, complementing the existing `equals`, `oneOf`, and `isActive` types.

Child of https://github.com/bpmn-io/bpmn-js-element-templates/issues/258

Discussed in detail on [original design document](https://github.com/camunda/connections-design/blob/main/analysis/ISEMPTY_CONDITION.md#L4).

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->