### PR TITLE
fix: add previously missing canceling task listener event type(backport #251)

### DIFF
--- a/packages/zeebe-element-templates-json-schema/CHANGELOG.md
+++ b/packages/zeebe-element-templates-json-schema/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to [@camunda/zeebe-element-templates-json-schema](https://gi
 
 ___Note:__ Yet to be released changes appear here._
 
+## 0.39.2
+
+* `FIX`: add previously missing `canceling` task listener event type ([#251](https://github.com/camunda/element-templates-json-schema/pull/251))
+
 ## 0.39.1
 
 * `FIX`: restrict usage of template-defined `zeebe:output` bindings when `entriesVisible.outputs === true` ([#227](https://github.com/camunda/element-templates-json-schema/pull/227))

--- a/packages/zeebe-element-templates-json-schema/src/defs/properties/binding/listeners.json
+++ b/packages/zeebe-element-templates-json-schema/src/defs/properties/binding/listeners.json
@@ -43,7 +43,8 @@
               "creating",
               "assigning",
               "updating",
-              "completing"
+              "completing",
+              "canceling"
             ]
           }
         },

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/task-listener/invalid-event-type.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/task-listener/invalid-event-type.js
@@ -26,7 +26,8 @@ export const errors = [
         'creating',
         'assigning',
         'updating',
-        'completing'
+        'completing',
+        'canceling'
       ]
     },
     message: 'should be equal to one of the allowed values'

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/task-listener/valid.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/task-listener/valid.js
@@ -47,6 +47,16 @@ export const template = {
         'type': 'zeebe:taskListener',
         'eventType': 'updating'
       }
+    },
+    {
+      'type': 'Hidden',
+      'generatedValue': {
+        'type': 'uuid'
+      },
+      'binding': {
+        'type': 'zeebe:taskListener',
+        'eventType': 'canceling'
+      }
     }
   ]
 };


### PR DESCRIPTION
Related to camunda/camunda-modeler#6013

### Proposed Changes

Backport `fix: add previously missing canceling task listener event type`(#251) fix to be then backported to WebModeler 8.9

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->