### PR TITLE
feat(zeebe-element-templates-json-schema): add zeebe:agentDefinition binding

### DIFF
--- a/packages/zeebe-element-templates-json-schema/CHANGELOG.md
+++ b/packages/zeebe-element-templates-json-schema/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to [@camunda/zeebe-element-templates-json-schema](https://gi
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FEAT`: allow `zeebe:agentDefinition` binding on `bpmn:ServiceTask` and `bpmn:AdHocSubProcess` ([#265](https://github.com/camunda/element-templates-json-schema/pull/265))
+
 ## 0.45.0
 
 * `FEAT`: allow `businessId` as `zeebe:calledElement` binding property ([#263](https://github.com/camunda/element-templates-json-schema/pull/263)) 

--- a/packages/zeebe-element-templates-json-schema/src/defs/properties.json
+++ b/packages/zeebe-element-templates-json-schema/src/defs/properties.json
@@ -66,7 +66,8 @@
                     "zeebe:priorityDefinition",
                     "zeebe:jobPriorityDefinition",
                     "zeebe:adHoc",
-                    "zeebe:taskSchedule"
+                    "zeebe:taskSchedule",
+                    "zeebe:agentDefinition"
                   ]
                 }
               },
@@ -898,6 +899,9 @@
             }
           }
         }
+      },
+      {
+        "$ref": "./properties/agentDefinition.json"
       }
     ],
     "properties": {
@@ -1147,6 +1151,9 @@
           },
           {
             "$ref": "./properties/binding/jobPriorityDefinition.json"
+          },
+          {
+            "$ref": "./properties/binding/agentDefinition.json"
           }
         ],
         "properties": {
@@ -1180,7 +1187,8 @@
               "bpmn:Signal#property",
               "bpmn:TimerEventDefinition#property",
               "bpmn:ConditionalEventDefinition#property",
-              "bpmn:ConditionalEventDefinition#zeebe:conditionalFilter#property"
+              "bpmn:ConditionalEventDefinition#zeebe:conditionalFilter#property",
+              "zeebe:agentDefinition"
             ]
           },
           "name": {

--- a/packages/zeebe-element-templates-json-schema/src/defs/properties/agentDefinition.json
+++ b/packages/zeebe-element-templates-json-schema/src/defs/properties/agentDefinition.json
@@ -1,0 +1,37 @@
+{
+  "if": {
+    "type": "object",
+    "properties": {
+      "binding": {
+        "properties": {
+          "type": {
+            "const": "zeebe:agentDefinition"
+          },
+          "property": {
+            "const": "agentType"
+          }
+        },
+        "required": [
+          "type",
+          "property"
+        ]
+      }
+    },
+    "required": [
+      "binding"
+    ]
+  },
+  "then": {
+    "required": [
+      "type"
+    ],
+    "properties": {
+      "type": {
+        "enum": [
+          "Hidden",
+          "Dropdown"
+        ]
+      }
+    }
+  }
+}

--- a/packages/zeebe-element-templates-json-schema/src/defs/properties/binding/agentDefinition.json
+++ b/packages/zeebe-element-templates-json-schema/src/defs/properties/binding/agentDefinition.json
@@ -1,0 +1,22 @@
+{
+  "if": {
+    "properties": {
+      "type": {
+        "const": "zeebe:agentDefinition"
+      }
+    },
+    "required": [
+      "type"
+    ]
+  },
+  "then": {
+    "properties": {
+      "property": {
+        "const": "agentType"
+      }
+    },
+    "required": [
+      "property"
+    ]
+  }
+}

--- a/packages/zeebe-element-templates-json-schema/src/defs/template.json
+++ b/packages/zeebe-element-templates-json-schema/src/defs/template.json
@@ -812,6 +812,9 @@
           }
         ]
       }
+    },
+    {
+      "$ref": "./template/agentDefinition.json"
     }
   ]
 }

--- a/packages/zeebe-element-templates-json-schema/src/defs/template/agentDefinition.json
+++ b/packages/zeebe-element-templates-json-schema/src/defs/template/agentDefinition.json
@@ -1,0 +1,326 @@
+{
+  "allOf": [
+    {
+      "$comment": "zeebe:agentDefinition may only be used on bpmn:ServiceTask or bpmn:AdHocSubProcess, and the two are mutually exclusive when selected via appliesTo alone (no elementType)",
+      "if": {
+        "properties": {
+          "properties": {
+            "contains": {
+              "properties": {
+                "binding": {
+                  "properties": {
+                    "type": {
+                      "const": "zeebe:agentDefinition"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ]
+                }
+              },
+              "required": [
+                "binding"
+              ]
+            }
+          }
+        },
+        "required": [
+          "properties"
+        ]
+      },
+      "then": {
+        "anyOf": [
+          {
+            "required": [
+              "elementType"
+            ],
+            "properties": {
+              "elementType": {
+                "required": [
+                  "value"
+                ],
+                "properties": {
+                  "value": {
+                    "enum": [
+                      "bpmn:ServiceTask",
+                      "bpmn:AdHocSubProcess"
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          {
+            "required": [
+              "appliesTo"
+            ],
+            "properties": {
+              "appliesTo": {
+                "anyOf": [
+                  {
+                    "const": [
+                      "bpmn:ServiceTask"
+                    ]
+                  },
+                  {
+                    "const": [
+                      "bpmn:AdHocSubProcess"
+                    ]
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "$comment": "On bpmn:ServiceTask (via elementType or appliesTo), agentType is restricted to aiAgentTask or external",
+      "if": {
+        "allOf": [
+          {
+            "anyOf": [
+              {
+                "required": [
+                  "elementType"
+                ],
+                "properties": {
+                  "elementType": {
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "const": "bpmn:ServiceTask"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "required": [
+                  "appliesTo"
+                ],
+                "properties": {
+                  "appliesTo": {
+                    "const": [
+                      "bpmn:ServiceTask"
+                    ]
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "properties": {
+              "properties": {
+                "contains": {
+                  "properties": {
+                    "binding": {
+                      "properties": {
+                        "type": {
+                          "const": "zeebe:agentDefinition"
+                        },
+                        "property": {
+                          "const": "agentType"
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "property"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "binding"
+                  ]
+                }
+              }
+            },
+            "required": [
+              "properties"
+            ]
+          }
+        ]
+      },
+      "then": {
+        "properties": {
+          "properties": {
+            "items": {
+              "if": {
+                "properties": {
+                  "binding": {
+                    "properties": {
+                      "type": {
+                        "const": "zeebe:agentDefinition"
+                      },
+                      "property": {
+                        "const": "agentType"
+                      }
+                    },
+                    "required": [
+                      "type",
+                      "property"
+                    ]
+                  }
+                },
+                "required": [
+                  "binding"
+                ]
+              },
+              "then": {
+                "properties": {
+                  "value": {
+                    "enum": [
+                      "aiAgentTask",
+                      "external"
+                    ]
+                  },
+                  "choices": {
+                    "items": {
+                      "properties": {
+                        "value": {
+                          "enum": [
+                            "aiAgentTask",
+                            "external"
+                          ]
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "required": [
+          "properties"
+        ]
+      }
+    },
+    {
+      "$comment": "On bpmn:AdHocSubProcess (via elementType or appliesTo), agentType is restricted to aiAgentSubProcess or external",
+      "if": {
+        "allOf": [
+          {
+            "anyOf": [
+              {
+                "required": [
+                  "elementType"
+                ],
+                "properties": {
+                  "elementType": {
+                    "required": [
+                      "value"
+                    ],
+                    "properties": {
+                      "value": {
+                        "const": "bpmn:AdHocSubProcess"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "required": [
+                  "appliesTo"
+                ],
+                "properties": {
+                  "appliesTo": {
+                    "const": [
+                      "bpmn:AdHocSubProcess"
+                    ]
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "properties": {
+              "properties": {
+                "contains": {
+                  "properties": {
+                    "binding": {
+                      "properties": {
+                        "type": {
+                          "const": "zeebe:agentDefinition"
+                        },
+                        "property": {
+                          "const": "agentType"
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "property"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "binding"
+                  ]
+                }
+              }
+            },
+            "required": [
+              "properties"
+            ]
+          }
+        ]
+      },
+      "then": {
+        "properties": {
+          "properties": {
+            "items": {
+              "if": {
+                "properties": {
+                  "binding": {
+                    "properties": {
+                      "type": {
+                        "const": "zeebe:agentDefinition"
+                      },
+                      "property": {
+                        "const": "agentType"
+                      }
+                    },
+                    "required": [
+                      "type",
+                      "property"
+                    ]
+                  }
+                },
+                "required": [
+                  "binding"
+                ]
+              },
+              "then": {
+                "properties": {
+                  "value": {
+                    "enum": [
+                      "aiAgentSubProcess",
+                      "external"
+                    ]
+                  },
+                  "choices": {
+                    "items": {
+                      "properties": {
+                        "value": {
+                          "enum": [
+                            "aiAgentSubProcess",
+                            "external"
+                          ]
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "required": [
+          "properties"
+        ]
+      }
+    }
+  ]
+}

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/agent-definition/invalid-both-element-types.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/agent-definition/invalid-both-element-types.js
@@ -1,0 +1,95 @@
+export const template = {
+  name: 'Agent Definition',
+  id: 'agent-definition-invalid-both-element-types',
+  description: 'bpmn:ServiceTask and bpmn:AdHocSubProcess are mutually exclusive for zeebe:agentDefinition.',
+  version: 1,
+  appliesTo: [
+    'bpmn:ServiceTask',
+    'bpmn:AdHocSubProcess'
+  ],
+  properties: [
+    {
+      value: 'external',
+      type: 'Hidden',
+      binding: {
+        type: 'zeebe:agentDefinition',
+        property: 'agentType'
+      }
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'required',
+    dataPath: '',
+    schemaPath: '#/allOf/1/allOf/15/allOf/0/then/anyOf/0/required',
+    params: {
+      missingProperty: 'elementType'
+    },
+    message: 'should have required property \'elementType\''
+  },
+  {
+    keyword: 'const',
+    dataPath: '/appliesTo',
+    schemaPath: '#/allOf/1/allOf/15/allOf/0/then/anyOf/1/properties/appliesTo/anyOf/0/const',
+    params: {
+      allowedValue: [
+        'bpmn:ServiceTask'
+      ]
+    },
+    message: 'should be equal to constant'
+  },
+  {
+    keyword: 'const',
+    dataPath: '/appliesTo',
+    schemaPath: '#/allOf/1/allOf/15/allOf/0/then/anyOf/1/properties/appliesTo/anyOf/1/const',
+    params: {
+      allowedValue: [
+        'bpmn:AdHocSubProcess'
+      ]
+    },
+    message: 'should be equal to constant'
+  },
+  {
+    keyword: 'anyOf',
+    dataPath: '/appliesTo',
+    schemaPath: '#/allOf/1/allOf/15/allOf/0/then/anyOf/1/properties/appliesTo/anyOf',
+    params: {},
+    message: 'should match some schema in anyOf'
+  },
+  {
+    keyword: 'anyOf',
+    dataPath: '',
+    schemaPath: '#/allOf/1/allOf/15/allOf/0/then/anyOf',
+    params: {},
+    message: 'should match some schema in anyOf'
+  },
+  {
+    keyword: 'if',
+    dataPath: '',
+    schemaPath: '#/allOf/1/allOf/15/allOf/0/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: {
+      type: 'array'
+    },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: {
+      passingSchemas: null
+    },
+    message: 'should match exactly one schema in oneOf'
+  }
+];

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/agent-definition/invalid-input-types.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/agent-definition/invalid-input-types.js
@@ -1,0 +1,96 @@
+export const template = {
+  name: 'Agent Definition',
+  id: 'agent-definition-invalid-input-types',
+  description: 'zeebe:agentDefinition does not support a FEEL/String escape hatch.',
+  version: 1,
+  appliesTo: [
+    'bpmn:ServiceTask'
+  ],
+  elementType: {
+    value: 'bpmn:ServiceTask'
+  },
+  properties: [
+    {
+      label: 'Agent type',
+      value: '=aiAgentTask',
+      type: 'String',
+      feel: 'required',
+      binding: {
+        type: 'zeebe:agentDefinition',
+        property: 'agentType'
+      }
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'enum',
+    dataPath: '/properties/0/value',
+    schemaPath: '#/allOf/1/allOf/15/allOf/1/then/properties/properties/items/then/properties/value/enum',
+    params: {
+      allowedValues: [
+        'aiAgentTask',
+        'external'
+      ]
+    },
+    message: 'should be equal to one of the allowed values'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/0',
+    schemaPath: '#/allOf/1/allOf/15/allOf/1/then/properties/properties/items/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'if',
+    dataPath: '',
+    schemaPath: '#/allOf/1/allOf/15/allOf/1/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'enum',
+    dataPath: '/properties/0/type',
+    schemaPath: '#/allOf/1/items/allOf/36/then/properties/type/enum',
+    params: {
+      allowedValues: [
+        'Hidden',
+        'Dropdown'
+      ]
+    },
+    message: 'should be equal to one of the allowed values'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/0',
+    schemaPath: '#/allOf/1/items/allOf/36/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: {
+      type: 'array'
+    },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: {
+      passingSchemas: null
+    },
+    message: 'should match exactly one schema in oneOf'
+  }
+];

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/agent-definition/invalid-property.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/agent-definition/invalid-property.js
@@ -1,0 +1,61 @@
+export const template = {
+  name: 'Agent Definition',
+  id: 'agent-definition-invalid-property',
+  description: 'zeebe:agentDefinition only supports the agentType property.',
+  version: 1,
+  appliesTo: [
+    'bpmn:ServiceTask'
+  ],
+  elementType: {
+    value: 'bpmn:ServiceTask'
+  },
+  properties: [
+    {
+      value: 'aiAgentTask',
+      type: 'Hidden',
+      binding: {
+        type: 'zeebe:agentDefinition',
+        property: 'foo'
+      }
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'const',
+    dataPath: '/properties/0/binding/property',
+    schemaPath: '#/allOf/1/items/properties/binding/allOf/19/then/properties/property/const',
+    params: {
+      allowedValue: 'agentType'
+    },
+    message: 'should be equal to constant'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/0/binding',
+    schemaPath: '#/allOf/1/items/properties/binding/allOf/19/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: {
+      type: 'array'
+    },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: {
+      passingSchemas: null
+    },
+    message: 'should match exactly one schema in oneOf'
+  }
+];

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/agent-definition/invalid-value-appliesTo-only.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/agent-definition/invalid-value-appliesTo-only.js
@@ -1,0 +1,70 @@
+export const template = {
+  name: 'Agent Definition',
+  id: 'agent-definition-invalid-value-applies-to-only',
+  description: 'aiAgentSubProcess is not a valid agentType value on bpmn:ServiceTask, targeted via appliesTo only.',
+  version: 1,
+  appliesTo: [
+    'bpmn:ServiceTask'
+  ],
+  properties: [
+    {
+      value: 'aiAgentSubProcess',
+      type: 'Hidden',
+      binding: {
+        type: 'zeebe:agentDefinition',
+        property: 'agentType'
+      }
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'enum',
+    dataPath: '/properties/0/value',
+    schemaPath: '#/allOf/1/allOf/15/allOf/1/then/properties/properties/items/then/properties/value/enum',
+    params: {
+      allowedValues: [
+        'aiAgentTask',
+        'external'
+      ]
+    },
+    message: 'should be equal to one of the allowed values'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/0',
+    schemaPath: '#/allOf/1/allOf/15/allOf/1/then/properties/properties/items/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'if',
+    dataPath: '',
+    schemaPath: '#/allOf/1/allOf/15/allOf/1/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: {
+      type: 'array'
+    },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: {
+      passingSchemas: null
+    },
+    message: 'should match exactly one schema in oneOf'
+  }
+];

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/agent-definition/invalid-value-for-adhoc.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/agent-definition/invalid-value-for-adhoc.js
@@ -1,0 +1,73 @@
+export const template = {
+  name: 'Agent Definition',
+  id: 'agent-definition-invalid-value-for-adhoc',
+  description: 'aiAgentTask is not a valid agentType value on bpmn:AdHocSubProcess.',
+  version: 1,
+  appliesTo: [
+    'bpmn:AdHocSubProcess'
+  ],
+  elementType: {
+    value: 'bpmn:AdHocSubProcess'
+  },
+  properties: [
+    {
+      value: 'aiAgentTask',
+      type: 'Hidden',
+      binding: {
+        type: 'zeebe:agentDefinition',
+        property: 'agentType'
+      }
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'enum',
+    dataPath: '/properties/0/value',
+    schemaPath: '#/allOf/1/allOf/15/allOf/2/then/properties/properties/items/then/properties/value/enum',
+    params: {
+      allowedValues: [
+        'aiAgentSubProcess',
+        'external'
+      ]
+    },
+    message: 'should be equal to one of the allowed values'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/0',
+    schemaPath: '#/allOf/1/allOf/15/allOf/2/then/properties/properties/items/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'if',
+    dataPath: '',
+    schemaPath: '#/allOf/1/allOf/15/allOf/2/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: {
+      type: 'array'
+    },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: {
+      passingSchemas: null
+    },
+    message: 'should match exactly one schema in oneOf'
+  }
+];

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/agent-definition/invalid-value-for-service-task.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/agent-definition/invalid-value-for-service-task.js
@@ -1,0 +1,73 @@
+export const template = {
+  name: 'Agent Definition',
+  id: 'agent-definition-invalid-value-for-service-task',
+  description: 'aiAgentSubProcess is not a valid agentType value on bpmn:ServiceTask.',
+  version: 1,
+  appliesTo: [
+    'bpmn:ServiceTask'
+  ],
+  elementType: {
+    value: 'bpmn:ServiceTask'
+  },
+  properties: [
+    {
+      value: 'aiAgentSubProcess',
+      type: 'Hidden',
+      binding: {
+        type: 'zeebe:agentDefinition',
+        property: 'agentType'
+      }
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'enum',
+    dataPath: '/properties/0/value',
+    schemaPath: '#/allOf/1/allOf/15/allOf/1/then/properties/properties/items/then/properties/value/enum',
+    params: {
+      allowedValues: [
+        'aiAgentTask',
+        'external'
+      ]
+    },
+    message: 'should be equal to one of the allowed values'
+  },
+  {
+    keyword: 'if',
+    dataPath: '/properties/0',
+    schemaPath: '#/allOf/1/allOf/15/allOf/1/then/properties/properties/items/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'if',
+    dataPath: '',
+    schemaPath: '#/allOf/1/allOf/15/allOf/1/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: {
+      type: 'array'
+    },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: {
+      passingSchemas: null
+    },
+    message: 'should match exactly one schema in oneOf'
+  }
+];

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/agent-definition/invalid-wrong-element-type.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/agent-definition/invalid-wrong-element-type.js
@@ -1,0 +1,100 @@
+export const template = {
+  name: 'Agent Definition',
+  id: 'agent-definition-wrong-element-type',
+  description: 'zeebe:agentDefinition is not allowed on bpmn:UserTask.',
+  version: 1,
+  appliesTo: [
+    'bpmn:Task'
+  ],
+  elementType: {
+    value: 'bpmn:UserTask'
+  },
+  properties: [
+    {
+      value: 'aiAgentTask',
+      type: 'Hidden',
+      binding: {
+        type: 'zeebe:agentDefinition',
+        property: 'agentType'
+      }
+    }
+  ]
+};
+
+export const errors = [
+  {
+    keyword: 'enum',
+    dataPath: '/elementType/value',
+    schemaPath: '#/allOf/1/allOf/15/allOf/0/then/anyOf/0/properties/elementType/properties/value/enum',
+    params: {
+      allowedValues: [
+        'bpmn:ServiceTask',
+        'bpmn:AdHocSubProcess'
+      ]
+    },
+    message: 'should be equal to one of the allowed values'
+  },
+  {
+    keyword: 'const',
+    dataPath: '/appliesTo',
+    schemaPath: '#/allOf/1/allOf/15/allOf/0/then/anyOf/1/properties/appliesTo/anyOf/0/const',
+    params: {
+      allowedValue: [
+        'bpmn:ServiceTask'
+      ]
+    },
+    message: 'should be equal to constant'
+  },
+  {
+    keyword: 'const',
+    dataPath: '/appliesTo',
+    schemaPath: '#/allOf/1/allOf/15/allOf/0/then/anyOf/1/properties/appliesTo/anyOf/1/const',
+    params: {
+      allowedValue: [
+        'bpmn:AdHocSubProcess'
+      ]
+    },
+    message: 'should be equal to constant'
+  },
+  {
+    keyword: 'anyOf',
+    dataPath: '/appliesTo',
+    schemaPath: '#/allOf/1/allOf/15/allOf/0/then/anyOf/1/properties/appliesTo/anyOf',
+    params: {},
+    message: 'should match some schema in anyOf'
+  },
+  {
+    keyword: 'anyOf',
+    dataPath: '',
+    schemaPath: '#/allOf/1/allOf/15/allOf/0/then/anyOf',
+    params: {},
+    message: 'should match some schema in anyOf'
+  },
+  {
+    keyword: 'if',
+    dataPath: '',
+    schemaPath: '#/allOf/1/allOf/15/allOf/0/if',
+    params: {
+      failingKeyword: 'then'
+    },
+    message: 'should match "then" schema'
+  },
+  {
+    keyword: 'type',
+    dataPath: '',
+    schemaPath: '#/oneOf/1/type',
+    params: {
+      type: 'array'
+    },
+    message: 'should be array'
+  },
+  {
+    keyword: 'oneOf',
+    dataPath: '',
+    schemaPath: '#/oneOf',
+    params: {
+      passingSchemas: null
+    },
+    message: 'should match exactly one schema in oneOf'
+  }
+];

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/agent-definition/valid-adhoc-sub-process.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/agent-definition/valid-adhoc-sub-process.js
@@ -1,0 +1,24 @@
+export const template = {
+  name: 'Agent Definition',
+  id: 'agent-definition-adhoc-sub-process',
+  description: 'A template to define an agent definition on an ad-hoc sub-process.',
+  version: 1,
+  appliesTo: [
+    'bpmn:AdHocSubProcess'
+  ],
+  elementType: {
+    value: 'bpmn:AdHocSubProcess'
+  },
+  properties: [
+    {
+      value: 'aiAgentSubProcess',
+      type: 'Hidden',
+      binding: {
+        type: 'zeebe:agentDefinition',
+        property: 'agentType'
+      }
+    }
+  ]
+};
+
+export const errors = null;

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/agent-definition/valid-dropdown-choices.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/agent-definition/valid-dropdown-choices.js
@@ -1,0 +1,35 @@
+export const template = {
+  name: 'Agent Definition',
+  id: 'agent-definition-dropdown-choices',
+  description: 'A template with a dropdown of agent types for a service task.',
+  version: 1,
+  appliesTo: [
+    'bpmn:ServiceTask'
+  ],
+  elementType: {
+    value: 'bpmn:ServiceTask'
+  },
+  properties: [
+    {
+      label: 'Agent type',
+      value: 'aiAgentTask',
+      type: 'Dropdown',
+      binding: {
+        type: 'zeebe:agentDefinition',
+        property: 'agentType'
+      },
+      choices: [
+        {
+          name: 'AI Agent',
+          value: 'aiAgentTask'
+        },
+        {
+          name: 'External',
+          value: 'external'
+        }
+      ]
+    }
+  ]
+};
+
+export const errors = null;

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/agent-definition/valid-service-task-appliesTo-only.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/agent-definition/valid-service-task-appliesTo-only.js
@@ -1,0 +1,21 @@
+export const template = {
+  name: 'Agent Definition',
+  id: 'agent-definition-service-task-applies-to-only',
+  description: 'A template to define an agent definition on a service task, targeted via appliesTo only.',
+  version: 1,
+  appliesTo: [
+    'bpmn:ServiceTask'
+  ],
+  properties: [
+    {
+      value: 'aiAgentTask',
+      type: 'Hidden',
+      binding: {
+        type: 'zeebe:agentDefinition',
+        property: 'agentType'
+      }
+    }
+  ]
+};
+
+export const errors = null;

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/agent-definition/valid-service-task.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/agent-definition/valid-service-task.js
@@ -1,0 +1,24 @@
+export const template = {
+  name: 'Agent Definition',
+  id: 'agent-definition-service-task',
+  description: 'A template to define an agent definition on a service task.',
+  version: 1,
+  appliesTo: [
+    'bpmn:ServiceTask'
+  ],
+  elementType: {
+    value: 'bpmn:ServiceTask'
+  },
+  properties: [
+    {
+      value: 'aiAgentTask',
+      type: 'Hidden',
+      binding: {
+        type: 'zeebe:agentDefinition',
+        property: 'agentType'
+      }
+    }
+  ]
+};
+
+export const errors = null;

--- a/packages/zeebe-element-templates-json-schema/test/fixtures/invalid-binding-type.js
+++ b/packages/zeebe-element-templates-json-schema/test/fixtures/invalid-binding-type.js
@@ -62,7 +62,8 @@ export const errors = [
               'bpmn:Signal#property',
               'bpmn:TimerEventDefinition#property',
               'bpmn:ConditionalEventDefinition#property',
-              'bpmn:ConditionalEventDefinition#zeebe:conditionalFilter#property'
+              'bpmn:ConditionalEventDefinition#zeebe:conditionalFilter#property',
+              'zeebe:agentDefinition'
             ]
           },
           message: 'should be equal to one of the allowed values',

--- a/packages/zeebe-element-templates-json-schema/test/spec/validationSpec.js
+++ b/packages/zeebe-element-templates-json-schema/test/spec/validationSpec.js
@@ -878,6 +878,33 @@ describe('validation', function() {
   });
 
 
+  describe('zeebe:agentDefinition', function() {
+
+    it('agent-definition/valid-service-task');
+
+    it('agent-definition/valid-service-task-appliesTo-only');
+
+    it('agent-definition/valid-adhoc-sub-process');
+
+    it('agent-definition/valid-dropdown-choices');
+
+    it('agent-definition/invalid-wrong-element-type');
+
+    it('agent-definition/invalid-value-for-service-task');
+
+    it('agent-definition/invalid-value-for-adhoc');
+
+    it('agent-definition/invalid-value-appliesTo-only');
+
+    it('agent-definition/invalid-property');
+
+    it('agent-definition/invalid-input-types');
+
+    it('agent-definition/invalid-both-element-types');
+
+  });
+
+
   describe('zeebe:taskSchedule', function() {
 
     it('task-schedule/invalid-element-type');


### PR DESCRIPTION
### Proposed Changes

Adds a new element-template `property` binding type, `zeebe:agentDefinition`, mapping a template property to a single `<zeebe:agentDefinition agentType="..."/>` BPMN extension element.

- `zeebe:agentDefinition` binding may only be used on `bpmn:ServiceTask` or `bpmn:AdHocSubProcess` (mutually exclusive — a template may not target both at once via `appliesTo`).
- The bound property must be `agentType`, restricted to a `Hidden`/`Dropdown` widget (no FEEL/free-text escape hatch — this is a closed, design-time discriminator).
- Allowed `agentType` values differ by element type:
  - `bpmn:ServiceTask` → `aiAgentTask`, `external`
  - `bpmn:AdHocSubProcess` → `aiAgentSubProcess`, `external`

This mirrors how other single-instance extension elements (`zeebe:calledDecision`, `zeebe:priorityDefinition`, `zeebe:jobPriorityDefinition`) are bound today.

Part of the work to support `zeebe:agentDefinition` end to end — see [camunda/zeebe-bpmn-moddle](https://github.com/camunda/zeebe-bpmn-moddle) (moddle descriptor) and [bpmn-io/bpmn-js-element-templates](https://github.com/bpmn-io/bpmn-js-element-templates) (properties-panel application logic) for the companion changes.

Marked as draft pending the `zeebe-bpmn-moddle` release this depends on for full end-to-end verification downstream.

### Steps to try out

```
npm install
npm run build --workspace=packages/zeebe-element-templates-json-schema
npm test --workspace=packages/zeebe-element-templates-json-schema
```

New coverage lives under `packages/zeebe-element-templates-json-schema/test/fixtures/agent-definition/`, wired into `test/spec/validationSpec.js`.

### Checklist

* [x] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [x] __Steps to try out__ present
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

Related to https://github.com/camunda/camunda-modeler/issues/6094