### PR TITLE
feat(zeebe): allow businessId as calledElement binding property

### DIFF
--- a/packages/zeebe-element-templates-json-schema/CHANGELOG.md
+++ b/packages/zeebe-element-templates-json-schema/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to [@camunda/zeebe-element-templates-json-schema](https://gi
 
 ___Note:__ Yet to be released changes appear here._
 
+## 0.45.0
+
+* `FEAT`: allow `businessId` as `zeebe:calledElement` binding property ([#263](https://github.com/camunda/element-templates-json-schema/pull/263)) 
+
 ## 0.44.0
 
 * `FEAT`: support `Configuration` property type with `configurationTemplate` reference

--- a/packages/zeebe-element-templates-json-schema/src/defs/properties.json
+++ b/packages/zeebe-element-templates-json-schema/src/defs/properties.json
@@ -860,6 +860,44 @@
             }
           }
         }
+      },
+      {
+        "if": {
+          "properties": {
+            "binding": {
+              "properties": {
+                "type": {
+                  "const": "zeebe:calledElement"
+                },
+                "property": {
+                  "const": "businessId"
+                }
+              },
+              "required": [
+                "type",
+                "property"
+              ]
+            }
+          },
+          "required": [
+            "binding"
+          ]
+        },
+        "then": {
+          "properties": {
+            "value": {
+              "if": {
+                "type": "string",
+                "not": {
+                  "pattern": "^="
+                }
+              },
+              "then": {
+                "maxLength": 255
+              }
+            }
+          }
+        }
       }
     ],
     "properties": {
@@ -991,7 +1029,8 @@
                     "bindingType",
                     "versionTag",
                     "propagateAllParentVariables",
-                    "propagateAllChildVariables"
+                    "propagateAllChildVariables",
+                    "businessId"
                   ]
                 }
               },

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/called-element-business-id-feel-not-length-checked.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/called-element-business-id-feel-not-length-checked.js
@@ -1,0 +1,34 @@
+export const template = {
+  '$schema': 'https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json',
+  'id': 'io.camunda.examples.Payment',
+  'name': 'Payment',
+  'description': 'Payment process call activity',
+  'appliesTo': [
+    'bpmn:Task'
+  ],
+  'elementType': {
+    'value': 'bpmn:CallActivity'
+  },
+  'properties': [
+    {
+      'type': 'Hidden',
+      'value': 'paymentProcess',
+      'binding': {
+        'type': 'zeebe:calledElement',
+        'property': 'processId'
+      }
+    },
+    {
+      'label': 'Business ID',
+      'type': 'String',
+      'feel': 'optional',
+      'value': '=' + 'a'.repeat(300),
+      'binding': {
+        'type': 'zeebe:calledElement',
+        'property': 'businessId'
+      }
+    }
+  ]
+};
+
+export const errors = null;

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/called-element-business-id-max-length.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/called-element-business-id-max-length.js
@@ -1,0 +1,34 @@
+export const template = {
+  '$schema': 'https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json',
+  'id': 'io.camunda.examples.Payment',
+  'name': 'Payment',
+  'description': 'Payment process call activity',
+  'appliesTo': [
+    'bpmn:Task'
+  ],
+  'elementType': {
+    'value': 'bpmn:CallActivity'
+  },
+  'properties': [
+    {
+      'type': 'Hidden',
+      'value': 'paymentProcess',
+      'binding': {
+        'type': 'zeebe:calledElement',
+        'property': 'processId'
+      }
+    },
+    {
+      'label': 'Business ID',
+      'type': 'String',
+      'feel': 'optional',
+      'value': 'a'.repeat(255),
+      'binding': {
+        'type': 'zeebe:calledElement',
+        'property': 'businessId'
+      }
+    }
+  ]
+};
+
+export const errors = null;

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/called-element-business-id-too-long.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/called-element-business-id-too-long.js
@@ -1,0 +1,80 @@
+export const template = {
+  '$schema': 'https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json',
+  'id': 'io.camunda.examples.Payment',
+  'name': 'Payment',
+  'description': 'Payment process call activity',
+  'appliesTo': [
+    'bpmn:Task'
+  ],
+  'elementType': {
+    'value': 'bpmn:CallActivity'
+  },
+  'properties': [
+    {
+      'type': 'Hidden',
+      'value': 'paymentProcess',
+      'binding': {
+        'type': 'zeebe:calledElement',
+        'property': 'processId'
+      }
+    },
+    {
+      'label': 'Business ID',
+      'type': 'String',
+      'feel': 'optional',
+      'value': 'a'.repeat(256),
+      'binding': {
+        'type': 'zeebe:calledElement',
+        'property': 'businessId'
+      }
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'maxLength',
+    dataPath: '/properties/1/value',
+    schemaPath: '#/allOf/1/items/allOf/35/then/properties/value/then/maxLength',
+    params: {
+      limit: 255
+    },
+    message: 'should NOT have more than 255 characters'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/1/value',
+    schemaPath: '#/allOf/1/items/allOf/35/then/properties/value/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/1',
+    schemaPath: '#/allOf/1/items/allOf/35/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: {
+      type: 'array'
+    },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: {
+      passingSchemas: null
+    },
+    message: 'should match exactly one schema in oneOf'
+  }
+];

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/called-element-business-id.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/called-element-business-id.js
@@ -1,0 +1,34 @@
+export const template = {
+  '$schema': 'https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json',
+  'id': 'io.camunda.examples.Payment',
+  'name': 'Payment',
+  'description': 'Payment process call activity',
+  'appliesTo': [
+    'bpmn:Task'
+  ],
+  'elementType': {
+    'value': 'bpmn:CallActivity'
+  },
+  'properties': [
+    {
+      'type': 'Hidden',
+      'value': 'paymentProcess',
+      'binding': {
+        'type': 'zeebe:calledElement',
+        'property': 'processId'
+      }
+    },
+    {
+      'label': 'Business ID',
+      'type': 'String',
+      'feel': 'optional',
+      'value': '=order.customerId',
+      'binding': {
+        'type': 'zeebe:calledElement',
+        'property': 'businessId'
+      }
+    }
+  ]
+};
+
+export const errors = null;

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/called-element-invalid-property.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/called-element-invalid-property.js
@@ -67,7 +67,8 @@ export const errors = [
         'bindingType',
         'versionTag',
         'propagateAllParentVariables',
-        'propagateAllChildVariables'
+        'propagateAllChildVariables',
+        'businessId'
       ]
     },
     message: 'should be equal to one of the allowed values'

--- a/packages/zeebe-element-templates-json-schema/test/spec/validationSpec.js
+++ b/packages/zeebe-element-templates-json-schema/test/spec/validationSpec.js
@@ -525,6 +525,14 @@ describe('validation', function() {
 
       it('called-element-applies-to-only');
 
+      it('called-element-business-id');
+
+      it('called-element-business-id-max-length');
+
+      it('called-element-business-id-too-long');
+
+      it('called-element-business-id-feel-not-length-checked');
+
       it('called-element-invalid-applies-to-no-element-type');
 
       it('called-element-invalid-element-type');


### PR DESCRIPTION
### Proposed Changes

Adds `businessId` to the allowed `zeebe:calledElement` binding property enum so element templates can bind the Call Activity Business ID. The binding is already restricted to bpmn:CallActivity.

Related to https://github.com/camunda/camunda-modeler/issues/5912

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->